### PR TITLE
Fix retryable exceptions class list in RetryOptions

### DIFF
--- a/src/Common/RetryOptions.php
+++ b/src/Common/RetryOptions.php
@@ -199,7 +199,7 @@ class RetryOptions extends Options
     #[Pure]
     public function withNonRetryableExceptions(array $exceptions): self
     {
-        assert(Assert::valuesSubclassOf($exceptions, \Throwable::class));
+        assert(Assert::valuesSubclassOfOrSameClass($exceptions, \Throwable::class));
 
         $self = clone $this;
         $self->nonRetryableExceptions = $exceptions;

--- a/src/Common/RetryOptions.php
+++ b/src/Common/RetryOptions.php
@@ -193,13 +193,13 @@ class RetryOptions extends Options
     /**
      * @psalm-suppress ImpureMethodCall
      *
-     * @param mixed $exceptions
+     * @param ExceptionsList $exceptions
      * @return $this
      */
     #[Pure]
     public function withNonRetryableExceptions(array $exceptions): self
     {
-        assert(Assert::valuesInstanceOf($exceptions, \Throwable::class));
+        assert(Assert::valuesSubclassOf($exceptions, \Throwable::class));
 
         $self = clone $this;
         $self->nonRetryableExceptions = $exceptions;

--- a/src/Internal/Assert.php
+++ b/src/Internal/Assert.php
@@ -50,9 +50,9 @@ final class Assert
      * @param class-string $of
      * @return bool
      */
-    public static function valuesSubclassOf(array $values, string $of): bool
+    public static function valuesSubclassOfOrSameClass(array $values, string $of): bool
     {
-        return self::all($values, fn ($v) => is_subclass_of($v, $of));
+        return self::all($values, fn ($v) => is_a($v, $of, true));
     }
 
     /**

--- a/src/Internal/Assert.php
+++ b/src/Internal/Assert.php
@@ -46,7 +46,17 @@ final class Assert
     }
 
     /**
-     * @param array<object> $values
+     * @param array<class-string> $values
+     * @param class-string $of
+     * @return bool
+     */
+    public static function valuesSubclassOf(array $values, string $of): bool
+    {
+        return self::all($values, fn ($v) => is_subclass_of($v, $of));
+    }
+
+    /**
+     * @param array<mixed> $values
      * @param callable $filter
      * @return bool
      */


### PR DESCRIPTION
## What was changed
Fixed the retryable exceptions class list incorrect behavior.

1. Closes issue: https://github.com/temporalio/sdk-php/issues/95

2. How was this tested: 
There is no test case for `withNonRetryableExceptions`, so manual testing only.

3. Any docs updates needed?
No, the example provided in docs is correct.
