### PR TITLE
Add support for custom reader in WorkerFactory.

### DIFF
--- a/src/WorkerFactory.php
+++ b/src/WorkerFactory.php
@@ -154,11 +154,16 @@ final class WorkerFactory implements WorkerFactoryInterface, LoopInterface
     /**
      * @param DataConverterInterface $dataConverter
      * @param RPCConnectionInterface $rpc
+     * @param ReaderInterface|null $reader
      */
-    public function __construct(DataConverterInterface $dataConverter, RPCConnectionInterface $rpc)
-    {
+    public function __construct(
+        DataConverterInterface $dataConverter,
+        RPCConnectionInterface $rpc,
+        ReaderInterface $reader = null
+    ) {
         $this->converter = $dataConverter;
         $this->rpc = $rpc;
+        $this->reader = $reader ?? $this->createReader();
 
         $this->boot();
     }
@@ -166,15 +171,18 @@ final class WorkerFactory implements WorkerFactoryInterface, LoopInterface
     /**
      * @param DataConverterInterface|null $converter
      * @param RPCConnectionInterface|null $rpc
+     * @param ReaderInterface|null $reader
      * @return WorkerFactoryInterface
      */
     public static function create(
         DataConverterInterface $converter = null,
-        RPCConnectionInterface $rpc = null
+        RPCConnectionInterface $rpc = null,
+        ReaderInterface $reader = null
     ): WorkerFactoryInterface {
         return new self(
             $converter ?? DataConverter::createDefault(),
-            $rpc ?? Goridge::create()
+            $rpc ?? Goridge::create(),
+            $reader
         );
     }
 
@@ -283,7 +291,6 @@ final class WorkerFactory implements WorkerFactoryInterface, LoopInterface
      */
     private function boot(): void
     {
-        $this->reader = $this->createReader();
         $this->marshaller = $this->createMarshaller($this->reader);
         $this->queues = $this->createTaskQueue();
         $this->router = $this->createRouter();

--- a/tests/Unit/Declaration/Fixture/FixedReader.php
+++ b/tests/Unit/Declaration/Fixture/FixedReader.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\Declaration\Fixture;
+
+use Spiral\Attributes\ReaderInterface;
+use Temporal\Activity\ActivityInterface;
+use Temporal\Activity\ActivityMethod;
+
+class FixedReader implements ReaderInterface
+{
+    public function getClassMetadata(\ReflectionClass $class, string $name = null): iterable
+    {
+        return [];
+    }
+
+    public function firstClassMetadata(\ReflectionClass $class, string $name): ?object
+    {
+        if ($name === ActivityInterface::class) {
+            return new ActivityInterface();
+        }
+
+        return null;
+    }
+
+    public function getFunctionMetadata(\ReflectionFunctionAbstract $function, string $name = null): iterable
+    {
+        return [];
+    }
+
+    public function firstFunctionMetadata(\ReflectionFunctionAbstract $function, string $name): ?object
+    {
+        if ($name === ActivityMethod::class) {
+            return new ActivityMethod();
+        }
+
+        return null;
+    }
+
+    public function getPropertyMetadata(\ReflectionProperty $property, string $name = null): iterable
+    {
+        return [];
+    }
+
+    public function firstPropertyMetadata(\ReflectionProperty $property, string $name): ?object
+    {
+        return null;
+    }
+
+    public function getConstantMetadata(\ReflectionClassConstant $constant, string $name = null): iterable
+    {
+        return [];
+    }
+
+    public function firstConstantMetadata(\ReflectionClassConstant $constant, string $name): ?object
+    {
+        return null;
+    }
+
+    public function getParameterMetadata(\ReflectionParameter $parameter, string $name = null): iterable
+    {
+        return [];
+    }
+
+    public function firstParameterMetadata(\ReflectionParameter $parameter, string $name): ?object
+    {
+        return null;
+    }
+}

--- a/tests/Unit/WorkerFactory/CustomReaderInjectionTestCase.php
+++ b/tests/Unit/WorkerFactory/CustomReaderInjectionTestCase.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+
+namespace Temporal\Tests\Unit\WorkerFactory;
+
+use Temporal\Tests\Unit\Declaration\Fixture\FixedReader;
+use Temporal\Tests\Unit\Declaration\Fixture\UnannotatedClass;
+use Temporal\WorkerFactory;
+
+class CustomReaderInjectionTestCase extends WorkerFactoryTestCase
+{
+    public function testCustomReader()
+    {
+        $workerFactory = WorkerFactory::create(null, null, new FixedReader());
+        $worker = $workerFactory->newWorker()->registerActivityImplementations(new UnannotatedClass());
+
+        // With default reader we would get no activities.
+        $this->assertCount(1, $worker->getActivities());
+    }
+}

--- a/tests/Unit/WorkerFactory/WorkerFactoryTestCase.php
+++ b/tests/Unit/WorkerFactory/WorkerFactoryTestCase.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\WorkerFactory;
+
+use Temporal\Tests\Unit\UnitTestCase;
+
+/**
+ * @group worker
+ * @group unit
+ */
+abstract class WorkerFactoryTestCase extends UnitTestCase
+{
+}


### PR DESCRIPTION
## What was changed

Introduced an ability to pass a custom reader, just like with data converter.

## Why?

To be able to read activty/workflow config not only from annotations, but preset arrays etc.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-php/issues/110

2. How was this tested: Unit tests.

3. Any docs updates needed? No. Its self explanatory and no BC.
