### PR TITLE
Add support for custom reader in WorkerFactory.

### DIFF
--- a/src/WorkerFactory.php
+++ b/src/WorkerFactory.php
@@ -67,7 +67,7 @@ use Temporal\Worker\WorkerOptions;
  *
  * </code>
  */
-final class WorkerFactory implements WorkerFactoryInterface, LoopInterface
+class WorkerFactory implements WorkerFactoryInterface, LoopInterface
 {
     use EventEmitterTrait;
 
@@ -172,7 +172,7 @@ final class WorkerFactory implements WorkerFactoryInterface, LoopInterface
         DataConverterInterface $converter = null,
         RPCConnectionInterface $rpc = null
     ): WorkerFactoryInterface {
-        return new self(
+        return new static(
             $converter ?? DataConverter::createDefault(),
             $rpc ?? Goridge::create()
         );
@@ -296,7 +296,7 @@ final class WorkerFactory implements WorkerFactoryInterface, LoopInterface
     /**
      * @return ReaderInterface
      */
-    private function createReader(): ReaderInterface
+    protected function createReader(): ReaderInterface
     {
         if (\interface_exists(Reader::class)) {
             return new SelectiveReader([new AnnotationReader(), new AttributeReader()]);

--- a/tests/Unit/Declaration/Fixture/CustomReaderWorkerFactory.php
+++ b/tests/Unit/Declaration/Fixture/CustomReaderWorkerFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\Declaration\Fixture;
+
+use Spiral\Attributes\ReaderInterface;
+use Temporal\WorkerFactory;
+
+class CustomReaderWorkerFactory extends WorkerFactory
+{
+    protected function createReader(): ReaderInterface
+    {
+        return new FixedReader();
+    }
+}

--- a/tests/Unit/Declaration/Fixture/FixedReader.php
+++ b/tests/Unit/Declaration/Fixture/FixedReader.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\Declaration\Fixture;
+
+use Spiral\Attributes\ReaderInterface;
+use Temporal\Activity\ActivityInterface;
+use Temporal\Activity\ActivityMethod;
+
+class FixedReader implements ReaderInterface
+{
+    public function getClassMetadata(\ReflectionClass $class, string $name = null): iterable
+    {
+        return [];
+    }
+
+    public function firstClassMetadata(\ReflectionClass $class, string $name): ?object
+    {
+        if ($name === ActivityInterface::class) {
+            return new ActivityInterface();
+        }
+
+        return null;
+    }
+
+    public function getFunctionMetadata(\ReflectionFunctionAbstract $function, string $name = null): iterable
+    {
+        return [];
+    }
+
+    public function firstFunctionMetadata(\ReflectionFunctionAbstract $function, string $name): ?object
+    {
+        if ($name === ActivityMethod::class) {
+            return new ActivityMethod();
+        }
+
+        return null;
+    }
+
+    public function getPropertyMetadata(\ReflectionProperty $property, string $name = null): iterable
+    {
+        return [];
+    }
+
+    public function firstPropertyMetadata(\ReflectionProperty $property, string $name): ?object
+    {
+        return null;
+    }
+
+    public function getConstantMetadata(\ReflectionClassConstant $constant, string $name = null): iterable
+    {
+        return [];
+    }
+
+    public function firstConstantMetadata(\ReflectionClassConstant $constant, string $name): ?object
+    {
+        return null;
+    }
+
+    public function getParameterMetadata(\ReflectionParameter $parameter, string $name = null): iterable
+    {
+        return [];
+    }
+
+    public function firstParameterMetadata(\ReflectionParameter $parameter, string $name): ?object
+    {
+        return null;
+    }
+}

--- a/tests/Unit/WorkerFactory/CustomReaderTestCase.php
+++ b/tests/Unit/WorkerFactory/CustomReaderTestCase.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+
+namespace Temporal\Tests\Unit\WorkerFactory;
+
+use Temporal\Tests\Unit\Declaration\Fixture\CustomReaderWorkerFactory;
+use Temporal\Tests\Unit\Declaration\Fixture\UnannotatedClass;
+
+class CustomReaderTestCase extends WorkerFactoryTestCase
+{
+    public function testCustomReader()
+    {
+        $workerFactory = CustomReaderWorkerFactory::create();
+        $worker = $workerFactory->newWorker()->registerActivityImplementations(new UnannotatedClass());
+
+        // With default reader we would get no activities.
+        $this->assertCount(1, $worker->getActivities());
+    }
+}

--- a/tests/Unit/WorkerFactory/WorkerFactoryTestCase.php
+++ b/tests/Unit/WorkerFactory/WorkerFactoryTestCase.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\WorkerFactory;
+
+use Temporal\Tests\Unit\UnitTestCase;
+
+/**
+ * @group worker
+ * @group unit
+ */
+abstract class WorkerFactoryTestCase extends UnitTestCase
+{
+}


### PR DESCRIPTION
## What was changed

Introduced an ability to extend worker factory.

Dunno if I should make other `create*()` methods protected as well, besides reader.

## Why?

So a custom reader could be used. To be able to read activty/workflow config not only from annotations, but preset arrays etc.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-php/issues/110

2. How was this tested: Unit tests.

3. Any docs updates needed? No. Its self explanatory and no BC.
