### PR TITLE
Change docker hub repo to temporaliotest

### DIFF
--- a/docker/buildkite/docker-compose.yml
+++ b/docker/buildkite/docker-compose.yml
@@ -11,7 +11,7 @@ services:
           - cassandra
 
   temporal:
-    image: temporalio/auto-setup:latest
+    image: temporaliotest/auto-setup:latest
     ports:
       - "7233:7233"
       - "7234:7234"


### PR DESCRIPTION
After https://github.com/temporalio/temporal/pull/1740 `temporalio/auto-setup:latest` points to latest release not latest `master` commit.