### PR TITLE
Fix CI issues

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -38,7 +38,7 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
 
       - name: Install Composer Dependencies
-        run: composer install --prefer-dist --no-interaction --no-suggest --ignore-platform-reqs
+        run: composer install --prefer-dist --no-interaction --no-suggest
 
       - name: Verify
         run: composer require --dev roave/security-advisories:dev-latest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           tools: composer:v2
-          extensions: dom
+          extensions: dom, sockets
 
       - name: Check Out Code
         uses: actions/checkout@v2

--- a/psalm.xml
+++ b/psalm.xml
@@ -6,7 +6,6 @@
 
     errorLevel="7"
     hoistConstants="true"
-    allowPhpStormGenerics="true"
     findUnusedPsalmSuppress="false"
     findUnusedVariablesAndParams="true"
     ensureArrayStringOffsetsExist="true"


### PR DESCRIPTION
CI configs seem to be outdated:
- Remove deprecated option from psalm config.
- Add required sockets extension for some tests.
- Fix composer install step for security checks.