### PR TITLE
Allow for higher versions of Carbon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ Thumbs.db
 
 # Other
 *.exe
+rr
+.rr.yaml

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "google/common-protos": "^1.3",
         "google/protobuf": "^3.14",
         "grpc/grpc": "^1.34",
-        "nesbot/carbon": "2.52.*",
+        "nesbot/carbon": "^2.52.0",
         "psr/log": "^1.1",
         "react/promise": "^2.8",
         "spiral/attributes": "^2.7",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         "spiral/attributes": "^2.7",
         "spiral/roadrunner-worker": "^2.0.2",
         "spiral/roadrunner-cli": "^2.0",
-        "symfony/polyfill-php80": "^1.18"
+        "symfony/polyfill-php80": "^1.18",
+        "symfony/translation": "5.4.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## What was changed

Unlocked `nesbot/carbon` from `2.52.*` to `^2.52.0`

## Why?

Temporal was incompatible to latest versions of Laravel when Carbon is locked to `2.52.*`

Tested against latest Laravel version (8.81.0)