### PR TITLE
Move symfony/translation to dev-dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,7 @@
         "spiral/attributes": "^2.7",
         "spiral/roadrunner-worker": "^2.0.2",
         "spiral/roadrunner-cli": "^2.0",
-        "symfony/polyfill-php80": "^1.18",
-        "symfony/translation": "5.4.*"
+        "symfony/polyfill-php80": "^1.18"
     },
     "autoload": {
         "psr-4": {
@@ -52,6 +51,7 @@
         "jetbrains/phpstorm-attributes": "dev-master@dev",
         "monolog/monolog": "^2.1",
         "phpunit/phpunit": "^9.3",
+        "symfony/translation": "5.4.*",
         "symfony/var-dumper": "^5.1",
         "vimeo/psalm": "^4.1"
     },


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

I've moved the dependency for `symfony/translation` to the dev-dependencies

## Why?

The version constraint for `symfony/translation` is very narrow. Currently this severely restricts where the sdk can be installed.

As far as I can tell, this is only to support the test suite, so I've moved it to the dev dependencies. `nesbot/carbon` provides its own, much wider, dependency constraint on `symfony/translation`.

## Checklist
<!--- add/delete as needed --->

1. Closes 

NA

3. How was this tested:

I've struggled to run some of the test suites locally (specifically `Temporal\Tests\Functional\Client\ActivityCompletionClientTestCase` never seems to pass locally). However, the rest of the tests continue to pass, and I'm using my fork of this in my own project without any issues.

4. Any docs updates needed?

None
