### PR TITLE
Introduce workflow factory

### DIFF
--- a/src/Internal/Transport/Router/StartWorkflow.php
+++ b/src/Internal/Transport/Router/StartWorkflow.php
@@ -83,10 +83,7 @@ final class StartWorkflow extends Route
      */
     private function findWorkflowOrFail(WorkflowInfo $info): WorkflowPrototype
     {
-        $workflow = $this->services->workflows->find($info->type->name);
-        if ($workflow === null) {
-            $workflow = $this->workflowFactory->create($info->type->name);
-        }
+        $workflow = $this->findWorkflowPrototype($info->type->name);
 
         if ($workflow === null) {
             throw new \OutOfRangeException(\sprintf(self::ERROR_NOT_FOUND, $info->type->name));
@@ -99,5 +96,19 @@ final class StartWorkflow extends Route
         }
 
         return $workflow;
+    }
+
+    private function findWorkflowPrototype(string $workflowName): ?WorkflowPrototype
+    {
+        // Try to get from already defined workflows
+        $workflow = $this->services->workflows->find($workflowName);
+        if ($workflow !== null) {
+            return $workflow;
+        }
+
+        // Try to create from factory
+        $workflowObject = $this->workflowFactory->create($workflowName);
+
+        return $workflowObject !== null ? $this->services->workflowsReader->fromObject($workflowObject) : null;
     }
 }

--- a/src/Worker/WorkerFactoryInterface.php
+++ b/src/Worker/WorkerFactoryInterface.php
@@ -11,6 +11,9 @@ declare(strict_types=1);
 
 namespace Temporal\Worker;
 
+use Temporal\Exception\ExceptionInterceptorInterface;
+use Temporal\WorkflowFactory\WorkflowFactoryInterface;
+
 /**
  * The {@see WorkerFactoryInterface} is responsible for providing an
  * interface for registering all dependencies and creating a global
@@ -38,7 +41,9 @@ interface WorkerFactoryInterface
      */
     public function newWorker(
         string $taskQueue = self::DEFAULT_TASK_QUEUE,
-        WorkerOptions $options = null
+        WorkerOptions $options = null,
+        ExceptionInterceptorInterface $exceptionInterceptor = null,
+        WorkflowFactoryInterface $workflowFactory = null
     ): WorkerInterface;
 
     /**

--- a/src/WorkflowFactory/EmptyWorkflowFactory.php
+++ b/src/WorkflowFactory/EmptyWorkflowFactory.php
@@ -8,7 +8,7 @@ use Temporal\Internal\Declaration\Prototype\WorkflowPrototype;
 
 final class EmptyWorkflowFactory implements WorkflowFactoryInterface
 {
-    public function create(string $workflowName): ?WorkflowPrototype
+    public function create(string $workflowName): ?object
     {
         return null;
     }

--- a/src/WorkflowFactory/EmptyWorkflowFactory.php
+++ b/src/WorkflowFactory/EmptyWorkflowFactory.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\WorkflowFactory;
+
+use Temporal\Internal\Declaration\Prototype\WorkflowPrototype;
+
+final class EmptyWorkflowFactory implements WorkflowFactoryInterface
+{
+    public function create(string $workflowName): ?WorkflowPrototype
+    {
+        return null;
+    }
+}

--- a/src/WorkflowFactory/WorkflowFactoryInterface.php
+++ b/src/WorkflowFactory/WorkflowFactoryInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace Temporal\WorkflowFactory;
+
+
+use Temporal\Internal\Declaration\Prototype\WorkflowPrototype;
+
+interface WorkflowFactoryInterface
+{
+    public function create(string $workflowName): ?WorkflowPrototype;
+}

--- a/src/WorkflowFactory/WorkflowFactoryInterface.php
+++ b/src/WorkflowFactory/WorkflowFactoryInterface.php
@@ -10,5 +10,5 @@ use Temporal\Internal\Declaration\Prototype\WorkflowPrototype;
 
 interface WorkflowFactoryInterface
 {
-    public function create(string $workflowName): ?WorkflowPrototype;
+    public function create(string $workflowName): ?object;
 }

--- a/tests/Unit/Framework/WorkerFactoryMock.php
+++ b/tests/Unit/Framework/WorkerFactoryMock.php
@@ -36,6 +36,8 @@ use Temporal\Worker\Transport\Command\RequestInterface;
 use Temporal\Worker\WorkerFactoryInterface;
 use Temporal\Worker\WorkerInterface;
 use Temporal\Worker\WorkerOptions;
+use Temporal\WorkflowFactory\EmptyWorkflowFactory;
+use Temporal\WorkflowFactory\WorkflowFactoryInterface;
 
 /**
  * @internal
@@ -81,7 +83,8 @@ class WorkerFactoryMock implements WorkerFactoryInterface, LoopInterface
     public function newWorker(
         string $taskQueue = self::DEFAULT_TASK_QUEUE,
         WorkerOptions $options = null,
-        ExceptionInterceptorInterface $exceptionInterceptor = null
+        ExceptionInterceptorInterface $exceptionInterceptor = null,
+        WorkflowFactoryInterface $workflowFactory = null
     ): WorkerInterface {
         $worker = new WorkerMock(
             $taskQueue,
@@ -90,7 +93,7 @@ class WorkerFactoryMock implements WorkerFactoryInterface, LoopInterface
                 $this,
                 $exceptionInterceptor ?? ExceptionInterceptor::createDefault()
             ),
-
+            $workflowFactory ?? new EmptyWorkflowFactory()
         );
         $this->queues->add($worker);
 

--- a/tests/Unit/WorkflowContext/WorkflowFactoryTestCase.php
+++ b/tests/Unit/WorkflowContext/WorkflowFactoryTestCase.php
@@ -32,19 +32,9 @@ final class WorkflowFactoryTestCase extends UnitTestCase
     public function testWorkflowFactoryCanCreateWorkflowInRuntime(): void
     {
         $workflowFactory = new class implements WorkflowFactoryInterface {
-            private WorkflowReader $reader;
-
-            public function __construct()
+            public function create(string $workflowName): ?object
             {
-                $this->reader = new WorkflowReader(
-                    new SelectiveReader([new AnnotationReader(), new AttributeReader()])
-                );
-            }
-
-            public function create(string $workflowName): ?WorkflowPrototype
-            {
-                return $this->reader->fromObject(
-                    new
+                return new
                     /**
                      * Support for PHP7.4
                      * @Workflow\WorkflowInterface
@@ -60,8 +50,7 @@ final class WorkflowFactoryTestCase extends UnitTestCase
                         {
                             return 'hello';
                         }
-                    }
-                );
+                    };
             }
         };
 

--- a/tests/Unit/WorkflowContext/WorkflowFactoryTestCase.php
+++ b/tests/Unit/WorkflowContext/WorkflowFactoryTestCase.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\WorkflowContext;
+
+use Spiral\Attributes\AnnotationReader;
+use Spiral\Attributes\AttributeReader;
+use Spiral\Attributes\Composite\SelectiveReader;
+use Temporal\Internal\Declaration\Prototype\WorkflowPrototype;
+use Temporal\Internal\Declaration\Reader\WorkflowReader;
+use Temporal\Tests\Unit\Framework\WorkerFactoryMock;
+use Temporal\Tests\Unit\Framework\WorkerMock;
+use Temporal\Tests\Unit\UnitTestCase;
+use Temporal\Worker\WorkerFactoryInterface;
+use Temporal\Worker\WorkerInterface;
+use Temporal\Workflow;
+use Temporal\Workflow\WorkflowMethod;
+use Temporal\WorkflowFactory\WorkflowFactoryInterface;
+
+final class WorkflowFactoryTestCase extends UnitTestCase
+{
+    private WorkerFactoryInterface $factory;
+
+    protected function setUp(): void
+    {
+        $this->factory = WorkerFactoryMock::create();
+
+        parent::setUp();
+    }
+
+    public function testWorkflowFactoryCanCreateWorkflowInRuntime(): void
+    {
+        $workflowFactory = new class implements WorkflowFactoryInterface {
+            private WorkflowReader $reader;
+
+            public function __construct()
+            {
+                $this->reader = new WorkflowReader(
+                    new SelectiveReader([new AnnotationReader(), new AttributeReader()])
+                );
+            }
+
+            public function create(string $workflowName): ?WorkflowPrototype
+            {
+                return $this->reader->fromObject(
+                    new
+                    /**
+                     * Support for PHP7.4
+                     * @Workflow\WorkflowInterface
+                     */
+                    #[Workflow\WorkflowInterface]
+                    class {
+                        /**
+                         * Support for PHP7.4
+                         * @Workflow\WorkflowMethod(name="SimpleWorkflow")
+                         */
+                        #[WorkflowMethod(name: 'SimpleWorkflow')]
+                        public function handler()
+                        {
+                            return 'hello';
+                        }
+                    }
+                );
+            }
+        };
+
+        /** @var WorkerMock|WorkerInterface $worker */
+        $worker = $this->factory->newWorker(
+            'default',
+            null,
+            null,
+            $workflowFactory
+        );
+
+        $this->addToAssertionCount(1); // For workflow result assertion
+        $worker->runWorkflow('SimpleWorkflow');
+        $worker->assertWorkflowReturns('hello');
+        $this->factory->run($worker);
+    }
+}


### PR DESCRIPTION
The first idea was a factory to return an instance of `WorkflowPrototype`. But in this case any factory should have a dependency of `WorkflowReader`. I think that from the client point of view it is better to have just a plain class that returns just an object. Than, inside the `StartWorkflow` it will be read and converted to a `WorkflowPrototype`.


Api is the following:

```php
$workflowFactory = new class implements WorkflowFactoryInterface {
    public function create(string $workflowName): ?object
    {
        if ($workflowName !== 'my-workflow') {
            return null;
        }

        return new
        /**
         * Support for PHP7.4
         * @Workflow\WorkflowInterface
         */
        #[Workflow\WorkflowInterface]
        class {
            /**
             * Support for PHP7.4
             * @Workflow\WorkflowMethod(name="SimpleWorkflow")
             */
            #[WorkflowMethod(name: 'SimpleWorkflow')]
            public function handler()
            {
                return 'hello';
            }
        };
    }
};

$worker = $this->factory->newWorker(
    'default',
    null,
    null,
    $workflowFactory
);
```