### PR TITLE
Make activities truly stateless

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -204,6 +204,6 @@ jobs:
           docker-compose -f ./tests/docker-compose.yaml up -d
           sleep 35
           chmod +x ./rr
-          ./rr serve -c ./tests/.rr.silent.yaml &
+          ./rr serve -c .rr.silent.yaml -w tests &
           sleep 10
           vendor/bin/phpunit --testsuite=Functional --testdox --verbose

--- a/src/Worker/WorkerInterface.php
+++ b/src/Worker/WorkerInterface.php
@@ -53,6 +53,20 @@ interface WorkerInterface
     public function registerActivityImplementations(object ...$activity): self;
 
     /**
+     * Register an activity via its type or via a factory. When an activity class doesn't require
+     * any external dependencies and can be created with a keyword `new`:
+     *
+     * $worker->registerActivity(MyActivity::class);
+     *
+     * In case an activity class requires some external dependencies provide a callback - factory
+     * that creates or builds a new activity instance. The factory should be a callable which accepts
+     * an instance of ReflectionClass with an activity class which should be created.
+     *
+     * $worker->registerActivity(MyActivity::class, fn(ReflectionClass $class) => $container->create($class->getClass()));
+     */
+    public function registerActivity(string $type, callable $factory = null): self;
+
+    /**
      * Returns list of registered activities.
      *
      * @return iterable<ActivityPrototype>

--- a/tests/Unit/Activity/ActivityPrototypeTestCase.php
+++ b/tests/Unit/Activity/ActivityPrototypeTestCase.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\Activity;
+
+use Spiral\Attributes\AnnotationReader;
+use Spiral\Attributes\AttributeReader;
+use Spiral\Attributes\Composite\SelectiveReader;
+use Temporal\Internal\Declaration\Reader\ActivityReader;
+use Temporal\Tests\Unit\UnitTestCase;
+
+final class ActivityPrototypeTestCase extends UnitTestCase
+{
+    private ActivityReader $activityReader;
+
+    protected function setUp(): void
+    {
+        $this->activityReader = new ActivityReader(new SelectiveReader([new AnnotationReader(), new AttributeReader()]));
+        parent::setUp();
+    }
+
+
+    public function testGetInstanceFromObject(): void
+    {
+        $instance = new DummyActivity();
+        $proto = $this->activityReader->fromClass(DummyActivity::class)[0];
+        $proto = $proto->withInstance($instance);
+
+        self::assertSame($instance, $proto->getInstance()->getContext());
+    }
+
+    public function testGetInstanceFromClass(): void
+    {
+        $proto = $this->activityReader->fromClass(DummyActivity::class)[0];
+
+        self::assertInstanceOf(DummyActivity::class, $proto->getInstance()->getContext());
+    }
+
+    public function testGetInstanceFromFactory(): void
+    {
+        $proto = $this->activityReader->fromClass(DummyActivity::class)[0];
+        $protoWithFactory = $proto->withFactory(fn () => new DummyActivity());
+
+        $this->assertInstanceOf(DummyActivity::class, $protoWithFactory->getInstance()->getContext());
+    }
+
+    public function testFactoryCreatesNewInstances(): void
+    {
+        $proto = $this->activityReader->fromClass(DummyActivity::class)[0];
+        $protoWithFactory = $proto->withFactory(fn () => new DummyActivity());
+
+        $this->assertEquals($protoWithFactory->getInstance()->getContext(), $protoWithFactory->getInstance()->getContext());
+        $this->assertNotSame($protoWithFactory->getInstance()->getContext(), $protoWithFactory->getInstance()->getContext());
+    }
+
+    public function testFactoryAcceptsReflectionClassOfActivity(): void
+    {
+        $proto = $this->activityReader->fromClass(DummyActivity::class)[0];
+        $protoWithFactory = $proto->withFactory(fn (\ReflectionClass $reflectionClass) => $reflectionClass->newInstance());
+
+        $this->assertEquals($protoWithFactory->getInstance()->getContext(), $protoWithFactory->getInstance()->getContext());
+        $this->assertNotSame($protoWithFactory->getInstance()->getContext(), $protoWithFactory->getInstance()->getContext());
+    }
+}

--- a/tests/Unit/Activity/DummyActivity.php
+++ b/tests/Unit/Activity/DummyActivity.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\Activity;
+
+use Temporal\Activity\ActivityInterface;
+use Temporal\Activity\ActivityMethod;
+
+/**
+ * Support for PHP7.4
+ * @Temporal\Activity\ActivityInterface(prefix="DummyActivity")
+ */
+#[ActivityInterface(prefix: 'DummyActivity')]
+final class DummyActivity
+{
+    /**
+     * Support for PHP7.4
+     * @Temporal\Activity\ActivityMethod(name="DoNothing")
+     */
+    #[ActivityMethod(name: "DoNothing")]
+    public function doNothing(): void
+    {
+    }
+}


### PR DESCRIPTION
Introduce new method for activity registration. For simple activities without external dependencies:

```php
$worker->registerActivity(MyActivity::class);
```

In case we need dependencies provide a callable factory:

```php
$worker->registerActivity(MyActivity::class, fn(ReflectionClass $class) => $container->create($class->getClass()));
```