### PR TITLE
[FIX] Correct encoding of null values, strip names of arguments

### DIFF
--- a/src/DataConverter/EncodedValues.php
+++ b/src/DataConverter/EncodedValues.php
@@ -66,7 +66,7 @@ class EncodedValues implements ValuesInterface
      */
     public function getValue(int $index, $type = null)
     {
-        if (isset($this->values[$index])) {
+        if (is_array($this->values) && array_key_exists($index, $this->values)) {
             return $this->values[$index];
         }
 
@@ -131,7 +131,7 @@ class EncodedValues implements ValuesInterface
     public static function fromValues(array $values, DataConverterInterface $dataConverter = null): EncodedValues
     {
         $ev = new self();
-        $ev->values = $values;
+        $ev->values = array_values($values);
         $ev->converter = $dataConverter;
 
         return $ev;


### PR DESCRIPTION
## What was changed
Small fixes in Encoded values:
1. getValue fails if i.e. `$this->values[0] === null` 
2. fromValues fails when we call i.e. activity with named arguments, `$ev->values` will have named keys

1. Closes #180 
