### PR TITLE
Use `static` keyword in WorkflowException::withoutMessage method

### DIFF
--- a/src/Exception/Client/WorkflowException.php
+++ b/src/Exception/Client/WorkflowException.php
@@ -80,6 +80,6 @@ class WorkflowException extends TemporalException
         string $workflowType = null,
         \Throwable $previous = null
     ): WorkflowException {
-        return new self(null, $execution, $workflowType, $previous);
+        return new static(null, $execution, $workflowType, $previous);
     }
 }

--- a/tests/Unit/Internal/Client/WorkflowStubTest.php
+++ b/tests/Unit/Internal/Client/WorkflowStubTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\Internal\Client;
+
+use Temporal\Client\ClientOptions;
+use Temporal\Client\GRPC\ServiceClientInterface;
+use Temporal\Client\GRPC\StatusCode;
+use Temporal\DataConverter\DataConverterInterface;
+use Temporal\Exception\Client\ServiceClientException;
+use Temporal\Exception\Client\WorkflowNotFoundException;
+use Temporal\Exception\Client\WorkflowServiceException;
+use Temporal\Internal\Client\WorkflowStub;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Temporal\Workflow\WorkflowExecution;
+
+/**
+ * @internal
+ *
+ * @covers \Temporal\Internal\Client\WorkflowStub
+ */
+final class WorkflowStubTest extends TestCase
+{
+    private WorkflowStub $workflowStub;
+    /** @var MockObject|ServiceClientInterface */
+    private $serviceClient;
+
+    protected function setUp(): void
+    {
+        $this->serviceClient = $this->createMock(ServiceClientInterface::class);
+        $this->workflowStub = new WorkflowStub(
+            $this->serviceClient,
+            new ClientOptions(),
+            $this->createMock(DataConverterInterface::class),
+        );
+        $this->workflowStub->setExecution(new WorkflowExecution());
+    }
+
+    public function testSignalThrowsWorkflowNotFoundException(): void
+    {
+        $status = new \stdClass();
+        $status->details = 'status details';
+        $status->code = StatusCode::NOT_FOUND;
+        $serviceClientException = new ServiceClientException($status);
+        $this->serviceClient
+            ->expects(static::once())
+            ->method('SignalWorkflowExecution')
+            ->willThrowException($serviceClientException);
+
+        static::expectException(WorkflowNotFoundException::class);
+
+        $this->workflowStub->signal('signalName');
+    }
+
+    public function testSignalThrowsWorkflowServiceException(): void
+    {
+        $status = new \stdClass();
+        $status->details = 'status details';
+        $status->code = StatusCode::INTERNAL;
+        $serviceClientException = new ServiceClientException($status);
+        $this->serviceClient
+            ->expects(static::once())
+            ->method('SignalWorkflowExecution')
+            ->willThrowException($serviceClientException);
+
+        static::expectException(WorkflowServiceException::class);
+
+        $this->workflowStub->signal('signalName');
+    }
+}


### PR DESCRIPTION
## What was changed
use `static` keyword in WorkflowException::withoutMessage instead of `self` to create new exception

## Why?
::withoutMessage method is used in classes which extends WorkflowException, `new self` will always create WorkflowException instance.
