### PR TITLE
Change chmod for light temporal downloader

### DIFF
--- a/testing/src/Downloader.php
+++ b/testing/src/Downloader.php
@@ -42,7 +42,7 @@ final class Downloader
 
         $targetPath = getcwd() . DIRECTORY_SEPARATOR . $systemInfo->temporalServerExecutable;
         $this->filesystem->copy($pathToExtractedAsset . DIRECTORY_SEPARATOR . $systemInfo->temporalServerExecutable, $targetPath);
-        $this->filesystem->chmod($targetPath, 755);
+        $this->filesystem->chmod($targetPath, 0755);
         $this->filesystem->remove($pathToExtractedAsset);
     }
 


### PR DESCRIPTION
## What was changed
According to SF documentation https://symfony.com/doc/current/components/filesystem.html#chmod
Chmod was changed from 755 to 0755

## Why?
Test server was downloaded with wrong permissions

## Checklist
1. How was this tested:
Manually
2. Any docs updates needed?
No
