### PR TITLE
Enums php81

### DIFF
--- a/src/Internal/Marshaller/Type/EnumType.php
+++ b/src/Internal/Marshaller/Type/EnumType.php
@@ -52,6 +52,7 @@ class EnumType extends Type implements DetectableTypeInterface
     }
 
     /**
+     * @psalm-suppress UndefinedDocblockClass
      * @return \UnitEnum|null
      */
     public function serialize($value)

--- a/src/Internal/Marshaller/Type/EnumType.php
+++ b/src/Internal/Marshaller/Type/EnumType.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Internal\Marshaller\Type;
+
+use Temporal\Internal\Marshaller\MarshallerInterface;
+
+use function is_array;
+
+class EnumType extends Type implements DetectableTypeInterface
+{
+    private string $classFQCN;
+
+    public function __construct(MarshallerInterface $marshaller, string $class = null)
+    {
+        if (PHP_VERSION_ID < 80104) {
+            throw new \RuntimeException('Enums are not available in this version of PHP');
+        }
+
+        if ($class === null) {
+            throw new \RuntimeException('Enum is required');
+        }
+
+        $this->classFQCN = $class;
+        parent::__construct($marshaller);
+    }
+
+    public static function match(\ReflectionNamedType $type): bool
+    {
+        return $type->getName() === 'enum';
+    }
+
+    public function parse($value, $current)
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (is_array($value)) {
+            $value = $value['name'];
+        }
+
+        return ($this->classFQCN)::from($value);
+    }
+
+    public function serialize($value): \UnitEnum
+    {
+        return $value;
+    }
+}

--- a/src/Internal/Marshaller/Type/EnumType.php
+++ b/src/Internal/Marshaller/Type/EnumType.php
@@ -51,7 +51,7 @@ class EnumType extends Type implements DetectableTypeInterface
         return ($this->classFQCN)::from($value);
     }
 
-    public function serialize($value): \UnitEnum
+    public function serialize($value): ?\UnitEnum
     {
         return $value;
     }

--- a/src/Internal/Marshaller/Type/EnumType.php
+++ b/src/Internal/Marshaller/Type/EnumType.php
@@ -51,7 +51,10 @@ class EnumType extends Type implements DetectableTypeInterface
         return ($this->classFQCN)::from($value);
     }
 
-    public function serialize($value): ?\UnitEnum
+    /**
+     * @return \UnitEnum|null
+     */
+    public function serialize($value)
     {
         return $value;
     }

--- a/tests/Unit/DTO/Enum/EnumDTO.php
+++ b/tests/Unit/DTO/Enum/EnumDTO.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\DTO\Enum;
+
+use Temporal\Internal\Marshaller\Meta\Marshal;
+use Temporal\Internal\Marshaller\Type\EnumType;
+
+class EnumDTO
+{
+    #[Marshal(name: 'simpleEnum', type: EnumType::class, of: SimpleEnum::class)]
+    public SimpleEnum $simpleEnum;
+
+    #[Marshal(name: 'scalarEnum', type: EnumType::class, of: ScalarEnum::class)]
+    public ScalarEnum $scalarEnum;
+}

--- a/tests/Unit/DTO/Enum/EnumTestCase.php
+++ b/tests/Unit/DTO/Enum/EnumTestCase.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\DTO\Enum;
+
+use Temporal\Tests\Unit\DTO\DTOMarshallingTestCase;
+
+class EnumTestCase extends DTOMarshallingTestCase
+{
+    public function testMarshalling(): void
+    {
+        if (PHP_VERSION_ID < 80104) {
+            $this->markTestSkipped();
+        }
+
+        $dto = new EnumDTO();
+        $dto->simpleEnum = SimpleEnum::TEST;
+        $dto->scalarEnum = ScalarEnum::TESTED_ENUM;
+
+        $result = $this->marshal($dto);
+        $this->assertEquals($dto->simpleEnum, $result['simpleEnum']);
+        $this->assertEquals($dto->scalarEnum, $result['scalarEnum']);
+    }
+}

--- a/tests/Unit/DTO/Enum/ScalarEnum.php
+++ b/tests/Unit/DTO/Enum/ScalarEnum.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\DTO\Enum;
+
+enum ScalarEnum: string
+{
+    case TESTED_ENUM = 'tested';
+}

--- a/tests/Unit/DTO/Enum/SimpleEnum.php
+++ b/tests/Unit/DTO/Enum/SimpleEnum.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\DTO\Enum;
+
+enum SimpleEnum
+{
+    case TEST;
+}


### PR DESCRIPTION
## What was changed
Add new marshal type `EnumType` which is available for PHP 8.1

## Why?
To use all functionality provided by new version of PHP

## Checklist
1. How was this tested:
Unit + Manual
