### PR TITLE
Fix null pointer

### DIFF
--- a/src/Internal/Client/WorkflowStub.php
+++ b/src/Internal/Client/WorkflowStub.php
@@ -392,6 +392,10 @@ final class WorkflowStub implements WorkflowStubInterface
                 }
             }
 
+            if ($response->getHistory() === null) {
+                continue;
+            }
+
             if ($response->getHistory()->getEvents()->count() === 0) {
                 continue;
             }


### PR DESCRIPTION
## What was changed
In 399 line null pointer can occur.
```
if ($response->getHistory()->getEvents()->count() === 0) {
```

getHistory(): \Temporal\Api\History\V1\History|null

## Why?
<img width="738" alt="image" src="https://user-images.githubusercontent.com/9404962/180158181-3dd52630-2de6-4f3d-a164-3dd239d04908.png">

Bug

## Checklist
1. How was this tested:
In my project I have a multiple integration tests, so errors was visible.
