### PR TITLE
Do not pass nullable result to marshaller

### DIFF
--- a/src/Internal/Marshaller/Mapper/AttributeMapper.php
+++ b/src/Internal/Marshaller/Mapper/AttributeMapper.php
@@ -170,7 +170,7 @@ class AttributeMapper implements MapperInterface
                 return null;
             }
 
-            return $type ? $type->serialize($result) : $result;
+            return $type && $result !== null ? $type->serialize($result) : $result;
         };
     }
 

--- a/tests/Unit/Internal/Marshaller/Fixture/A.php
+++ b/tests/Unit/Internal/Marshaller/Fixture/A.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\Internal\Marshaller\Fixture;
+
+final class A
+{
+    public string $x;
+    public ?B $b;
+
+    public function __construct(string $x, ?B $b = null)
+    {
+        $this->x = $x;
+        $this->b = $b;
+    }
+}

--- a/tests/Unit/Internal/Marshaller/Fixture/B.php
+++ b/tests/Unit/Internal/Marshaller/Fixture/B.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\Internal\Marshaller\Fixture;
+
+final class B
+{
+    public string $code;
+    public ?string $description;
+
+    public function __construct(string $code, ?string $description = null)
+    {
+        $this->code = $code;
+        $this->description = $description;
+    }
+}

--- a/tests/Unit/Internal/Marshaller/MarshallerTestCase.php
+++ b/tests/Unit/Internal/Marshaller/MarshallerTestCase.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\Internal\Marshaller;
+
+use PHPUnit\Framework\TestCase;
+use Spiral\Attributes\AttributeReader;
+use Temporal\Internal\Marshaller\Mapper\AttributeMapperFactory;
+use Temporal\Internal\Marshaller\Marshaller;
+use Temporal\Tests\Unit\Internal\Marshaller\Fixture\A;
+use Temporal\Tests\Unit\Internal\Marshaller\Fixture\B;
+
+/**
+ * @internal
+ *
+ * @covers \Temporal\Internal\Marshaller\Marshaller
+ */
+final class MarshallerTestCase extends TestCase
+{
+    public function testNestedNullableObjectWasSerialized(): void
+    {
+        $marshaller = new Marshaller(new AttributeMapperFactory(new AttributeReader()));
+        self::assertEquals(['x' => 'x', 'b' => null], $marshaller->marshal(new A('x')));
+    }
+
+    public function testNestedNotNullableObjectWasSerialized(): void
+    {
+        $marshaller = new Marshaller(new AttributeMapperFactory(new AttributeReader()));
+        self::assertEquals(['x' => 'x', 'b' => ['code' => 'y', 'description' => null]], $marshaller->marshal(new A('x', new B('y'))));
+    }
+}


### PR DESCRIPTION
## What was changed
Changed behavior for data marshalling.  

Now marshaller throws the `TypeError` when we trying to marshal nullable structure:

```php
final class DeclineReason
{
     public function __construct(
        public readonly string $code,
        public readonly ?string $description = null,
     ) {}  
}

final class Transaction
{
    public function __construct(public readonly ?DeclineReason $reason = null)
    {
    }
}
```