### PR TITLE
fix: don't fail on null workflow result history

### DIFF
--- a/src/Internal/Client/WorkflowStub.php
+++ b/src/Internal/Client/WorkflowStub.php
@@ -392,6 +392,10 @@ final class WorkflowStub implements WorkflowStubInterface
                 }
             }
 
+            if ($response->getHistory() === null) {
+                continue;
+            }
+
             if ($response->getHistory()->getEvents()->count() === 0) {
                 continue;
             }


### PR DESCRIPTION
Originally copied from #209 but added a test for it.