### PR TITLE
Enum as a input for workflow

### DIFF
--- a/src/DataConverter/JsonConverter.php
+++ b/src/DataConverter/JsonConverter.php
@@ -137,9 +137,12 @@ class JsonConverter extends Converter
 
         if ((\is_object($data) || \is_array($data)) && $type->isClass()) {
             try {
-                $instance = (new \ReflectionClass($type->getName()))
-                    ->newInstanceWithoutConstructor()
-                ;
+                $reflection = new \ReflectionClass($type->getName());
+                if (PHP_VERSION_ID >= 80104 && $reflection->isEnum()) {
+                    return $reflection->getConstant($data->name);
+                }
+
+                $instance = $reflection->newInstanceWithoutConstructor();
             } catch (\ReflectionException $e) {
                 throw new DataConverterException($e->getMessage(), $e->getCode(), $e);
             }

--- a/src/DataConverter/Type.php
+++ b/src/DataConverter/Type.php
@@ -101,6 +101,7 @@ final class Type
         if ($type instanceof \ReflectionNamedType) {
             $name = $type->getName();
 
+            /** @psalm-suppress UndefinedClass */
             if (PHP_VERSION_ID >= 80104 && is_subclass_of($name, \UnitEnum::class)) {
                 return new self($type->getName(), true);
             }

--- a/src/DataConverter/Type.php
+++ b/src/DataConverter/Type.php
@@ -101,6 +101,10 @@ final class Type
         if ($type instanceof \ReflectionNamedType) {
             $name = $type->getName();
 
+            if (PHP_VERSION_ID >= 80104 && is_subclass_of($name, \UnitEnum::class)) {
+                return new self($type->getName(), true);
+            }
+
             // Traversable types (i.e. Generator) not allowed
             if (!$name instanceof \Traversable && $name !== 'array' && $name !== 'iterable') {
                 return new self($type->getName(), $type->allowsNull());

--- a/tests/Fixtures/src/Activity/SimpleActivity.php
+++ b/tests/Fixtures/src/Activity/SimpleActivity.php
@@ -18,6 +18,8 @@ use Temporal\Api\Common\V1\WorkflowExecution;
 use Temporal\DataConverter\Bytes;
 use Temporal\Tests\DTO\Message;
 use Temporal\Tests\DTO\User;
+use Temporal\Tests\Unit\DTO\Enum\SimpleEnum;
+use Temporal\Tests\Unit\DTO\Enum\ScalarEnum;
 
 #[ActivityInterface(prefix: "SimpleActivity.")]
 class SimpleActivity
@@ -98,5 +100,17 @@ class SimpleActivity
     public function fail()
     {
         throw new \Error("failed activity");
+    }
+
+    #[ActivityMethod]
+    public function simpleEnum(SimpleEnum $enum): SimpleEnum
+    {
+        return $enum;
+    }
+
+    #[ActivityMethod]
+    public function scalarEnum(ScalarEnum $enum): ScalarEnum
+    {
+        return $enum;
     }
 }

--- a/tests/Fixtures/src/Workflow/ScalarEnumWorkflow.php
+++ b/tests/Fixtures/src/Workflow/ScalarEnumWorkflow.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Workflow;
+
+use Temporal\Workflow\WorkflowMethod;
+use Temporal\Workflow;
+use Temporal\Tests\Activity\SimpleActivity;
+use Temporal\Activity\ActivityOptions;
+use Temporal\Common\RetryOptions;
+use Temporal\Tests\Unit\DTO\Enum\ScalarEnum;
+
+#[Workflow\WorkflowInterface]
+class ScalarEnumWorkflow
+{
+    #[WorkflowMethod(name: 'ScalarEnumWorkflow')]
+    public function handler(ScalarEnum $enum): iterable
+    {
+        $simple = Workflow::newActivityStub(
+            SimpleActivity::class,
+            ActivityOptions::new()
+                ->withStartToCloseTimeout(5)
+                ->withRetryOptions(
+                    RetryOptions::new()->withMaximumAttempts(2)
+                )
+        );
+
+        return yield $simple->scalarEnum($enum);
+    }
+}

--- a/tests/Fixtures/src/Workflow/SimpleEnumWorkflow.php
+++ b/tests/Fixtures/src/Workflow/SimpleEnumWorkflow.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Workflow;
+
+use Temporal\Workflow\WorkflowMethod;
+use Temporal\Workflow;
+use Temporal\Tests\Activity\SimpleActivity;
+use Temporal\Activity\ActivityOptions;
+use Temporal\Common\RetryOptions;
+use Temporal\Tests\Unit\DTO\Enum\SimpleEnum;
+
+#[Workflow\WorkflowInterface]
+class SimpleEnumWorkflow
+{
+    #[WorkflowMethod(name: 'SimpleEnumWorkflow')]
+    public function handler(SimpleEnum $enum): iterable
+    {
+        $simple = Workflow::newActivityStub(
+            SimpleActivity::class,
+            ActivityOptions::new()
+                ->withStartToCloseTimeout(5)
+                ->withRetryOptions(
+                    RetryOptions::new()->withMaximumAttempts(2)
+                )
+        );
+
+        return yield $simple->simpleEnum($enum);
+    }
+}

--- a/tests/Functional/Client/EnumTestCase.php
+++ b/tests/Functional/Client/EnumTestCase.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Functional\Client;
+
+use Temporal\Tests\Workflow\SimpleEnumWorkflow;
+use Temporal\Tests\Unit\DTO\Enum\SimpleEnum;
+use Temporal\Tests\Workflow\ScalarEnumWorkflow;
+use Temporal\Tests\Unit\DTO\Enum\ScalarEnum;
+
+/**
+ * @group client
+ * @group functional
+ */
+class EnumTestCase extends ClientTestCase
+{
+    public function testSimpleEnum(): void
+    {
+        $client = $this->createClient();
+        $workflow = $client->newWorkflowStub(SimpleEnumWorkflow::class);
+
+        $result = $client->start($workflow, SimpleEnum::TEST);
+
+        $this->assertSame(SimpleEnum::TEST, $result->getResult(SimpleEnum::class));
+    }
+
+    public function testScalarEnum(): void
+    {
+        $client = $this->createClient();
+        $workflow = $client->newWorkflowStub(ScalarEnumWorkflow::class);
+
+        $result = $client->start($workflow, ScalarEnum::TESTED_ENUM);
+
+        $this->assertSame(ScalarEnum::TESTED_ENUM, $result->getResult(ScalarEnum::class));
+    }
+}

--- a/tests/Functional/Client/EnumTestCase.php
+++ b/tests/Functional/Client/EnumTestCase.php
@@ -22,6 +22,15 @@ use Temporal\Tests\Unit\DTO\Enum\ScalarEnum;
  */
 class EnumTestCase extends ClientTestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+        
+        if (PHP_VERSION_ID < 80104) {
+            $this->markTestSkipped();
+        }
+    }
+
     public function testSimpleEnum(): void
     {
         $client = $this->createClient();


### PR DESCRIPTION
## What was changed
Part of code related with serialisation.

## Why?
To have possibility to put Enum directly as a input to workflow without proxying.

## Checklist
1. How was this tested:
Functional tests

