### PR TITLE
Possibility to configure temporal test server host

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -33,5 +33,6 @@
     <php>
         <ini name="error_reporting" value="-1"/>
         <ini name="memory_limit" value="-1"/>
+        <env name="TEMPORAL_ADDRESS" value="127.0.0.1:7233" />
     </php>
 </phpunit>

--- a/testing/Readme.md
+++ b/testing/Readme.md
@@ -14,12 +14,15 @@ $environment->start();
 register_shutdown_function(fn () => $environment->stop());
 ```
 
-2. Add `bootstrap.php` to your `phpunit.xml`:
+2. Add environment variable and `bootstrap.php` to your `phpunit.xml`:
 ```xml
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          bootstrap="tests/bootstrap.php"
 >
+    <php>
+        <env name="TEMPORAL_ADDRESS" value="127.0.0.1:7233" />
+    </php>
 </phpunit>
 ```
 

--- a/testing/src/Environment.php
+++ b/testing/src/Environment.php
@@ -42,9 +42,11 @@ final class Environment
             $this->output->writeln('<info>done.</info>');
         }
 
+        $temporalAddress = getenv('TEMPORAL_ADDRESS') ?: '127.0.0.1:7233';
+
         $this->output->write('Starting Temporal test server... ');
         $this->temporalServerProcess = new Process(
-            [$this->systemInfo->temporalServerExecutable, getenv('TEMPORAL_ADDRESS'), '--enable-time-skipping']
+            [$this->systemInfo->temporalServerExecutable, $temporalAddress, '--enable-time-skipping']
         );
         $this->temporalServerProcess->setTimeout(10);
         $this->temporalServerProcess->start();

--- a/testing/src/Environment.php
+++ b/testing/src/Environment.php
@@ -34,7 +34,7 @@ final class Environment
         );
     }
 
-    public function start(string $rrCommand = null, int $temporalTestServerPort = 7233): void
+    public function start(string $rrCommand = null): void
     {
         if (!$this->downloader->check($this->systemInfo->temporalServerExecutable)) {
             $this->output->write('Download temporal test server... ');
@@ -44,7 +44,7 @@ final class Environment
 
         $this->output->write('Starting Temporal test server... ');
         $this->temporalServerProcess = new Process(
-            [$this->systemInfo->temporalServerExecutable, $temporalTestServerPort, '--enable-time-skipping']
+            [$this->systemInfo->temporalServerExecutable, getenv('TEMPORAL_ADDRESS'), '--enable-time-skipping']
         );
         $this->temporalServerProcess->setTimeout(10);
         $this->temporalServerProcess->start();

--- a/testing/src/Environment.php
+++ b/testing/src/Environment.php
@@ -42,7 +42,7 @@ final class Environment
             $this->output->writeln('<info>done.</info>');
         }
 
-        $temporalPort = parse_url(getenv('TEMPORAL_ADDRESS') ?: '127.0.0.1:7233',PHP_URL_PORT);
+        $temporalPort = parse_url(getenv('TEMPORAL_ADDRESS') ?: '127.0.0.1:7233', PHP_URL_PORT);
 
         $this->output->write('Starting Temporal test server... ');
         $this->temporalServerProcess = new Process(

--- a/testing/src/Environment.php
+++ b/testing/src/Environment.php
@@ -42,11 +42,11 @@ final class Environment
             $this->output->writeln('<info>done.</info>');
         }
 
-        $temporalAddress = getenv('TEMPORAL_ADDRESS') ?: '127.0.0.1:7233';
+        $temporalPort = parse_url(getenv('TEMPORAL_ADDRESS') ?: '127.0.0.1:7233',PHP_URL_PORT);
 
         $this->output->write('Starting Temporal test server... ');
         $this->temporalServerProcess = new Process(
-            [$this->systemInfo->temporalServerExecutable, $temporalAddress, '--enable-time-skipping']
+            [$this->systemInfo->temporalServerExecutable, $temporalPort, '--enable-time-skipping']
         );
         $this->temporalServerProcess->setTimeout($commandTimeout);
         $this->temporalServerProcess->start();

--- a/testing/src/Environment.php
+++ b/testing/src/Environment.php
@@ -34,7 +34,7 @@ final class Environment
         );
     }
 
-    public function start(string $rrCommand = null): void
+    public function start(string $rrCommand = null, int $temporalTestServerPort = 7233): void
     {
         if (!$this->downloader->check($this->systemInfo->temporalServerExecutable)) {
             $this->output->write('Download temporal test server... ');
@@ -44,7 +44,7 @@ final class Environment
 
         $this->output->write('Starting Temporal test server... ');
         $this->temporalServerProcess = new Process(
-            [$this->systemInfo->temporalServerExecutable, 7233, '--enable-time-skipping']
+            [$this->systemInfo->temporalServerExecutable, $temporalTestServerPort, '--enable-time-skipping']
         );
         $this->temporalServerProcess->setTimeout(10);
         $this->temporalServerProcess->start();

--- a/testing/src/WithoutTimeSkipping.php
+++ b/testing/src/WithoutTimeSkipping.php
@@ -11,7 +11,7 @@ trait WithoutTimeSkipping
     protected function setUp(): void
     {
         $this->testService = TestService::create(
-            getenv('TEMPORAL_ADDRESS')
+            getenv('TEMPORAL_ADDRESS') ?: '127.0.0.1:7233'
         );
         $this->testService->lockTimeSkipping();
         parent::setUp();

--- a/testing/src/WithoutTimeSkipping.php
+++ b/testing/src/WithoutTimeSkipping.php
@@ -10,9 +10,16 @@ trait WithoutTimeSkipping
 
     protected function setUp(): void
     {
-        $this->testService = TestService::create('localhost:7233');
+        $this->testService = TestService::create(
+            $this->testServiceHost()
+        );
         $this->testService->lockTimeSkipping();
         parent::setUp();
+    }
+
+    protected function testServiceHost(): string
+    {
+        return 'localhost:7233';
     }
 
     protected function tearDown(): void

--- a/testing/src/WithoutTimeSkipping.php
+++ b/testing/src/WithoutTimeSkipping.php
@@ -11,15 +11,10 @@ trait WithoutTimeSkipping
     protected function setUp(): void
     {
         $this->testService = TestService::create(
-            $this->testServiceHost()
+            getenv('TEMPORAL_ADDRESS')
         );
         $this->testService->lockTimeSkipping();
         parent::setUp();
-    }
-
-    protected function testServiceHost(): string
-    {
-        return 'localhost:7233';
     }
 
     protected function tearDown(): void

--- a/testing/src/WorkflowTestCase.php
+++ b/testing/src/WorkflowTestCase.php
@@ -15,7 +15,7 @@ class WorkflowTestCase extends TestCase
 
     protected function setUp(): void
     {
-        $temporalAddress = getenv('TEMPORAL_ADDRESS');
+        $temporalAddress = getenv('TEMPORAL_ADDRESS') ?: '127.0.0.1:7233';
         $this->workflowClient = new WorkflowClient(ServiceClient::create($temporalAddress));
         $this->testingService = TestService::create($temporalAddress);
 

--- a/testing/src/WorkflowTestCase.php
+++ b/testing/src/WorkflowTestCase.php
@@ -15,14 +15,10 @@ class WorkflowTestCase extends TestCase
 
     protected function setUp(): void
     {
-        $this->workflowClient = new WorkflowClient(ServiceClient::create($this->testServiceHost()));
-        $this->testingService = TestService::create($this->testServiceHost());
+        $temporalAddress = getenv('TEMPORAL_ADDRESS');
+        $this->workflowClient = new WorkflowClient(ServiceClient::create($temporalAddress));
+        $this->testingService = TestService::create($temporalAddress);
 
         parent::setUp();
-    }
-
-    protected function testServiceHost(): string
-    {
-        return 'localhost:7233';
     }
 }

--- a/testing/src/WorkflowTestCase.php
+++ b/testing/src/WorkflowTestCase.php
@@ -15,9 +15,14 @@ class WorkflowTestCase extends TestCase
 
     protected function setUp(): void
     {
-        $this->workflowClient = new WorkflowClient(ServiceClient::create('localhost:7233'));
-        $this->testingService = TestService::create('localhost:7233');
+        $this->workflowClient = new WorkflowClient(ServiceClient::create($this->testServiceHost()));
+        $this->testingService = TestService::create($this->testServiceHost());
 
         parent::setUp();
+    }
+
+    protected function testServiceHost(): string
+    {
+        return 'localhost:7233';
     }
 }


### PR DESCRIPTION
## Why?
To have possibility to change default port for temporal test server.
Also:
Since output of RR is not visible in PHPunit sometimes it's hard to figure out where is the error. So you can switch test server to real temporal server and see in UI what's happened.
Alternatively Datadog offers https://github.com/temporalio/temporalite own server which also can be use for tests purposes.

