### PR TITLE
Stop tests and display error if RoadRunner start failed

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -25,20 +25,18 @@ jobs:
           fetch-depth: 1
 
       - name: Get Composer Cache Directory
-        # Docs: <https://github.com/actions/cache/blob/master/examples.md#php---composer>
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
       - name: Cache Dependencies
-        # Docs: <https://github.com/actions/cache/blob/master/examples.md#php---composer>
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: php-${{ matrix.php }}-${{ runner.os }}-composer-
 
       - name: Install Composer Dependencies
-        run: composer install --prefer-dist --no-interaction --no-suggest
+        run: composer install --prefer-dist --no-interaction
 
       - name: Run Tests
         run: vendor/bin/psalm

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -5,13 +5,17 @@ on:
         required: true
         type: string
       fail-fast:
-        required: true
+        required: false
         type: boolean
         default: true
       test-timeout:
         required: false
         type: number
         default: 10
+      run-temporal-test-server:
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   test:
@@ -50,7 +54,8 @@ jobs:
         run: |
           echo "::set-output name=dir::$(composer config cache-files-dir)"
 
-      - uses: actions/cache@v3
+      - name: Cache Composer Dependencies
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: php-${{ matrix.php }}-${{ matrix.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -69,9 +74,29 @@ jobs:
         if: matrix.dependencies == 'highest'
         run: composer update --no-interaction --no-progress
 
+      - name: Cache Roadrunner
+        id: cache-roadrunner
+        uses: actions/cache@v3
+        if: inputs.run-temporal-test-server == true
+        with:
+          path: |
+            ./rr*
+            .rr.yaml
+          key: ${{ matrix.os }}-roadrunner-${{ hashFiles('**/rr') }}
+          restore-keys: |
+            ${{ matrix.os }}-roadrunner-
+
       - name: Download RoadRunner
+        if: inputs.run-temporal-test-server == true && steps.cache-roadrunner.outputs.cache-hit != 'true'
         run: |
           vendor/bin/rr get --no-interaction
 
-      - name: Run Tests
+      - name: Run tests with Temporal test server
+        if: inputs.run-temporal-test-server == true
+        run: vendor/bin/phpunit --testsuite=${{ inputs.test-suite }} --testdox --verbose
+        env:
+          RUN_TEMPORAL_TEST_SERVER: ${{ inputs.run-temporal-test-server }}
+
+      - name: Run tests without Temporal test server
+        if: inputs.run-temporal-test-server == false
         run: vendor/bin/phpunit --testsuite=${{ inputs.test-suite }} --testdox --verbose

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -1,0 +1,77 @@
+on:
+  workflow_call:
+    inputs:
+      test-suite:
+        required: true
+        type: string
+      fail-fast:
+        required: true
+        type: boolean
+        default: true
+      test-timeout:
+        required: false
+        type: number
+        default: 10
+
+jobs:
+  test:
+    name: (PHP ${{ matrix.php }}, OS ${{ matrix.os }}, with ${{ matrix.dependencies }} deps
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: ${{ inputs.test-timeout }}
+    strategy:
+      fail-fast: ${{ inputs.fail-fast }}
+      matrix:
+        php: [ 7.4, 8.0 ]
+        os: [ ubuntu-latest , windows-latest]
+        dependencies: [ lowest , highest ]
+    steps:
+      - name: Set Git To Use LF
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+
+      - name: Setup PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          tools: composer:v2
+          extensions: dom, sockets, grpc, curl
+
+      - name: Check Out Code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+
+      - name: Validate composer.json and composer.lock
+        run: composer validate --strict
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - uses: actions/cache@v3
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: php-${{ matrix.php }}-${{ matrix.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            php-${{ matrix.php }}-${{ matrix.os }}-composer-
+
+      - name: Install lowest dependencies from composer.json
+        if: matrix.dependencies == 'lowest'
+        run: composer update --no-interaction --no-progress --prefer-lowest
+
+      - name: Validate lowest dependencies
+        if: matrix.dependencies == 'lowest'
+        run: vendor/bin/validate-prefer-lowest
+
+      - name: Install highest dependencies from composer.json
+        if: matrix.dependencies == 'highest'
+        run: composer update --no-interaction --no-progress
+
+      - name: Download RoadRunner
+        run: |
+          vendor/bin/rr get --no-interaction
+
+      - name: Run Tests
+        run: vendor/bin/phpunit --testsuite=${{ inputs.test-suite }} --testdox --verbose

--- a/.github/workflows/security-check.yml
+++ b/.github/workflows/security-check.yml
@@ -1,0 +1,42 @@
+name: Security
+
+on: [push, pull_request]
+
+jobs:
+  security:
+    name: Security Checks (PHP ${{ matrix.php }}, OS ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Note: This workflow requires only the LATEST version of PHP
+        php: [ 7.4, 8.0 ]
+        os: [ ubuntu-latest ]
+    steps:
+      - name: Set up PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, sockets, grpc, curl
+
+      - name: Check Out Code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache Dependencies
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: php-${{ matrix.php }}-${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: php-${{ matrix.php }}-${{ runner.os }}-composer-
+
+      - name: Install Composer Dependencies
+        run: composer install --prefer-dist --no-interaction
+
+      - name: Verify
+        run: composer require --dev roave/security-advisories:dev-latest

--- a/.github/workflows/security-check.yml
+++ b/.github/workflows/security-check.yml
@@ -29,7 +29,7 @@ jobs:
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
       - name: Cache Dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: php-${{ matrix.php }}-${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,6 +9,7 @@ jobs:
     with:
       fail-fast: false
       test-suite: Unit
+      run-temporal-test-server: false
 
   feature:
     name: Feature Testing

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -3,210 +3,24 @@ name: Testing
 on: [push, pull_request]
 
 jobs:
-  security:
-    name: Security Checks (PHP ${{ matrix.php }}, OS ${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        # Note: This workflow requires only the LATEST version of PHP
-        php: [ 7.4 ]
-        os: [ ubuntu-latest ]
-    steps:
-      - name: Set up PHP ${{ matrix.php }}
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          extensions: dom, sockets, grpc, curl
-
-      - name: Check Out Code
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-
-      - name: Get Composer Cache Directory
-        # Docs: <https://github.com/actions/cache/blob/master/examples.md#php---composer>
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Cache Dependencies
-        # Docs: <https://github.com/actions/cache/blob/master/examples.md#php---composer>
-        uses: actions/cache@v1
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-
-
-      - name: Install Composer Dependencies
-        run: composer install --prefer-dist --no-interaction --no-suggest
-
-      - name: Verify
-        run: composer require --dev roave/security-advisories:dev-latest
-
-
   unit:
-    name: Unit Testing (PHP ${{ matrix.php }}, OS ${{ matrix.os }}, Stability ${{ matrix.stability }})
-    runs-on: ${{ matrix.os }}
-    strategy:
+    name: Unit Testing
+    uses: ./.github/workflows/run-test-suite.yml
+    with:
       fail-fast: false
-      matrix:
-        php: [7.4, 8.0]
-        os: [ubuntu-latest, windows-latest]
-        stability: [prefer-lowest, prefer-stable]
-
-    steps:
-      - name: Set Git To Use LF
-        run: |
-          git config --global core.autocrlf false
-          git config --global core.eol lf
-
-      - name: Setup PHP ${{ matrix.php }}
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          tools: composer:v2
-          extensions: dom, sockets, grpc, curl
-
-      - name: Check Out Code
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-
-      - name: Get Composer Cache Directory
-        # Docs: <https://github.com/actions/cache/blob/master/examples.md#php---composer>
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Cache Dependencies
-        # Docs: <https://github.com/actions/cache/blob/master/examples.md#php---composer>
-        uses: actions/cache@v1
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-
-
-      - name: Install Composer Dependencies
-        uses: nick-invision/retry@v1
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
-      
-      - name: Download RoadRunner
-        run: |
-          vendor/bin/rr get --no-interaction
-
-      - name: Run Tests
-        run: vendor/bin/phpunit --testsuite=Unit --testdox --verbose
-
+      test-suite: Unit
 
   feature:
-    timeout-minutes: 20
-    name: Feature Testing (PHP ${{ matrix.php }}, OS ${{ matrix.os }}, Stability ${{ matrix.stability }})
-    runs-on: ${{ matrix.os }}
-    strategy:
+    name: Feature Testing
+    uses: ./.github/workflows/run-test-suite.yml
+    with:
       fail-fast: true
-      matrix:
-        php: [7.4, 8.0]
-        os: [ubuntu-latest, windows-latest]
-        stability: [prefer-lowest, prefer-stable]
-
-    steps:
-      - name: Set Git To Use LF
-        run: |
-          git config --global core.autocrlf false
-          git config --global core.eol lf
-
-      - name: Setup PHP ${{ matrix.php }}
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          tools: composer:v2
-          extensions: dom, sockets, grpc, curl
-
-      - name: Check Out Code
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-
-      - name: Get Composer Cache Directory
-        # Docs: <https://github.com/actions/cache/blob/master/examples.md#php---composer>
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Cache Dependencies
-        # Docs: <https://github.com/actions/cache/blob/master/examples.md#php---composer>
-        uses: actions/cache@v1
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-
-
-      - name: Install Composer Dependencies
-        uses: nick-invision/retry@v1
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
-      
-      - name: Download RoadRunner
-        run: |
-          vendor/bin/rr get --no-interaction
-
-      - name: Run Tests
-        run: vendor/bin/phpunit --testsuite=Feature --testdox --verbose
+      test-suite: Feature
+      test-timeout: 20
 
   functional:
-    name: Functional Testing (PHP ${{ matrix.php }}, OS ${{ matrix.os }}, Stability ${{ matrix.stability }})
-    runs-on: ${{ matrix.os }}
-    strategy:
+    name: Functional Testing
+    uses: ./.github/workflows/run-test-suite.yml
+    with:
       fail-fast: false
-      matrix:
-        php: [7.4, 8.0]
-        os: [ubuntu-latest]
-
-    steps:
-      - name: Set Git To Use LF
-        run: |
-          git config --global core.autocrlf false
-          git config --global core.eol lf
-
-      - name: Setup PHP ${{ matrix.php }}
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          tools: composer:v2
-          extensions: dom, sockets, grpc, curl
-
-      - name: Check Out Code
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-
-      - name: Get Composer Cache Directory
-        # Docs: <https://github.com/actions/cache/blob/master/examples.md#php---composer>
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Cache Dependencies
-        # Docs: <https://github.com/actions/cache/blob/master/examples.md#php---composer>
-        uses: actions/cache@v1
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-
-
-      - name: Install Composer Dependencies
-        uses: nick-invision/retry@v1
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: composer update --prefer-dist --no-interaction --no-progress
-
-      - name: Download RoadRunner
-        run: |
-          vendor/bin/rr get --no-interaction
-
-      - name: Run Tests
-        run: |
-          vendor/bin/phpunit --testsuite=Functional --testdox --verbose
+      test-suite: Functional

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -91,6 +91,10 @@ jobs:
           timeout_minutes: 5
           max_attempts: 5
           command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
+      
+      - name: Download RoadRunner
+        run: |
+          vendor/bin/rr get --no-interaction
 
       - name: Run Tests
         run: vendor/bin/phpunit --testsuite=Unit --testdox --verbose
@@ -144,6 +148,10 @@ jobs:
           timeout_minutes: 5
           max_attempts: 5
           command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
+      
+      - name: Download RoadRunner
+        run: |
+          vendor/bin/rr get --no-interaction
 
       - name: Run Tests
         run: vendor/bin/phpunit --testsuite=Feature --testdox --verbose

--- a/composer.json
+++ b/composer.json
@@ -28,16 +28,16 @@
         "google/protobuf": "^3.14",
         "grpc/grpc": "^1.34",
         "nesbot/carbon": "^2.52.0",
-        "psr/log": "^1.0 || ^2.0 || ^3.0",
+        "psr/log": "^1.0.1 || ^2.0 || ^3.0",
         "react/promise": "^2.8",
         "spiral/attributes": "^2.7 || ^3.0",
-        "spiral/roadrunner-cli": "^2.0",
+        "spiral/roadrunner-cli": "^2.2",
         "spiral/roadrunner-kv": "^2.1",
         "spiral/roadrunner-worker": "^2.0.2",
-        "symfony/filesystem": "^4.4|^5.3|^6.0",
-        "symfony/http-client": "^4.4|^5.3|^6.0",
-        "symfony/polyfill-php80": "^1.18",
-        "symfony/process": "^4.4|^5.3|^6.0"
+        "symfony/filesystem": "^4.4.9|^5.3|^6.0",
+        "symfony/http-client": "^4.4.11|^5.3|^6.0",
+        "symfony/polyfill-php80": "^1.23",
+        "symfony/process": "^4.4.11|^5.3|^6.0"
     },
     "autoload": {
         "psr-4": {
@@ -51,13 +51,13 @@
         }
     },
     "require-dev": {
-        "ext-curl": "*",
-        "friendsofphp/php-cs-fixer": "^2.8",
         "composer/composer": "^2.0",
-        "laminas/laminas-code": "^4.0",
+        "dereuromark/composer-prefer-lowest": "^0.1.10",
         "doctrine/annotations": "^1.11",
+        "friendsofphp/php-cs-fixer": "^2.8",
         "illuminate/support": "^7.0",
         "jetbrains/phpstorm-attributes": "dev-master@dev",
+        "laminas/laminas-code": "^4.0",
         "monolog/monolog": "^2.1 || ^3.0",
         "phpunit/phpunit": "^9.3",
         "symfony/translation": "5.4.*",

--- a/testing/Readme.md
+++ b/testing/Readme.md
@@ -14,6 +14,17 @@ $environment->start();
 register_shutdown_function(fn () => $environment->stop());
 ```
 
+If you don't want to run temporal test server with all of your tests you can set, for example,
+add condition to start it only if `RUN_TEMPORAL_TEST_SERVER` environment variable is present:
+
+```php
+if (getenv('RUN_TEMPORAL_TEST_SERVER') !== false) {
+    $environment = Environment::create();
+    $environment->start('./rr serve -c .rr.silent.yaml -w tests');
+    register_shutdown_function(fn() => $environment->stop());
+}
+```
+
 2. Add `bootstrap.php` to your `phpunit.xml`:
 ```xml
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -36,7 +47,9 @@ The code in `bootstrap.php` will start/stop (and download if it doesn't exist) T
 server and RoadRunner for every phpunit run. Test server runs as a regular server on 7233 port. 
 Thus, if you use default connection settings, there is no need to change them.
 
-Under the hood RoadRunner is started with `rr serve` command. You can specify your own command in `bootstrap.php`:
+Under the hood RoadRunner is started with `rr serve` command. So make sure you have the binary.
+
+You can specify your own command in `bootstrap.php`:
 ```php
 $environment->start('./rr serve -c .rr.test.yaml -w tests');
 ```

--- a/testing/src/Environment.php
+++ b/testing/src/Environment.php
@@ -65,9 +65,16 @@ final class Environment
             exit(1);
         }
 
-        $this->roadRunnerProcess->waitUntil(
+        $roadRunnerStarted = $this->roadRunnerProcess->waitUntil(
             fn($type, $output) => strpos($output, 'RoadRunner server started') !== false
         );
+
+        if (!$roadRunnerStarted) {
+            $this->output->writeln('<error>error</error>');
+            $this->output->writeln('Error starting RoadRunner: ' . $this->roadRunnerProcess->getErrorOutput());
+            exit(1);
+        }
+        
         $this->output->writeln('<info>done.</info>');
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,6 +6,9 @@ use Temporal\Testing\Environment;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$environment = Environment::create();
-$environment->start('./rr serve -c .rr.silent.yaml -w tests');
-register_shutdown_function(fn () => $environment->stop());
+if (getenv('RUN_TEMPORAL_TEST_SERVER') !== false) {
+    $environment = Environment::create();
+    $environment->start('./rr serve -c .rr.silent.yaml -w tests');
+    register_shutdown_function(fn() => $environment->stop());
+}
+


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Added additional check for RR in the Temporal\Testing\Environment::start method

## Why?
<!-- Tell your future self why have you made these changes -->
RoadRunner could fail to start for many reasons, for example:
- rr binary doesn't exist (but in that case we could download it I suppose)
- config file not found
- error in the worker setup

It is useful to stop the tests right away and display the error, otherwise the tests are just hang
## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
- Delete rr binary
- Set wrong path to config in rrCommand (`$environment->start('./rr serve -c missing.rr.yaml');`)
- Put die, or some other error in the worker

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
