### PR TITLE
Issue 211. Test for readonly properties

### DIFF
--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: ${{ inputs.fail-fast }}
       matrix:
-        php: [ 7.4, 8.0 ]
+        php: [ 7.4, 8.0, 8.1 ]
         os: [ ubuntu-latest , windows-latest]
         dependencies: [ lowest , highest ]
     steps:

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "google/common-protos": "^1.3",
-        "google/protobuf": "^3.20",
+        "google/protobuf": "^3.20.1",
         "grpc/grpc": "^1.34",
         "nesbot/carbon": "^2.52.0",
         "psr/log": "^1.0.1 || ^2.0 || ^3.0",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "google/common-protos": "^1.3",
-        "google/protobuf": "^3.14",
+        "google/protobuf": "^3.20",
         "grpc/grpc": "^1.34",
         "nesbot/carbon": "^2.52.0",
         "psr/log": "^1.0.1 || ^2.0 || ^3.0",

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         "jetbrains/phpstorm-attributes": "dev-master@dev",
         "laminas/laminas-code": "^4.0",
         "monolog/monolog": "^2.1 || ^3.0",
-        "phpunit/phpunit": "^9.3",
+        "phpunit/phpunit": "^9.5.21",
         "symfony/translation": "5.4.*",
         "symfony/var-dumper": "^5.1",
         "vimeo/psalm": "^4.1"

--- a/tests/Unit/DTO/DTOMarshallingTestCase.php
+++ b/tests/Unit/DTO/DTOMarshallingTestCase.php
@@ -51,4 +51,15 @@ abstract class DTOMarshallingTestCase extends UnitTestCase
     {
         return $this->marshaller->marshal($object);
     }
+
+    /**
+     * @param array $payload
+     * @param object $to
+     * @return object
+     * @throws \ReflectionException
+     */
+    protected function unmarshal(array $payload, object $to): object
+    {
+        return $this->marshaller->unmarshal($payload, $to);
+    }
 }

--- a/tests/Unit/DTO/Readonly/ReadonlyPropertiesDTO.php
+++ b/tests/Unit/DTO/Readonly/ReadonlyPropertiesDTO.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\DTO\Readonly;
+
+use Temporal\Tests\Unit\DTO\Enum\ScalarEnum;
+
+class ReadonlyPropertiesDTO
+{
+    readonly public string $propertiesString;
+
+    public function __construct(
+        readonly public string $promotedString,
+        readonly public string $secondPromotedString,
+        string $propertiesString
+    )
+    {
+        $this->propertiesString = $propertiesString;
+    }
+}

--- a/tests/Unit/DTO/Readonly/ReadonlyPropertiesTestCase.php
+++ b/tests/Unit/DTO/Readonly/ReadonlyPropertiesTestCase.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\DTO\Readonly;
+
+use Temporal\DataConverter\DataConverter;
+use Temporal\Tests\Unit\DTO\DTOMarshallingTestCase;
+
+class ReadonlyPropertiesTestCase extends DTOMarshallingTestCase
+{
+    public function testMarshalling(): void
+    {
+        if (PHP_VERSION_ID < 80104) {
+            $this->markTestSkipped();
+        }
+
+        $dto = new ReadonlyPropertiesDTO(
+            'promotedString',
+            'secondPromotedString',
+            'propertiesString',
+        );
+
+        $reflection = new \ReflectionClass(ReadonlyPropertiesDTO::class);
+
+        $converter = DataConverter::createDefault();
+
+        $payload = $converter->toPayload($dto);
+        $fromPayload = $converter->fromPayload($payload, ReadonlyPropertiesDTO::class);
+
+        self::assertEquals($dto, $fromPayload);
+
+        $marshaled = $this->marshal($dto);
+        $unmarshaled = $this->unmarshal(
+            $marshaled,
+            $reflection->newInstanceWithoutConstructor()
+        );
+
+        self::assertEquals($dto, $unmarshaled);
+    }
+}


### PR DESCRIPTION
Ok, I remember that readonly didn't work for me, but now they are working, so I created a test case for it. In order for it to work we need to add php 8.1 in CI matrix settings.

But php 8.1 will not work with current lower versions.

The questions is - do you want to add php 8.1 support? If no, I can just add the test and it will be waiting for the version upgrade.

There is another question: how should I go about testing this behavior: with **marshaller** or with **payload converter**? I created both, but I think that one of them is enough. Or both is good?

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added test that covers [readonly properties issue](https://github.com/temporalio/sdk-php/issues/211)

## Why?
Because issue is open and I though readonly properties would not work, but surprisingly they are working just fine

## Checklist
<!--- add/delete as needed --->

1. Closes [issue 221](https://github.com/temporalio/sdk-php/issues/211)

2. How was this tested:
With unit test