### PR TITLE
Configurable timeout for test server commands

### DIFF
--- a/testing/src/Environment.php
+++ b/testing/src/Environment.php
@@ -34,7 +34,7 @@ final class Environment
         );
     }
 
-    public function start(string $rrCommand = null): void
+    public function start(string $rrCommand = null, int $commandTimeout = 10): void
     {
         if (!$this->downloader->check($this->systemInfo->temporalServerExecutable)) {
             $this->output->write('Download temporal test server... ');
@@ -46,7 +46,7 @@ final class Environment
         $this->temporalServerProcess = new Process(
             [$this->systemInfo->temporalServerExecutable, 7233, '--enable-time-skipping']
         );
-        $this->temporalServerProcess->setTimeout(10);
+        $this->temporalServerProcess->setTimeout($commandTimeout);
         $this->temporalServerProcess->start();
         $this->output->writeln('<info>done.</info>');
         sleep(1);
@@ -54,7 +54,7 @@ final class Environment
         $this->roadRunnerProcess = new Process(
             $rrCommand ? explode(' ', $rrCommand) : [$this->systemInfo->rrExecutable, 'serve']
         );
-        $this->roadRunnerProcess->setTimeout(10);
+        $this->roadRunnerProcess->setTimeout($commandTimeout);
 
         $this->output->write('Starting RoadRunner... ');
         $this->roadRunnerProcess->start();


### PR DESCRIPTION
## What was changed
Possibility to set timeout for triggering roadrunner and temporal test server.

## Why?
In some cases roadrunner needs more time to wake up. We are initiating temporal test server during test bootstrap. Because of time out we do experience random failures in local and CI environments.
