### PR TITLE
Ability to return associative array from an activity

### DIFF
--- a/src/DataConverter/JsonConverter.php
+++ b/src/DataConverter/JsonConverter.php
@@ -83,7 +83,12 @@ class JsonConverter extends Converter
     public function fromPayload(Payload $payload, Type $type)
     {
         try {
-            $data = \json_decode($payload->getData(), false, 512, self::JSON_FLAGS);
+            $data = \json_decode(
+                $payload->getData(),
+                $type->getName() === Type::TYPE_ARRAY,
+                512,
+                self::JSON_FLAGS
+            );
         } catch (\Throwable $e) {
             throw new DataConverterException($e->getMessage(), $e->getCode(), $e);
         }

--- a/src/DataConverter/Type.php
+++ b/src/DataConverter/Type.php
@@ -107,7 +107,7 @@ final class Type
             }
 
             // Traversable types (i.e. Generator) not allowed
-            if (!$name instanceof \Traversable && $name !== 'array' && $name !== 'iterable') {
+            if (!$name instanceof \Traversable && $name !== 'iterable') {
                 return new self($type->getName(), $type->allowsNull());
             }
         }

--- a/tests/Unit/DataConverter/DataConverterTestCase.php
+++ b/tests/Unit/DataConverter/DataConverterTestCase.php
@@ -45,6 +45,8 @@ class DataConverterTestCase extends UnitTestCase
             Type::TYPE_INT    => [Type::TYPE_INT, 42],
             Type::TYPE_FLOAT  => [Type::TYPE_FLOAT, 0.1],
             Type::TYPE_VOID   => [Type::TYPE_VOID, null],
+
+            Type::TYPE_ARRAY . ' (associative)  => ' . Type::TYPE_ARRAY => [Type::TYPE_ARRAY, ['field' => 'value']],
         ];
     }
 
@@ -89,7 +91,6 @@ class DataConverterTestCase extends UnitTestCase
             Type::TYPE_BOOL . ' => ' . Type::TYPE_OBJECT   => [Type::TYPE_OBJECT, true],
             Type::TYPE_VOID . ' => ' . Type::TYPE_OBJECT   => [Type::TYPE_OBJECT, null],
 
-            Type::TYPE_OBJECT . ' => ' . Type::TYPE_ARRAY => [Type::TYPE_ARRAY, (object)['field' => 'value']],
             Type::TYPE_FLOAT . ' => ' . Type::TYPE_ARRAY  => [Type::TYPE_ARRAY, .42],
             Type::TYPE_INT . ' => ' . Type::TYPE_ARRAY    => [Type::TYPE_ARRAY, 42],
             Type::TYPE_STRING . ' => ' . Type::TYPE_ARRAY => [Type::TYPE_ARRAY, 'string'],


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Added ability to return associative array from activities with JsonEncoder.
## Why?
<!-- Tell your future self why have you made these changes -->
Although @SerafimArts explains in every related issue that json has no support for hashmaps or associative arrays (and this is indisputable true), but we in PHP do have support for it.

And in case of PHP workflow, PHP activity and PHP sdk we control input, output and the type, so I say we should be able to use associative arrays.

Yes, it is json, but we will use stock json_decode to get the required associative array.

Otherwise the SDK should forbid typehint activities with the `array` type. It is counterintuitive: if the `newActivityStub` returns `T` and I have an `array` declared as a return type for a function of `T` I would like to get it, or get an error when I'm trying to create proxy of `T`

## Checklist
<!--- add/delete as needed --->

1. Closes
#117
#93
#112

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
With unit test and in [my worker](https://github.com/shanginn/temporal-php-worker/tree/feature-test-assoc-arrays)
3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
I read in these issues that it is documented behavior. I guess this part should be updated is this PR is accepted
