### PR TITLE
Add error output for temporal test server

### DIFF
--- a/testing/src/Environment.php
+++ b/testing/src/Environment.php
@@ -53,6 +53,12 @@ final class Environment
         $this->output->writeln('<info>done.</info>');
         sleep(1);
 
+        if (!$this->temporalServerProcess->isRunning()) {
+            $this->output->writeln('<error>error</error>');
+            $this->output->writeln('Error starting Temporal server: ' . $this->temporalServerProcess->getErrorOutput());
+            exit(1);
+        }
+
         $this->roadRunnerProcess = new Process(
             $rrCommand ? explode(' ', $rrCommand) : [$this->systemInfo->rrExecutable, 'serve']
         );


### PR DESCRIPTION
## What was changed

## Why?
Got error on temporal test server starting but not handle it
![image](https://user-images.githubusercontent.com/16839017/185919782-304fad45-f6c3-45da-b170-b61d87fbfd9f.png)
