### PR TITLE
[Testing] Allow mocking activity result with complex objects

### DIFF
--- a/src/Worker/ActivityInvocationCache/ActivityInvocationResult.php
+++ b/src/Worker/ActivityInvocationCache/ActivityInvocationResult.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Worker\ActivityInvocationCache;
+
+use Temporal\Api\Common\V1\Payloads;
+use Temporal\DataConverter\DataConverterInterface;
+use Temporal\DataConverter\EncodedValues;
+use Temporal\DataConverter\Type;
+
+final class ActivityInvocationResult
+{
+    public function __construct(protected Payloads $payloads)
+    {
+    }
+
+    public static function fromValue(mixed $value, ?DataConverterInterface $dataConverter = null): ActivityInvocationResult {
+        $value = $value instanceof EncodedValues ? $value : EncodedValues::fromValues([$value], $dataConverter);
+
+        return new self($value->toPayloads());
+    }
+
+    public function toValue(Type|string $type = null, ?DataConverterInterface $dataConverter = null)
+    {
+        return $this->toEncodedValues($dataConverter)->getValue(0, $type);
+    }
+
+    public function toEncodedValues(?DataConverterInterface $dataConverter = null): EncodedValues
+    {
+        return EncodedValues::fromPayloads($this->payloads, $dataConverter);
+    }
+
+    public function __serialize(): array
+    {
+        return [
+            'payloads' => $this->payloads->serializeToJsonString(),
+        ];
+    }
+
+    public function __unserialize(array $data): void
+    {
+        $this->payloads = new Payloads();
+        $this->payloads->mergeFromJsonString($data['payloads']);
+    }
+}

--- a/src/Worker/Worker.php
+++ b/src/Worker/Worker.php
@@ -20,7 +20,6 @@ use Temporal\Internal\Repository\RepositoryInterface;
 use Temporal\Internal\ServiceContainer;
 use Temporal\Internal\Transport\Router;
 use Temporal\Internal\Transport\RouterInterface;
-use Temporal\Worker\ActivityInvocationCache\ActivityInvocationCacheInterface;
 use Temporal\Worker\Transport\Command\RequestInterface;
 use Temporal\Worker\Transport\RPCConnectionInterface;
 

--- a/testing/src/ActivityMocker.php
+++ b/testing/src/ActivityMocker.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Temporal\Testing;
 
+use Temporal\Worker\ActivityInvocationCache\ActivityInvocationCacheInterface;
 use Temporal\Worker\ActivityInvocationCache\RoadRunnerActivityInvocationCache;
 use Throwable;
 
 final class ActivityMocker
 {
-    private RoadRunnerActivityInvocationCache $cache;
+    private ActivityInvocationCacheInterface $cache;
 
-    public function __construct()
+    public function __construct(ActivityInvocationCacheInterface $cache = null)
     {
-        $this->cache = RoadRunnerActivityInvocationCache::create();
+        $this->cache = $cache ?? RoadRunnerActivityInvocationCache::create();
     }
 
     public function clear(): void


### PR DESCRIPTION
## What was changed
This changes improve activity mocking with support for complex return types (and not just native types)
The changed made to allow this are:
- Added an `ActivityInvocationResult` class which encode the response value with the `DataConverter` and wrap it in `EncodedValues` (like a real response) and then save the `EncodedValues` payload to the cache.
- In `ActivityInvocationCacheInterface@execute` method check for the new `ActivityInvocationResult` object and return the encoded values a response

The other changes are only required for passing the `DataConverter` to the cache and to allow an easy override of the cache during test worker construction

## Why?
Right now activity mocking works only with native types and not with more complex object.

## Checklist
How was this tested:
- All existing tests pass
- The added parameters are all optional so there shouldn't be any breaking change

