### PR TITLE
Separate start of Temporal Test Server and RoadRunner worker in tests

### DIFF
--- a/testing/Readme.md
+++ b/testing/Readme.md
@@ -14,15 +14,26 @@ $environment->start();
 register_shutdown_function(fn () => $environment->stop());
 ```
 
-If you don't want to run temporal test server with all of your tests you can set, for example,
-add condition to start it only if `RUN_TEMPORAL_TEST_SERVER` environment variable is present:
+`$environment->start();` is a shortcut to run Temporal test server and RoadRunner worker.
+You can start them separately if you need to customize the configuration:
 
 ```php
+$this->startTemporalTestServer(); // starts Temporal server
+$this->startRoadRunner(); // starts RoadRunner worker
+```
+
+So if, for example, you only need roadrunner worker and not the server you can
+set condition to start it only if `RUN_TEMPORAL_TEST_SERVER` environment variable is present:
+
+```php
+$environment = Environment::create();
+
 if (getenv('RUN_TEMPORAL_TEST_SERVER') !== false) {
-    $environment = Environment::create();
-    $environment->start('./rr serve -c .rr.silent.yaml -w tests');
-    register_shutdown_function(fn() => $environment->stop());
+    $this->startTemporalTestServer();
 }
+
+$environment->startRoadRunner('./rr serve -c .rr.silent.yaml -w tests');
+register_shutdown_function(fn() => $environment->stop());
 ```
 
 2. Add environment variable and `bootstrap.php` to your `phpunit.xml`:

--- a/testing/src/Environment.php
+++ b/testing/src/Environment.php
@@ -36,6 +36,12 @@ final class Environment
 
     public function start(string $rrCommand = null, int $commandTimeout = 10): void
     {
+        $this->startTemporalTestServer($commandTimeout);
+        $this->startRoadRunner($rrCommand, $commandTimeout);
+    }
+
+    public function startTemporalTestServer(int $commandTimeout = 10): void
+    {
         if (!$this->downloader->check($this->systemInfo->temporalServerExecutable)) {
             $this->output->write('Download temporal test server... ');
             $this->downloader->download($this->systemInfo);
@@ -58,7 +64,10 @@ final class Environment
             $this->output->writeln('Error starting Temporal server: ' . $this->temporalServerProcess->getErrorOutput());
             exit(1);
         }
+    }
 
+    public function startRoadRunner(string $rrCommand = null, int $commandTimeout = 10): void
+    {
         $this->roadRunnerProcess = new Process(
             $rrCommand ? explode(' ', $rrCommand) : [$this->systemInfo->rrExecutable, 'serve']
         );


### PR DESCRIPTION
## What was changed
As title of the PR suggest I did separate start of the temporal test server and roadrunner process

## Why?
To be able to fine tune the test process. For example, I don't want to run temporal in the tests (I have separate container for that), but I do want to start roadrunner worker, there is no straightforward way to do this now.

## Checklist
<!--- add/delete as needed --->

1. Closes -

2. How was this tested:
I ran external Temporal instance and only used `startRoadRunner` to start worker

3. Any docs updates needed?
updated docs for tests
