### PR TITLE
Send signal to workflow via parent interface

### DIFF
--- a/src/Client/WorkflowClient.php
+++ b/src/Client/WorkflowClient.php
@@ -14,7 +14,6 @@ namespace Temporal\Client;
 use Doctrine\Common\Annotations\Reader;
 use Spiral\Attributes\AnnotationReader;
 use Spiral\Attributes\AttributeReader;
-use Spiral\Attributes\Composite\Composite;
 use Spiral\Attributes\Composite\SelectiveReader;
 use Spiral\Attributes\ReaderInterface;
 use Temporal\Client\GRPC\ServiceClientInterface;
@@ -107,7 +106,7 @@ class WorkflowClient implements WorkflowClientInterface
     public function start($workflow, ...$args): WorkflowRunInterface
     {
         if ($workflow instanceof WorkflowProxy && !$workflow->hasHandler()) {
-            throw new InvalidArgumentException('Unable to start workflow without workflow method');
+            throw new InvalidArgumentException('Unable to start workflow without workflow handler');
         }
 
         $workflowStub = WorkflowStubConverter::fromWorkflow($workflow);
@@ -152,7 +151,7 @@ class WorkflowClient implements WorkflowClientInterface
         array $startArgs = []
     ): WorkflowRunInterface {
         if ($workflow instanceof WorkflowProxy && !$workflow->hasHandler()) {
-            throw new InvalidArgumentException('Unable to start workflow without workflow method');
+            throw new InvalidArgumentException('Unable to start workflow without workflow handler');
         }
 
         $workflowStub = WorkflowStubConverter::fromWorkflow($workflow);

--- a/src/Client/WorkflowClient.php
+++ b/src/Client/WorkflowClient.php
@@ -106,6 +106,10 @@ class WorkflowClient implements WorkflowClientInterface
      */
     public function start($workflow, ...$args): WorkflowRunInterface
     {
+        if ($workflow instanceof WorkflowProxy && !$workflow->hasHandler()) {
+            throw new InvalidArgumentException('Unable to start workflow without workflow method');
+        }
+
         $workflowStub = WorkflowStubConverter::fromWorkflow($workflow);
 
         $returnType = null;
@@ -147,6 +151,10 @@ class WorkflowClient implements WorkflowClientInterface
         array $signalArgs = [],
         array $startArgs = []
     ): WorkflowRunInterface {
+        if ($workflow instanceof WorkflowProxy && !$workflow->hasHandler()) {
+            throw new InvalidArgumentException('Unable to start workflow without workflow method');
+        }
+
         $workflowStub = WorkflowStubConverter::fromWorkflow($workflow);
 
         $returnType = null;

--- a/src/DataConverter/Type.php
+++ b/src/DataConverter/Type.php
@@ -116,7 +116,7 @@ final class Type
     }
 
     /**
-     * @param string|\ReflectionClass|\ReflectionType|Type $type
+     * @param string|\ReflectionClass|\ReflectionType|Type|ReturnType $type
      * @return Type
      */
     public static function create($type): Type

--- a/src/Exception/InstantiationException.php
+++ b/src/Exception/InstantiationException.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Exception;
+
+class InstantiationException extends TemporalException
+{
+}

--- a/src/Internal/Client/WorkflowProxy.php
+++ b/src/Internal/Client/WorkflowProxy.php
@@ -61,7 +61,7 @@ final class WorkflowProxy extends Proxy
      */
     public function __call(string $method, array $args)
     {
-        if ($method === $this->prototype->getHandler()->getName()) {
+        if ($method === $this->prototype->getHandler()?->getName()) {
             // no timeout (use async mode to get it)
             return $this->client->start($this, ...$args)->getResult($this->__getReturnType());
         }
@@ -114,5 +114,14 @@ final class WorkflowProxy extends Proxy
     public function __getReturnType()
     {
         return $this->prototype->getReturnType();
+    }
+
+    /**
+     * @return bool
+     * @internal
+     */
+    public function hasHandler(): bool
+    {
+        return $this->prototype->getHandler() !== null;
     }
 }

--- a/src/Internal/Declaration/Instance.php
+++ b/src/Internal/Declaration/Instance.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Temporal\Internal\Declaration;
 
 use Temporal\DataConverter\ValuesInterface;
+use Temporal\Exception\InstantiationException;
 use Temporal\Internal\Declaration\Dispatcher\AutowiredPayloads;
 use Temporal\Internal\Declaration\Prototype\Prototype;
 
@@ -33,7 +34,7 @@ abstract class Instance implements InstanceInterface
         $handler = $prototype->getHandler();
 
         if ($handler === null) {
-            throw new \InvalidArgumentException(\sprintf(
+            throw new InstantiationException(\sprintf(
                 'Unable to instantiate "%s" without handler method',
                 $prototype->getID(),
             ));

--- a/src/Internal/Declaration/Instance.php
+++ b/src/Internal/Declaration/Instance.php
@@ -30,9 +30,18 @@ abstract class Instance implements InstanceInterface
      */
     public function __construct(Prototype $prototype, ?object $context)
     {
+        $handler = $prototype->getHandler();
+
+        if ($handler === null) {
+            throw new \InvalidArgumentException(\sprintf(
+                'Unable to instantiate "%s" without handler method',
+                $prototype->getID(),
+            ));
+        }
+
         $this->prototype = $prototype;
         $this->context = $context;
-        $this->handler = $this->createHandler($prototype->getHandler());
+        $this->handler = $this->createHandler($handler);
     }
 
     /**

--- a/src/Internal/Declaration/Instantiator/WorkflowInstantiator.php
+++ b/src/Internal/Declaration/Instantiator/WorkflowInstantiator.php
@@ -37,7 +37,16 @@ final class WorkflowInstantiator extends Instantiator
      */
     protected function getInstance(PrototypeInterface $prototype): ?object
     {
-        $class = $prototype->getHandler()->getDeclaringClass();
+        $handler = $prototype->getHandler();
+
+        if ($handler === null) {
+            throw new \InvalidArgumentException(\sprintf(
+                'Unable to instantiate workflow "%s" without handler method',
+                $prototype->getID(),
+            ));
+        }
+
+        $class = $handler->getDeclaringClass();
 
         if ($class !== null) {
             return $class->newInstanceWithoutConstructor();

--- a/src/Internal/Declaration/Instantiator/WorkflowInstantiator.php
+++ b/src/Internal/Declaration/Instantiator/WorkflowInstantiator.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Temporal\Internal\Declaration\Instantiator;
 
+use Temporal\Exception\InstantiationException;
 use Temporal\Internal\Declaration\Prototype\PrototypeInterface;
 use Temporal\Internal\Declaration\Prototype\WorkflowPrototype;
 use Temporal\Internal\Declaration\WorkflowInstance;
@@ -40,7 +41,7 @@ final class WorkflowInstantiator extends Instantiator
         $handler = $prototype->getHandler();
 
         if ($handler === null) {
-            throw new \InvalidArgumentException(\sprintf(
+            throw new InstantiationException(\sprintf(
                 'Unable to instantiate workflow "%s" without handler method',
                 $prototype->getID(),
             ));

--- a/src/Internal/Declaration/Prototype/ActivityPrototype.php
+++ b/src/Internal/Declaration/Prototype/ActivityPrototype.php
@@ -41,6 +41,17 @@ final class ActivityPrototype extends Prototype
     }
 
     /**
+     * @return \ReflectionMethod
+     */
+    public function getHandler(): \ReflectionMethod
+    {
+        $handler = parent::getHandler();
+        assert($handler !== null);
+
+        return $handler;
+    }
+
+    /**
      * @return MethodRetry|null
      */
     public function getMethodRetry(): ?MethodRetry

--- a/src/Internal/Declaration/Prototype/Prototype.php
+++ b/src/Internal/Declaration/Prototype/Prototype.php
@@ -107,6 +107,6 @@ abstract class Prototype implements PrototypeInterface
     {
         $handler = $prototype->getHandler();
 
-        return $handler !== null && $handler->getName() === $method;
+        return $handler?->getName() === $method;
     }
 }

--- a/src/Internal/Declaration/Prototype/Prototype.php
+++ b/src/Internal/Declaration/Prototype/Prototype.php
@@ -21,9 +21,9 @@ abstract class Prototype implements PrototypeInterface
     protected string $name;
 
     /**
-     * @var \ReflectionMethod
+     * @var \ReflectionMethod|null
      */
-    protected \ReflectionMethod $handler;
+    protected ?\ReflectionMethod $handler;
 
     /**
      * @var \ReflectionClass
@@ -32,10 +32,10 @@ abstract class Prototype implements PrototypeInterface
 
     /**
      * @param string $name
-     * @param \ReflectionMethod $handler
+     * @param \ReflectionMethod|null $handler
      * @param \ReflectionClass $class
      */
-    public function __construct(string $name, \ReflectionMethod $handler, \ReflectionClass $class)
+    public function __construct(string $name, ?\ReflectionMethod $handler, \ReflectionClass $class)
     {
         $this->handler = $handler;
         $this->name = $name;
@@ -79,9 +79,9 @@ abstract class Prototype implements PrototypeInterface
     }
 
     /**
-     * @return \ReflectionMethod
+     * @return \ReflectionMethod|null
      */
-    public function getHandler(): \ReflectionMethod
+    public function getHandler(): ?\ReflectionMethod
     {
         return $this->handler;
     }
@@ -107,6 +107,6 @@ abstract class Prototype implements PrototypeInterface
     {
         $handler = $prototype->getHandler();
 
-        return $handler->getName() === $method;
+        return $handler !== null && $handler->getName() === $method;
     }
 }

--- a/src/Internal/Declaration/Prototype/PrototypeInterface.php
+++ b/src/Internal/Declaration/Prototype/PrototypeInterface.php
@@ -32,7 +32,7 @@ interface PrototypeInterface extends Identifiable
     /**
      * Returns the reflection of the handler function.
      *
-     * @return \ReflectionMethod
+     * @return \ReflectionMethod|null
      */
-    public function getHandler(): \ReflectionMethod;
+    public function getHandler(): ?\ReflectionMethod;
 }

--- a/src/Internal/Declaration/Reader/WorkflowReader.php
+++ b/src/Internal/Declaration/Reader/WorkflowReader.php
@@ -38,13 +38,6 @@ class WorkflowReader extends Reader
     /**
      * @var string
      */
-    private const ERROR_HANDLER_NOT_FOUND =
-        'Can not find workflow handler, because class %s has no method marked with #[%s] attribute'
-    ;
-
-    /**
-     * @var string
-     */
     private const ERROR_HANDLER_DUPLICATE =
         'Workflow class %s must contain only one handler marked by #[%s] attribute, but %d has been found'
     ;
@@ -81,8 +74,7 @@ class WorkflowReader extends Reader
 
         switch (\count($prototypes)) {
             case 0:
-                $message = \sprintf(self::ERROR_HANDLER_NOT_FOUND, $graph, WorkflowMethod::class);
-                throw new \LogicException($message);
+                return $this->withSignalsAndQueries($graph, $this->getDefaultPrototype($graph));
 
             case 1:
                 return $this->withSignalsAndQueries($graph, \reset($prototypes));
@@ -291,6 +283,11 @@ class WorkflowReader extends Reader
         }
 
         return $prototype;
+    }
+
+    private function getDefaultPrototype(ClassNode $graph): WorkflowPrototype
+    {
+        return new WorkflowPrototype($graph->getReflection()->getName(), null, $graph->getReflection());
     }
 
     /**

--- a/src/Internal/Workflow/ChildWorkflowProxy.php
+++ b/src/Internal/Workflow/ChildWorkflowProxy.php
@@ -96,7 +96,7 @@ final class ChildWorkflowProxy extends Proxy
         if (!$this->isRunning()) {
             $handler = $this->workflow->getHandler();
 
-            if ($handler === null || $handler->getName() !== $method) {
+            if ($method !== $handler?->getName()) {
                 throw new \BadMethodCallException(
                     \sprintf(self::ERROR_UNDEFINED_WORKFLOW_METHOD, $this->class, $method)
                 );

--- a/src/Internal/Workflow/ChildWorkflowProxy.php
+++ b/src/Internal/Workflow/ChildWorkflowProxy.php
@@ -96,7 +96,7 @@ final class ChildWorkflowProxy extends Proxy
         if (!$this->isRunning()) {
             $handler = $this->workflow->getHandler();
 
-            if ($handler->getName() !== $method) {
+            if ($handler === null || $handler->getName() !== $method) {
                 throw new \BadMethodCallException(
                     \sprintf(self::ERROR_UNDEFINED_WORKFLOW_METHOD, $this->class, $method)
                 );
@@ -148,7 +148,7 @@ final class ChildWorkflowProxy extends Proxy
 
         $handler = $prototype->getHandler();
 
-        return Type::create($handler->getReturnType());
+        return Type::create($handler?->getReturnType());
     }
 
     /**

--- a/src/Internal/Workflow/ContinueAsNewProxy.php
+++ b/src/Internal/Workflow/ContinueAsNewProxy.php
@@ -88,7 +88,7 @@ class ContinueAsNewProxy extends Proxy
 
         $handler = $this->workflow->getHandler();
 
-        if ($handler === null || $method !== $handler->getName()) {
+        if ($method !== $handler?->getName()) {
             throw new \BadMethodCallException(
                 \sprintf(self::ERROR_UNDEFINED_WORKFLOW_METHOD, $this->class, $method)
             );

--- a/src/Internal/Workflow/ContinueAsNewProxy.php
+++ b/src/Internal/Workflow/ContinueAsNewProxy.php
@@ -88,7 +88,7 @@ class ContinueAsNewProxy extends Proxy
 
         $handler = $this->workflow->getHandler();
 
-        if ($method !== $handler->getName()) {
+        if ($handler === null || $method !== $handler->getName()) {
             throw new \BadMethodCallException(
                 \sprintf(self::ERROR_UNDEFINED_WORKFLOW_METHOD, $this->class, $method)
             );

--- a/tests/Fixtures/src/Workflow/SignalWorkflowWithInheritanceImpl.php
+++ b/tests/Fixtures/src/Workflow/SignalWorkflowWithInheritanceImpl.php
@@ -17,16 +17,14 @@ class SignalWorkflowWithInheritanceImpl implements SignalledWorkflowWithInherita
 {
     private array $values = [];
 
-    public function addValue(
-        string $value
-    ) {
+    public function addValue(string $value)
+    {
         $this->values[] = $value;
     }
 
-    public function run(
-        int $count
-    ) {
-        yield Workflow::await(fn() => count($this->values) === $count);
+    public function run(int $count)
+    {
+        yield Workflow::await(fn() => \count($this->values) === $count);
 
         return $this->values;
     }

--- a/tests/Fixtures/src/Workflow/SignalWorkflowWithInheritanceImpl.php
+++ b/tests/Fixtures/src/Workflow/SignalWorkflowWithInheritanceImpl.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Workflow;
+
+use Temporal\Workflow;
+
+class SignalWorkflowWithInheritanceImpl implements SignalledWorkflowWithInheritance
+{
+    private array $values = [];
+
+    public function addValue(
+        string $value
+    ) {
+        $this->values[] = $value;
+    }
+
+    public function run(
+        int $count
+    ) {
+        yield Workflow::await(fn() => count($this->values) === $count);
+
+        return $this->values;
+    }
+}

--- a/tests/Fixtures/src/Workflow/SignalledWorkflowReusable.php
+++ b/tests/Fixtures/src/Workflow/SignalledWorkflowReusable.php
@@ -9,22 +9,16 @@
 
 declare(strict_types=1);
 
-namespace Temporal\Tests\Unit\Declaration\Fixture;
+namespace Temporal\Tests\Workflow;
 
 use Temporal\Workflow\SignalMethod;
 use Temporal\Workflow\WorkflowInterface;
 
-/** @WorkflowInterface */
 #[WorkflowInterface]
-class WorkflowWithoutHandler
+interface SignalledWorkflowReusable
 {
-    public function handler()
-    {
-        return 42;
-    }
-
     #[SignalMethod]
-    public function signal()
-    {
-    }
+    public function addValue(
+        string $value
+    );
 }

--- a/tests/Fixtures/src/Workflow/SignalledWorkflowReusable.php
+++ b/tests/Fixtures/src/Workflow/SignalledWorkflowReusable.php
@@ -18,7 +18,5 @@ use Temporal\Workflow\WorkflowInterface;
 interface SignalledWorkflowReusable
 {
     #[SignalMethod]
-    public function addValue(
-        string $value
-    );
+    public function addValue(string $value);
 }

--- a/tests/Fixtures/src/Workflow/SignalledWorkflowWithInheritance.php
+++ b/tests/Fixtures/src/Workflow/SignalledWorkflowWithInheritance.php
@@ -9,22 +9,16 @@
 
 declare(strict_types=1);
 
-namespace Temporal\Tests\Unit\Declaration\Fixture;
+namespace Temporal\Tests\Workflow;
 
-use Temporal\Workflow\SignalMethod;
 use Temporal\Workflow\WorkflowInterface;
+use Temporal\Workflow\WorkflowMethod;
 
-/** @WorkflowInterface */
 #[WorkflowInterface]
-class WorkflowWithoutHandler
+interface SignalledWorkflowWithInheritance extends SignalledWorkflowReusable
 {
-    public function handler()
-    {
-        return 42;
-    }
-
-    #[SignalMethod]
-    public function signal()
-    {
-    }
+    #[WorkflowMethod(name: 'SignalledWorkflowWithInheritance')]
+    public function run(
+        int $count
+    );
 }

--- a/tests/Fixtures/src/Workflow/SignalledWorkflowWithInheritance.php
+++ b/tests/Fixtures/src/Workflow/SignalledWorkflowWithInheritance.php
@@ -18,7 +18,5 @@ use Temporal\Workflow\WorkflowMethod;
 interface SignalledWorkflowWithInheritance extends SignalledWorkflowReusable
 {
     #[WorkflowMethod(name: 'SignalledWorkflowWithInheritance')]
-    public function run(
-        int $count
-    );
+    public function run(int $count);
 }

--- a/tests/Functional/Client/TypedStubTestCase.php
+++ b/tests/Functional/Client/TypedStubTestCase.php
@@ -56,7 +56,7 @@ class TypedStubTestCase extends ClientTestCase
         $workflow = $client->newWorkflowStub(WorkflowWithoutHandler::class);
 
         $this->expectExceptionMessage(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unable to start workflow without workflow method');
+        $this->expectExceptionMessage('Unable to start workflow without workflow handler');
 
         $client->start($workflow);
     }
@@ -67,7 +67,7 @@ class TypedStubTestCase extends ClientTestCase
         $workflow = $client->newWorkflowStub(WorkflowWithoutHandler::class);
 
         $this->expectExceptionMessage(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unable to start workflow without workflow method');
+        $this->expectExceptionMessage('Unable to start workflow without workflow handler');
 
         $client->startWithSignal($workflow, 'signal');
     }

--- a/tests/Unit/Declaration/WorkflowDeclarationTestCase.php
+++ b/tests/Unit/Declaration/WorkflowDeclarationTestCase.php
@@ -19,6 +19,7 @@ use Temporal\Tests\Unit\Declaration\Fixture\WorkflowWithCron;
 use Temporal\Tests\Unit\Declaration\Fixture\WorkflowWithCronAndRetry;
 use Temporal\Tests\Unit\Declaration\Fixture\WorkflowWithCustomName;
 use Temporal\Tests\Unit\Declaration\Fixture\WorkflowWithInterface;
+use Temporal\Tests\Unit\Declaration\Fixture\WorkflowWithoutHandler;
 use Temporal\Tests\Unit\Declaration\Fixture\WorkflowWithQueries;
 use Temporal\Tests\Unit\Declaration\Fixture\WorkflowWithRetry;
 use Temporal\Tests\Unit\Declaration\Fixture\WorkflowWithSignals;
@@ -29,6 +30,20 @@ use Temporal\Tests\Unit\Declaration\Fixture\WorkflowWithSignals;
  */
 class WorkflowDeclarationTestCase extends DeclarationTestCase
 {
+    /**
+     * @testdox Reading workflow without handler
+     * @dataProvider workflowReaderDataProvider
+     *
+     * @param WorkflowReader $reader
+     * @throws \ReflectionException
+     */
+    public function testWorkflowWithoutHandler(WorkflowReader $reader): void
+    {
+        $prototype = $reader->fromClass(WorkflowWithoutHandler::class);
+
+        $this->assertNull($prototype->getHandler());
+    }
+
     /**
      * @testdox Reading workflow without cron attribute (cron prototype value should be null)
      * @dataProvider workflowReaderDataProvider

--- a/tests/Unit/Declaration/WorkflowNegativeDeclarationTestCase.php
+++ b/tests/Unit/Declaration/WorkflowNegativeDeclarationTestCase.php
@@ -46,27 +46,6 @@ class WorkflowNegativeDeclarationTestCase extends DeclarationTestCase
     }
 
     /**
-     * @testdox Validate errors while loading workflow without WorkflowInterface attribute
-     * @dataProvider workflowReaderDataProvider
-     *
-     * @param WorkflowReader $reader
-     * @throws \ReflectionException
-     */
-    public function testWorkflowWithoutHandler(WorkflowReader $reader): void
-    {
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage(\vsprintf(
-            'Can not find workflow handler, because class %s has no method marked with #[%s] attribute',
-            [
-                WorkflowWithoutHandler::class,
-                WorkflowMethod::class,
-            ]
-        ));
-
-        $reader->fromClass(WorkflowWithoutHandler::class);
-    }
-
-    /**
      * @testdox Workflow handlers duplication
      * @dataProvider workflowReaderDataProvider
      *

--- a/tests/Unit/Declaration/WorkflowNegativeDeclarationTestCase.php
+++ b/tests/Unit/Declaration/WorkflowNegativeDeclarationTestCase.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Unit\Declaration;
 
+use Temporal\Exception\InstantiationException;
+use Temporal\Internal\Declaration\Instantiator\WorkflowInstantiator;
 use Temporal\Internal\Declaration\Reader\WorkflowReader;
 use Temporal\Tests\Unit\Declaration\Fixture\UnannotatedClass;
 use Temporal\Tests\Unit\Declaration\Fixture\WorkflowWithMultipleMethods;
@@ -57,5 +59,24 @@ class WorkflowNegativeDeclarationTestCase extends DeclarationTestCase
         $this->expectException(\LogicException::class);
 
         $reader->fromClass(WorkflowWithMultipleMethods::class);
+    }
+
+    /**
+     * @testdox Workflow without handler instantiation
+     * @dataProvider workflowReaderDataProvider
+     *
+     * @param WorkflowReader $reader
+     * @throws \ReflectionException
+     */
+    public function testWorkflowWithoutHandlerInstantiation(WorkflowReader $reader): void
+    {
+        $this->expectException(InstantiationException::class);
+        $this->expectExceptionMessage(
+            \sprintf('Unable to instantiate workflow "%s" without handler method', WorkflowWithoutHandler::class),
+        );
+
+        $protorype = $reader->fromClass(WorkflowWithoutHandler::class);
+
+        (new WorkflowInstantiator())->instantiate($protorype);
     }
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Add an ability to create workflow stub without a handler method, so that signals can be sent to a running workflow via parent reusable interface.

## Why?
<!-- Tell your future self why have you made these changes -->
[Workflow interface inheritance](https://docs.temporal.io/php/workflows/#workflow-interface-inheritance) is broken because workflow stub can not be created without a handler method annotated with `WorkflowMethod`.

Handler method is needed only to start a new workflow, but it's okay to send signals or queries to other workflows by stub created from a reusable parent interface.

## Checklist
<!--- add/delete as needed --->

1. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Integration tests
