### PR TITLE
Extend `spiral/roadrunner-kv` package version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "react/promise": "^2.8",
         "spiral/attributes": "^2.7 || ^3.0",
         "spiral/roadrunner-cli": "^2.2",
-        "spiral/roadrunner-kv": "^2.1",
+        "spiral/roadrunner-kv": "^2.1 || ^3.0",
         "spiral/roadrunner-worker": "^2.1.3",
         "symfony/filesystem": "^6.0",
         "symfony/http-client": "^6.0",


### PR DESCRIPTION
## What was changed

Extended the `spiral/roadrunner-kv` version.

## Why?

To use Temporal v2 with Spiral Framework v3

## Checklist
