### PR TITLE
Add Troubleshooting section to testing README with first instruction

### DIFF
--- a/testing/Readme.md
+++ b/testing/Readme.md
@@ -215,3 +215,20 @@ To mock a failure use `expectFailure()` method:
 ```php
 $this->activityMocks->expectFailure('SimpleActivity.echo', new \LogicException('something went wrong'));
 ```
+
+### Troubleshooting
+
+#### Error starting Temporal server: `sh: exec: line 0: ./temporal-test-server: not found`
+
+On `alpine`-based image *not found* might be caused by dynamic link failure.
+Because `temporal-test-server` is
+[built against `glibc`](https://github.com/temporalio/sdk-java/blob/master/temporal-test-server/build.gradle#L128)
+and `alpine` uses [musl](https://musl.libc.org/) libc library.
+
+To fix this you need to install one the glibc compatibility packages, for example `gcompat`.
+
+```bash
+apk add gcompat
+```
+
+> More info could be found in this [stackoverflow answer](https://stackoverflow.com/a/66974607/2457191)


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Instruction how to fix 'temporal-test-server: not found' error on Alpine-based images
in the new Troubleshooting part of the testing README

## Why?
The error is confusing and might take a lot of time to debug.
