### PR TITLE
Revert removing Symfony LTS versions from available versions.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,9 +34,9 @@
         "spiral/roadrunner-cli": "^2.2",
         "spiral/roadrunner-kv": "^2.1 || ^3.0",
         "spiral/roadrunner-worker": "^2.1.3",
-        "symfony/filesystem": "^5.0 || ^6.0",
-        "symfony/http-client": "^5.0 || ^6.0",
-        "symfony/process": "^5.0 || ^6.0"
+        "symfony/filesystem": "^4.4 || ^5.0 || ^6.0",
+        "symfony/http-client": "^4.4 || ^5.0 || ^6.0",
+        "symfony/process": "^4.4 || ^5.0 || ^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -28,15 +28,15 @@
         "google/protobuf": "^3.20.1",
         "grpc/grpc": "^1.34",
         "nesbot/carbon": "^2.52.0",
-        "psr/log": "^1.0 || ^2.0 || ^3.0",
+        "psr/log": "^1.0.1 || ^2.0 || ^3.0",
         "react/promise": "^2.8",
         "spiral/attributes": "^2.7 || ^3.0",
         "spiral/roadrunner-cli": "^2.2",
         "spiral/roadrunner-kv": "^2.1 || ^3.0",
         "spiral/roadrunner-worker": "^2.1.3",
-        "symfony/filesystem": "^4.4 || ^5.0 || ^6.0",
-        "symfony/http-client": "^4.4 || ^5.0 || ^6.0",
-        "symfony/process": "^4.4 || ^5.0 || ^6.0"
+        "symfony/filesystem": "^4.4.2 || ^5.0 || ^6.0",
+        "symfony/http-client": "^4.4.2 || ^5.0 || ^6.0",
+        "symfony/process": "^4.4.2 || ^5.0 || ^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -34,9 +34,9 @@
         "spiral/roadrunner-cli": "^2.2",
         "spiral/roadrunner-kv": "^2.1 || ^3.0",
         "spiral/roadrunner-worker": "^2.1.3",
-        "symfony/filesystem": "^4.4.2 || ^5.0 || ^6.0",
-        "symfony/http-client": "^4.4.2 || ^5.0 || ^6.0",
-        "symfony/process": "^4.4.2 || ^5.0 || ^6.0"
+        "symfony/filesystem": "^4.4.20 || ^5.0 || ^6.0",
+        "symfony/http-client": "^4.4.20 || ^5.0 || ^6.0",
+        "symfony/process": "^4.4.20 || ^5.0 || ^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -28,15 +28,15 @@
         "google/protobuf": "^3.20.1",
         "grpc/grpc": "^1.34",
         "nesbot/carbon": "^2.52.0",
-        "psr/log": "^2.0 || ^3.0",
+        "psr/log": "^1.0 || ^2.0 || ^3.0",
         "react/promise": "^2.8",
         "spiral/attributes": "^2.7 || ^3.0",
         "spiral/roadrunner-cli": "^2.2",
         "spiral/roadrunner-kv": "^2.1 || ^3.0",
         "spiral/roadrunner-worker": "^2.1.3",
-        "symfony/filesystem": "^6.0",
-        "symfony/http-client": "^6.0",
-        "symfony/process": "^6.0"
+        "symfony/filesystem": "^5.0 || ^6.0",
+        "symfony/http-client": "^5.0 || ^6.0",
+        "symfony/process": "^5.0 || ^6.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
I've readded the versions, making it difficult to use `temporal/sdk` in a big project with multiple services and packages.
* Add support for old `psr/log` (all 2.0 and 3.0 changes is it add strict types, I don't see why you would need to enforce it in composer.json).
* Readded support for current LTS symfony versions. 

## Why?
No big project wants to upgrade to some new version which isn't LTS. In fact upgrading, other than security fixes, if the code is working, is to be skipped.

Please view [this page](https://symfony.com/releases). There isn't even a ^6 LTS version out there.
## Checklist
1. Any docs updates needed?
Nope.
