### PR TITLE
feat: allow to return array of objects

### DIFF
--- a/src/DataConverter/JsonConverter.php
+++ b/src/DataConverter/JsonConverter.php
@@ -150,13 +150,15 @@ class JsonConverter extends Converter
             }
 
             if ($type->isArrayOf()) {
-                return array_map(
-                    fn($rawObject) => $this->unmarshal($rawObject, $reflection->newInstanceWithoutConstructor()),
-                    $data
-                );
+                $result = [];
+                foreach ($data as $key => $value) {
+                    $result[$key] = $this->unmarshal($value, $reflection);
+                }
+
+                return $result;
             }
 
-            return $this->unmarshal($data, $reflection->newInstanceWithoutConstructor());
+            return $this->unmarshal($data, $reflection);
         }
 
         throw $this->errorInvalidTypeName($type);
@@ -229,8 +231,19 @@ class JsonConverter extends Converter
         return new AttributeReader();
     }
 
-    private function unmarshal(array|object $data, object $instance): mixed
+    /**
+     * @template T of object
+     *
+     * @param object|array $data
+     * @param \ReflectionClass<T> $reflection
+     *
+     * @return T
+     */
+    private function unmarshal(object|array $data, \ReflectionClass $reflection): object
     {
-        return $this->marshaller->unmarshal($this->toHashMap($data), $instance);
+        return $this->marshaller->unmarshal(
+            $this->toHashMap($data),
+            $reflection->newInstanceWithoutConstructor(),
+        );
     }
 }

--- a/src/DataConverter/JsonConverter.php
+++ b/src/DataConverter/JsonConverter.php
@@ -63,8 +63,7 @@ class JsonConverter extends Converter
         if (\is_object($value)) {
             $value = $value instanceof \stdClass
                 ? $value
-                : $this->marshaller->marshal($value)
-            ;
+                : $this->marshaller->marshal($value);
         }
 
         try {
@@ -146,13 +145,18 @@ class JsonConverter extends Converter
                 if (PHP_VERSION_ID >= 80104 && $reflection->isEnum()) {
                     return $reflection->getConstant($data->name);
                 }
-
-                $instance = $reflection->newInstanceWithoutConstructor();
             } catch (\ReflectionException $e) {
                 throw new DataConverterException($e->getMessage(), $e->getCode(), $e);
             }
 
-            return $this->marshaller->unmarshal($this->toHashMap($data), $instance);
+            if ($type->isArrayOf()) {
+                return array_map(
+                    fn($rawObject) => $this->unmarshal($rawObject, $reflection->newInstanceWithoutConstructor()),
+                    $data
+                );
+            }
+
+            return $this->unmarshal($data, $reflection->newInstanceWithoutConstructor());
         }
 
         throw $this->errorInvalidTypeName($type);
@@ -223,5 +227,10 @@ class JsonConverter extends Converter
         }
 
         return new AttributeReader();
+    }
+
+    private function unmarshal(array|object $data, object $instance): mixed
+    {
+        return $this->marshaller->unmarshal($this->toHashMap($data), $instance);
     }
 }

--- a/src/DataConverter/Type.php
+++ b/src/DataConverter/Type.php
@@ -26,6 +26,7 @@ final class Type
     public const TYPE_INT       = 'int';
     public const TYPE_FLOAT     = 'float';
     public const TYPE_VOID      = 'void';
+    public const TYPE_ARRAY_OF  = 'array_of';
     public const TYPE_NULL      = 'null';
     public const TYPE_TRUE      = 'true';
     public const TYPE_FALSE     = 'false';
@@ -41,16 +42,28 @@ final class Type
     private bool $allowsNull;
 
     /**
+     * @var bool
+     */
+    private bool $isArrayOf;
+
+    /**
      * @param TypeEnum|string $name
      * @param bool|null $allowsNull
+     * @param bool $isArrayOf
      */
-    public function __construct(string $name = Type::TYPE_ANY, bool $allowsNull = null)
+    public function __construct(string $name = Type::TYPE_ANY, bool $allowsNull = null, bool $isArrayOf = false)
     {
         $this->name = $name;
 
         $this->allowsNull = $allowsNull ?? (
             $name === self::TYPE_ANY || $name === self::TYPE_VOID || $name === self::TYPE_NULL
         );
+        $this->isArrayOf = $isArrayOf;
+    }
+
+    public static function arrayOf(string $class): self
+    {
+        return new self($class, null, true);
     }
 
     /**
@@ -143,5 +156,10 @@ final class Type
             default:
                 return new self();
         }
+    }
+
+    public function isArrayOf(): bool
+    {
+        return $this->isArrayOf;
     }
 }

--- a/src/DataConverter/Type.php
+++ b/src/DataConverter/Type.php
@@ -26,39 +26,28 @@ final class Type
     public const TYPE_INT       = 'int';
     public const TYPE_FLOAT     = 'float';
     public const TYPE_VOID      = 'void';
-    public const TYPE_ARRAY_OF  = 'array_of';
     public const TYPE_NULL      = 'null';
     public const TYPE_TRUE      = 'true';
     public const TYPE_FALSE     = 'false';
 
     /**
-     * @var string
-     */
-    private string $name;
-
-    /**
      * @var bool
      */
-    private bool $allowsNull;
-
-    /**
-     * @var bool
-     */
-    private bool $isArrayOf;
+    private readonly bool $allowsNull;
 
     /**
      * @param TypeEnum|string $name
      * @param bool|null $allowsNull
      * @param bool $isArrayOf
      */
-    public function __construct(string $name = Type::TYPE_ANY, bool $allowsNull = null, bool $isArrayOf = false)
-    {
-        $this->name = $name;
-
+    public function __construct(
+        private readonly string $name = Type::TYPE_ANY,
+        bool $allowsNull = null,
+        private readonly bool $isArrayOf = false,
+    ) {
         $this->allowsNull = $allowsNull ?? (
             $name === self::TYPE_ANY || $name === self::TYPE_VOID || $name === self::TYPE_NULL
         );
-        $this->isArrayOf = $isArrayOf;
     }
 
     public static function arrayOf(string $class): self

--- a/src/Workflow/WorkflowRunInterface.php
+++ b/src/Workflow/WorkflowRunInterface.php
@@ -31,6 +31,14 @@ interface WorkflowRunInterface
      * Behind the scene this call performs long poll on Temporal service waiting
      * for workflow completion notification.
      *
+     * <code>
+     * // Map to array
+     * $result = $run->getResult(Type::TYPE_ARRAY);
+     *
+     * // Map to list of custom class
+     * $result = $run->getResult(Type::arrayOf(Message::class));
+     * </code>
+     *
      * @param string|\ReflectionClass|\ReflectionType|Type|null $type
      * @param int|null $timeout Timeout in seconds. Infinite by the default.
      * @return mixed

--- a/tests/Fixtures/src/Activity/SimpleActivity.php
+++ b/tests/Fixtures/src/Activity/SimpleActivity.php
@@ -115,6 +115,16 @@ class SimpleActivity
         return $enum;
     }
 
+    #[ActivityMethod('arrayOfObjects')]
+    public function arrayOfObjects(
+        $user
+    ): array {
+        return [
+            new Message(sprintf("Hello %s", strtolower($user))),
+            new Message(sprintf("Hello %s", strtoupper($user))),
+        ];
+    }
+
     #[ActivityMethod]
     public function simpleEnumDto(WithEnum $dto): WithEnum
     {

--- a/tests/Fixtures/src/Workflow/ArrayOfObjectsWorkflow.php
+++ b/tests/Fixtures/src/Workflow/ArrayOfObjectsWorkflow.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Workflow;
+
+use Temporal\Activity\ActivityOptions;
+use Temporal\Common\RetryOptions;
+use Temporal\DataConverter\Type;
+use Temporal\Tests\DTO\Message;
+use Temporal\Workflow;
+use Temporal\Workflow\WorkflowMethod;
+use Temporal\Tests\Activity\SimpleActivity;
+
+#[Workflow\WorkflowInterface]
+class ArrayOfObjectsWorkflow
+{
+    #[WorkflowMethod(name: 'ArrayOfObjectsWorkflow')]
+    public function handler(
+        string $input
+    ): iterable {
+        $activity = Workflow::newUntypedActivityStub(
+            ActivityOptions::new()
+                ->withStartToCloseTimeout(5)
+                ->withRetryOptions(
+                    RetryOptions::new()->withMaximumAttempts(2)
+                )
+        );
+
+        return yield $activity->execute('SimpleActivity.arrayOfObjects', [$input], Type::arrayOf(Message::class));
+    }
+}

--- a/tests/Functional/Client/TypeArrayOfObjectsTestCase.php
+++ b/tests/Functional/Client/TypeArrayOfObjectsTestCase.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Functional\Client;
+
+use Temporal\DataConverter\Type;
+use Temporal\Tests\DTO\Message;
+use Temporal\Tests\Workflow\ArrayOfObjectsWorkflow;
+
+/**
+ * @group client
+ * @group functional
+ */
+class TypeArrayOfObjectsTestCase extends ClientTestCase
+{
+    public function testArrayOfMessagesReceived(): void
+    {
+        $client = $this->createClient();
+        $workflow = $client->newWorkflowStub(ArrayOfObjectsWorkflow::class);
+
+        /** @var Message[] $result */
+        $result = $client->start($workflow, 'John')->getResult(Type::arrayOf(Message::class));
+        $this->assertCount(2, $result);
+        $this->assertInstanceOf(Message::class, $result[0]);
+
+        $this->assertSame('Hello john', $result[0]->message);
+        $this->assertSame('Hello JOHN', $result[1]->message);
+    }
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Allowed possibility to return a list of object from activity/workflow. 
When executing workflow:
```php
/** @var Message[] $result */
$result = $client->start($workflow, 'John')->getResult(Type::arrayOf(Message::class));
```

When executing activity within a workflow:
```php
/** @var Message[] $result */
$result = yield $activity->execute('myActivity', [$input], Type::arrayOf(Message::class));
```

## Why?
Now, we cant return a list of objects. It will always be an array of arrays.

### How was this tested:
With a functional test.

### Any docs updates needed?
Not sure that it is covered in the docs 🤔 