### PR TITLE
Fix aggregation for garbage cycles in Activity worker

### DIFF
--- a/src/Internal/Declaration/Instance.php
+++ b/src/Internal/Declaration/Instance.php
@@ -21,7 +21,6 @@ use Temporal\Internal\Declaration\Prototype\Prototype;
  */
 abstract class Instance implements InstanceInterface
 {
-    protected Prototype $prototype;
     protected ?object $context;
     /**
      * @var \Closure(ValuesInterface): mixed
@@ -43,7 +42,6 @@ abstract class Instance implements InstanceInterface
             ));
         }
 
-        $this->prototype = $prototype;
         $this->context = $context;
         $this->handler = $this->createHandler($handler);
     }
@@ -74,7 +72,8 @@ abstract class Instance implements InstanceInterface
     {
         $valueMapper = new AutowiredPayloads($func);
 
-        return fn (ValuesInterface $values): mixed => $valueMapper->dispatchValues($this->context, $values);
+        $context = $this->context;
+        return static fn (ValuesInterface $values): mixed => $valueMapper->dispatchValues($context, $values);
     }
 
     /**

--- a/src/Internal/Declaration/Reader/ActivityReader.php
+++ b/src/Internal/Declaration/Reader/ActivityReader.php
@@ -37,7 +37,7 @@ class ActivityReader extends Reader
         'been previously registered in %s:%d';
 
     /**
-     * @param string $class
+     * @param class-string $class
      * @return array<ActivityPrototype>
      * @throws \ReflectionException
      */


### PR DESCRIPTION
## What was changed

Fix some cases when garbage cycles are got memorized.

## Why?

The cycles colud be collected with the `gc_collect_cycles` automatically but i think it will be better when we have no these ones.
It might affect some memory metrics for the better.

## Checklist

- [x] tests
- [x] fix

1. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

I use Weak references to check the objects was destroyed after related variables unseting.
