### PR TITLE
Feature: pass error into activity finalizer

### DIFF
--- a/src/Internal/Transport/Router/InvokeActivity.php
+++ b/src/Internal/Transport/Router/InvokeActivity.php
@@ -83,7 +83,7 @@ class InvokeActivity extends Route
         } finally {
             $finalizer = $this->services->activities->getFinalizer();
             if ($finalizer !== null) {
-                call_user_func($finalizer);
+                call_user_func($finalizer, $e ?? null);
             }
             Activity::setCurrentContext(null);
         }

--- a/tests/Unit/Router/InvokeActivityTestCase.php
+++ b/tests/Unit/Router/InvokeActivityTestCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Temporal\Tests\Unit\Router;
 
 use React\Promise\Deferred;
+use RuntimeException;
 use Spiral\Attributes\AnnotationReader;
 use Spiral\Attributes\AttributeReader;
 use Spiral\Attributes\Composite\SelectiveReader;
@@ -81,8 +82,10 @@ final class InvokeActivityTestCase extends UnitTestCase
     {
         $finalizerWasCalled = false;
         $this->services->activities->addFinalizer(
-            function () use (&$finalizerWasCalled) {
+            function (\Throwable $error) use (&$finalizerWasCalled) {
                 $finalizerWasCalled = true;
+                $this->assertInstanceOf(RuntimeException::class, $error);
+                $this->assertSame('Failed', $error->getMessage());
             }
         );
 


### PR DESCRIPTION
## What was changed
If an error happens when executing an activity it will be convenient to know it within a finalizer.

## Why?
For example, we collect logs and metrics and want to flush or send them only if the activity failed. Currently, within a finalizer there is no way to detect whether it was a success execution or failure.

## Checklist
1. How was this tested:
With unit tests.

3. Any docs updates needed?
Need to make a small update here with `registerActivityFinalizer()` example and provide a snippet with a closure that accepts an exception:

```md
$worker->registerActivityFinalizer(
    function (Throwable $error = null) {
        if ($error !== null) {
            $this->logger->flush();
        }
        
        $this->kernel->showtdown();
    }
);
```

 https://docs.temporal.io/application-development/foundations?lang=php#register-types