### PR TITLE
Fix memory leak when a workflow with an active internal timer is destroyed

### DIFF
--- a/src/Internal/Transport/Client.php
+++ b/src/Internal/Transport/Client.php
@@ -37,17 +37,14 @@ final class Client implements ClientInterface
         'a request with that identifier was not sent';
 
     private QueueInterface $queue;
-    private LoopInterface $loop;
     private array $requests = [];
 
     /**
      * @param QueueInterface $queue
-     * @param LoopInterface $loop
      */
-    public function __construct(QueueInterface $queue, LoopInterface $loop)
+    public function __construct(QueueInterface $queue)
     {
         $this->queue = $queue;
-        $this->loop = $loop;
     }
 
     /**

--- a/src/Internal/Transport/Router/DestroyWorkflow.php
+++ b/src/Internal/Transport/Router/DestroyWorkflow.php
@@ -34,6 +34,8 @@ class DestroyWorkflow extends WorkflowProcessAwareRoute
         $this->kill($runId);
 
         $resolver->resolve(EncodedValues::fromValues([null]));
+
+        \gc_collect_cycles();
     }
 
     /**

--- a/src/Internal/Workflow/Process/Scope.php
+++ b/src/Internal/Workflow/Process/Scope.php
@@ -273,7 +273,7 @@ class Scope implements CancellationScopeInterface, PromisorInterface
      */
     public function onAwait(Deferred $deferred): void
     {
-        $this->onCancel[++$this->cancelID] = function (\Throwable $e = null) use ($deferred): void {
+        $this->onCancel[++$this->cancelID] = static function (\Throwable $e = null) use ($deferred): void {
             $deferred->reject($e ?? new CanceledFailure(''));
         };
 

--- a/src/Internal/Workflow/ScopeContext.php
+++ b/src/Internal/Workflow/ScopeContext.php
@@ -14,9 +14,7 @@ namespace Temporal\Internal\Workflow;
 use React\Promise\Deferred;
 use React\Promise\PromiseInterface;
 use Temporal\Exception\Failure\CanceledFailure;
-use Temporal\Internal\Support\DateInterval;
 use Temporal\Internal\Transport\CompletableResult;
-use Temporal\Internal\Transport\Request\NewTimer;
 use Temporal\Internal\Workflow\Process\Scope;
 use Temporal\Worker\Transport\Command\RequestInterface;
 use Temporal\Workflow\CancellationScopeInterface;
@@ -120,21 +118,6 @@ class ScopeContext extends WorkflowContext implements ScopedContextInterface
         );
     }
 
-    protected function addAsyncCondition(string $conditionGroupId, PromiseInterface $condition): PromiseInterface
-    {
-        $this->parent->asyncAwaits[$conditionGroupId][] = $condition;
-
-        return $condition->then(
-            function ($result) use ($conditionGroupId) {
-                $this->resolveConditionGroup($conditionGroupId);
-                return $result;
-            },
-            function () use ($conditionGroupId) {
-                $this->rejectConditionGroup($conditionGroupId);
-            }
-        );
-    }
-
     /**
      * Calculate unblocked conditions.
      */
@@ -151,18 +134,6 @@ class ScopeContext extends WorkflowContext implements ScopedContextInterface
     public function rejectConditionGroup(string $conditionGroupId): void
     {
         $this->parent->rejectConditionGroup($conditionGroupId);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function timer($interval): PromiseInterface
-    {
-        $request = new NewTimer(DateInterval::parse($interval, DateInterval::FORMAT_SECONDS));
-        $result = $this->request($request);
-        $this->parent->timers->attach($result, $request);
-
-        return $result;
     }
 
     /**

--- a/src/Internal/Workflow/ScopeContext.php
+++ b/src/Internal/Workflow/ScopeContext.php
@@ -26,6 +26,7 @@ class ScopeContext extends WorkflowContext implements ScopedContextInterface
 {
     private WorkflowContext $parent;
     private Scope $scope;
+    /** @var callable */
     private $onRequest;
 
     /**

--- a/src/Internal/Workflow/WorkflowContext.php
+++ b/src/Internal/Workflow/WorkflowContext.php
@@ -449,10 +449,10 @@ class WorkflowContext implements WorkflowContextInterface
                 $result[] = $this->addCondition($conditionGroupId, $condition);
             }
 
-            if ($condition instanceof PromiseInterface)
-            {
-                $result[] = $this->addAsyncCondition($conditionGroupId, $condition);
-            }
+            // if ($condition instanceof PromiseInterface)
+            // {
+            //     $result[] = $this->addAsyncCondition($conditionGroupId, $condition);
+            // }
         }
 
         if (\count($result) === 1) {
@@ -472,6 +472,7 @@ class WorkflowContext implements WorkflowContextInterface
         $conditions[] = $timer;
 
         return $this->await(...$conditions)
+            // is internal timer is not complete then cancel it
             ->then(static fn (): bool => !$timer->isComplete());
     }
 
@@ -505,19 +506,19 @@ class WorkflowContext implements WorkflowContextInterface
         return $deferred->promise();
     }
 
-    protected function addAsyncCondition(string $conditionGroupId, PromiseInterface $condition): PromiseInterface
-    {
-        $this->asyncAwaits[$conditionGroupId][] = $condition;
-        return $condition->then(
-            function ($result) use ($conditionGroupId) {
-                $this->resolveConditionGroup($conditionGroupId);
-                return $result;
-            },
-            function () use ($conditionGroupId) {
-                $this->rejectConditionGroup($conditionGroupId);
-            }
-        );
-    }
+    // protected function addAsyncCondition(string $conditionGroupId, PromiseInterface $condition): PromiseInterface
+    // {
+    //     $this->asyncAwaits[$conditionGroupId][] = $condition;
+    //     return $condition->then(
+    //         function ($result) use ($conditionGroupId) {
+    //             $this->resolveConditionGroup($conditionGroupId);
+    //             return $result;
+    //         },
+    //         function () use ($conditionGroupId) {
+    //             $this->rejectConditionGroup($conditionGroupId);
+    //         }
+    //     );
+    // }
 
     /**
      * Record last stack trace of the call.
@@ -560,24 +561,24 @@ class WorkflowContext implements WorkflowContextInterface
 
     private function clearAsyncAwaits(string $conditionGroupId): void
     {
-        // Check pending timers in this group
-        if (!isset($this->asyncAwaits[$conditionGroupId])) {
-            return;
-        }
-
-        // Then cancel any pending timers if exist
-        foreach ($this->asyncAwaits[$conditionGroupId] as $index => $awaitCondition) {
-            if (!$awaitCondition->isComplete()) {
-                /** @var NewTimer $timer */
-                $timer = $this->timers->offsetGet($awaitCondition);
-                if ($timer !== null) {
-                    $request = new Cancel($timer->getID());
-                    $this->request($request);
-                    $this->timers->offsetUnset($awaitCondition);
-                }
-            }
-            unset($this->asyncAwaits[$conditionGroupId][$index]);
-        }
-        unset($this->asyncAwaits[$conditionGroupId]);
+        // // Check pending timers in this group
+        // if (!isset($this->asyncAwaits[$conditionGroupId])) {
+        //     return;
+        // }
+        //
+        // // Then cancel any pending timers if exist
+        // foreach ($this->asyncAwaits[$conditionGroupId] as $index => $awaitCondition) {
+        //     if (!$awaitCondition->isComplete()) {
+        //         /** @var NewTimer $timer */
+        //         $timer = $this->timers->offsetGet($awaitCondition);
+        //         if ($timer !== null) {
+        //             $request = new Cancel($timer->getID());
+        //             $this->request($request);
+        //             $this->timers->offsetUnset($awaitCondition);
+        //         }
+        //     }
+        //     unset($this->asyncAwaits[$conditionGroupId][$index]);
+        // }
+        // unset($this->asyncAwaits[$conditionGroupId]);
     }
 }

--- a/src/Internal/Workflow/WorkflowContext.php
+++ b/src/Internal/Workflow/WorkflowContext.php
@@ -449,9 +449,9 @@ class WorkflowContext implements WorkflowContextInterface
             }
         }
 
-        // if (\count($result) === 1) {
-        //     return $result[0];
-        // }
+        if (\count($result) === 1) {
+            return $result[0];
+        }
 
         return Promise::any($result)->then(
             function ($result) use ($conditionGroupId) {

--- a/src/Internal/Workflow/WorkflowContext.php
+++ b/src/Internal/Workflow/WorkflowContext.php
@@ -500,6 +500,15 @@ class WorkflowContext implements WorkflowContextInterface
                 }
             }
         }
+        // foreach ($this->awaits as $awaitsGroupId => $awaitsGroup) {
+        //     foreach ($awaitsGroup as $i => [$condition, $_]) {
+        //         if ($condition()) {
+        //             unset($this->awaits[$awaitsGroupId][$i]);
+        //             $this->resolveConditionGroup($awaitsGroupId);
+        //             break;
+        //         }
+        //     }
+        // }
     }
 
     /**
@@ -527,11 +536,26 @@ class WorkflowContext implements WorkflowContextInterface
 
     public function resolveConditionGroup(string $conditionGroupId): void
     {
-        unset($this->awaits[$conditionGroupId]);
+        // First resolve pending promises
+        if (isset($this->awaits[$conditionGroupId])) {
+            foreach ($this->awaits[$conditionGroupId] as $i => $cond) {
+                [$_, $deferred] = $cond;
+                unset($this->awaits[$conditionGroupId][$i]);
+                $deferred->resolve();
+            }
+            unset($this->awaits[$conditionGroupId]);
+        }
     }
 
     public function rejectConditionGroup(string $conditionGroupId): void
     {
-        unset($this->awaits[$conditionGroupId]);
+        if (isset($this->awaits[$conditionGroupId])) {
+            foreach ($this->awaits[$conditionGroupId] as $i => $cond) {
+                [$_, $deferred] = $cond;
+                unset($this->awaits[$conditionGroupId][$i]);
+                $deferred->reject();
+            }
+            unset($this->awaits[$conditionGroupId]);
+        }
     }
 }

--- a/tests/Fixtures/Splitter.php
+++ b/tests/Fixtures/Splitter.php
@@ -16,8 +16,8 @@ namespace Temporal\Tests\Fixtures;
  */
 class Splitter
 {
-    /** @var string */
-    private string $filename;
+    /** @var string[] */
+    private array $lines;
 
     /** @var array */
     private array $in = [];
@@ -28,9 +28,9 @@ class Splitter
     /**
      * @param string $filename
      */
-    public function __construct(string $filename)
+    public function __construct(array $lines)
     {
-        $this->filename = $filename;
+        $this->lines = $lines;
         $this->parse();
     }
 
@@ -49,12 +49,10 @@ class Splitter
      */
     private function parse()
     {
-        $lines = file($this->filename);
-
         // skip get worker info
         $offset = 0;
-        while (isset($lines[$offset])) {
-            $line = $lines[$offset];
+        while (isset($this->lines[$offset])) {
+            $line = $this->lines[$offset];
 
             if (preg_match('/(?:\[0m\t)(\[.*\])\s*({.*})(?:[\r\n]*)$/', $line, $matches)) {
                 $ctx = json_decode($matches[2], true);
@@ -72,10 +70,22 @@ class Splitter
     }
 
     /**
+     * Create from file
+     *
      * @return Splitter
      */
-    public static function create(string $name)
+    public static function create(string $name): self
     {
-        return new self(__DIR__ . '/data/' . $name);
+        return new self(file(__DIR__ . '/data/' . $name));
+    }
+
+    /**
+     * Create from text block
+     *
+     * @return Splitter
+     */
+    public static function createFromString(string $text): self
+    {
+        return new self(\explode("\n", $text));
     }
 }

--- a/tests/Fixtures/src/Workflow/AwaitWithSingleTimeoutWorkflow.php
+++ b/tests/Fixtures/src/Workflow/AwaitWithSingleTimeoutWorkflow.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Workflow;
+
+use Temporal\Workflow;
+use Temporal\Workflow\WorkflowMethod;
+
+#[Workflow\WorkflowInterface]
+class AwaitWithSingleTimeoutWorkflow
+{
+    #[WorkflowMethod()]
+    public function handler()
+    {
+        yield Workflow::await(Workflow::timer(5000));
+
+        return 'ok';
+    }
+}

--- a/tests/Fixtures/src/Workflow/AwaitWithTimeoutWorkflow.php
+++ b/tests/Fixtures/src/Workflow/AwaitWithTimeoutWorkflow.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Workflow;
+
+use Temporal\Workflow;
+use Temporal\Workflow\WorkflowMethod;
+
+#[Workflow\WorkflowInterface]
+class AwaitWithTimeoutWorkflow
+{
+    #[WorkflowMethod()]
+    public function handler()
+    {
+        yield Workflow::awaitWithTimeout(
+            999,
+            fn() => false,
+        );
+
+        yield Workflow::awaitWithTimeout(
+            20,
+            Workflow::awaitWithTimeout(500, fn() => false),
+            Workflow::awaitWithTimeout(120, fn() => false),
+        );
+
+        return 'ok';
+    }
+}

--- a/tests/Fixtures/src/Workflow/TimerWayWorkflow.php
+++ b/tests/Fixtures/src/Workflow/TimerWayWorkflow.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Workflow;
+
+use Temporal\Workflow;
+use Temporal\Workflow\WorkflowMethod;
+
+#[Workflow\WorkflowInterface]
+class TimerWayWorkflow
+{
+    #[WorkflowMethod(name: 'TimerWayWorkflow')]
+    public function handler(): iterable
+    {
+        $timerResolved = false;
+
+        $timer = Workflow::timer(20)
+            ->then(function () use (&$timerResolved) {
+                $timerResolved = true;
+            });
+
+        yield Workflow::await($timer, fn() => true);
+
+        return $timerResolved;
+    }
+}

--- a/tests/Fixtures/src/Workflow/TimerWorkflow.php
+++ b/tests/Fixtures/src/Workflow/TimerWorkflow.php
@@ -16,6 +16,9 @@ use Temporal\Workflow;
 use Temporal\Workflow\WorkflowMethod;
 use Temporal\Tests\Activity\SimpleActivity;
 
+/**
+ * @see \Temporal\Tests\Functional\WorkflowTestCase::testTimer()
+ */
 #[Workflow\WorkflowInterface]
 class TimerWorkflow
 {

--- a/tests/Functional/Client/AwaitTestCase.php
+++ b/tests/Functional/Client/AwaitTestCase.php
@@ -20,6 +20,7 @@ use Temporal\Testing\WithoutTimeSkipping;
 use Temporal\Tests\Workflow\AggregatedWorkflow;
 use Temporal\Tests\Workflow\LoopWithSignalCoroutinesWorkflow;
 use Temporal\Tests\Workflow\LoopWorkflow;
+use Temporal\Tests\Workflow\TimerWayWorkflow;
 use Temporal\Tests\Workflow\WaitWorkflow;
 use Temporal\Workflow\WorkflowStub;
 
@@ -188,5 +189,14 @@ class AwaitTestCase extends ClientTestCase
         } catch (WorkflowFailedException $e) {
             $this->assertInstanceOf(CanceledFailure::class, $e->getPrevious());
         }
+    }
+
+    public function testTimer(): void
+    {
+        $client = $this->createClient();
+        $wait = $client->newWorkflowStub(TimerWayWorkflow::class);
+        $run = $client->start($wait);
+
+        $this->assertFalse($run->getResult());
     }
 }

--- a/tests/Functional/WorkflowTestCase.php
+++ b/tests/Functional/WorkflowTestCase.php
@@ -228,8 +228,9 @@ class WorkflowTestCase extends FunctionalTestCase
 
     /**
      * Destroy workflow with a started awaitWithTimeout promise inside.
+     * @see \Temporal\Tests\Workflow\AwaitWithTimeoutWorkflow
      */
-    public function testAwaitWithTimeout()
+    public function testAwaitWithTimeout(): void
     {
         $worker = WorkerMock::createMock();
 
@@ -250,8 +251,9 @@ class WorkflowTestCase extends FunctionalTestCase
      * Destroy 100 workflows with a started awaitWithTimeout promise inside.
      * The promise will be annihilated on the workflow destroy.
      * There mustn't be any leaks.
+     * @see \Temporal\Tests\Workflow\AwaitWithTimeoutWorkflow
      */
-    public function testAwaitWithTimeout_Leaks()
+    public function testAwaitWithTimeout_Leaks(): void
     {
         $worker = WorkerMock::createMock();
 
@@ -261,7 +263,9 @@ class WorkflowTestCase extends FunctionalTestCase
             $uuid2 = Uuid::v4();
             $log = <<<LOG
                 [0m	[{"id":1,"command":"StartWorkflow","options":{"info":{"WorkflowExecution":{"ID":"$uuid1","RunID":"$uuid2"},"WorkflowType":{"Name":"AwaitWithTimeoutWorkflow"},"TaskQueueName":"default","WorkflowExecutionTimeout":315360000000000000,"WorkflowRunTimeout":315360000000000000,"WorkflowTaskTimeout":0,"Namespace":"default","Attempt":1,"CronSchedule":"","ContinuedExecutionRunID":"","ParentWorkflowNamespace":"","ParentWorkflowExecution":null,"Memo":null,"SearchAttributes":null,"BinaryChecksum":"4301710877bf4b107429ee12de0922be"}},"payloads":"CicKFgoIZW5jb2RpbmcSCmpzb24vcGxhaW4SDSJIZWxsbyBXb3JsZCI="}] {"taskQueue":"default","tickTime":"2021-01-12T15:21:52.2672785Z"}
+                # Run a timers
                 [0m	[{"id":$id,"command":"NewTimer","options":{"ms":999000},"payloads":""},{"id":1,"payloads":"ChkKFwoIZW5jb2RpbmcSC2JpbmFyeS9udWxs"}]	{"receive": true}
+                # Destroy workflow
                 [0m	[{"id":2,"command":"DestroyWorkflow","options":{"runId":"$uuid2"}}] {"taskQueue":"default","tickTime":"2021-01-12T15:21:53.3838443Z","replay":true}
                 [0m	[{"id":2,"payloads":"ChkKFwoIZW5jb2RpbmcSC2JpbmFyeS9udWxs"}]	{"receive": true}
                 LOG;
@@ -278,16 +282,17 @@ class WorkflowTestCase extends FunctionalTestCase
      * Destroy 100 workflows with started few awaitWithTimeout promises inside.
      * The promises will be annihilated on the workflow destroy.
      * There mustn't be any leaks.
+     * @see \Temporal\Tests\Workflow\AwaitWithTimeoutWorkflow
      */
-    public function testAwaitWithFewParallelTimeouts_Leaks()
+    public function testAwaitWithFewParallelTimeouts_Leaks(): void
     {
         $worker = WorkerMock::createMock();
 
         // Run the workflow $i times
-        for ($id = 9001, $i = 0; $i < 100; ++$i, ++$id) {
+        for ($id = 9000, $i = 0; $i < 100; ++$i) {
             $uuid1 = Uuid::v4();
             $uuid2 = Uuid::v4();
-            $id1 = $id;
+            $id1 = ++$id;
             $id2 = ++$id;
             $id3 = ++$id;
             $id4 = ++$id;
@@ -297,7 +302,38 @@ class WorkflowTestCase extends FunctionalTestCase
                 [0m	[{"id":$id1}] {"taskQueue":"default","tickTime":"2021-01-12T15:21:53.3204026Z"}
                 # Run three async timers
                 [0m	[{"id":{$id2},"command":"NewTimer","options":{"ms":500000},"payloads":""},{"id":$id3,"command":"NewTimer","options":{"ms":120000},"payloads":""},{"id":$id4,"command":"NewTimer","options":{"ms":20000},"payloads":""}]	{"receive": true}
-                # Destroy worker
+                # Destroy workflow
+                [0m	[{"id":2,"command":"DestroyWorkflow","options":{"runId":"$uuid2"}}] {"taskQueue":"default","tickTime":"2021-01-12T15:21:53.3838443Z","replay":true}
+                [0m	[{"id":2,"payloads":"ChkKFwoIZW5jb2RpbmcSC2JpbmFyeS9udWxs"}]	{"receive": true}
+                LOG;
+
+            $worker->run($this, Splitter::createFromString($log)->getQueue());
+            $before ??= \memory_get_usage();
+        }
+        $after = \memory_get_usage();
+
+        $this->assertSame(0, $after - $before);
+    }
+
+    /**
+     * Destroy 100 workflows with single promise inside Workflow::await.
+     * That case mustn't leak.
+     * @see \Temporal\Tests\Workflow\AwaitWithSingleTimeoutWorkflow
+     */
+    public function testAwaitWithOneTimer_Leaks()
+    {
+        $worker = WorkerMock::createMock();
+
+        // Run the workflow $i times
+        for ($id = 9000, $i = 0; $i < 100; ++$i) {
+            $uuid1 = Uuid::v4();
+            $uuid2 = Uuid::v4();
+            $id1 = ++$id;
+            $log = <<<LOG
+                [0m	[{"id":1,"command":"StartWorkflow","options":{"info":{"WorkflowExecution":{"ID":"$uuid1","RunID":"$uuid2"},"WorkflowType":{"Name":"AwaitWithSingleTimeoutWorkflow"},"TaskQueueName":"default","WorkflowExecutionTimeout":315360000000000000,"WorkflowRunTimeout":315360000000000000,"WorkflowTaskTimeout":0,"Namespace":"default","Attempt":1,"CronSchedule":"","ContinuedExecutionRunID":"","ParentWorkflowNamespace":"","ParentWorkflowExecution":null,"Memo":null,"SearchAttributes":null,"BinaryChecksum":"4301710877bf4b107429ee12de0922be"}},"payloads":"CicKFgoIZW5jb2RpbmcSCmpzb24vcGxhaW4SDSJIZWxsbyBXb3JsZCI="}] {"taskQueue":"default","tickTime":"2021-01-12T15:21:52.2672785Z"}
+                # Run a timer
+                [0m	[{"id":$id1,"command":"NewTimer","options":{"ms":5000000},"payloads":""},{"id":1,"payloads":"ChkKFwoIZW5jb2RpbmcSC2JpbmFyeS9udWxs"}]	{"receive": true}
+                # Destroy workflow
                 [0m	[{"id":2,"command":"DestroyWorkflow","options":{"runId":"$uuid2"}}] {"taskQueue":"default","tickTime":"2021-01-12T15:21:53.3838443Z","replay":true}
                 [0m	[{"id":2,"payloads":"ChkKFwoIZW5jb2RpbmcSC2JpbmFyeS9udWxs"}]	{"receive": true}
                 LOG;

--- a/tests/Unit/WorkflowContext/AwaitWithTimeoutTestCase.php
+++ b/tests/Unit/WorkflowContext/AwaitWithTimeoutTestCase.php
@@ -33,16 +33,8 @@ final class AwaitWithTimeoutTestCase extends UnitTestCase
     {
         $this->worker->registerWorkflowObject(
             new
-            /**
-             * Support for PHP7.4
-             * @Workflow\WorkflowInterface
-             */
             #[Workflow\WorkflowInterface]
             class {
-                /**
-                 * Support for PHP7.4
-                 * @Workflow\WorkflowMethod(name="AwaitWorkflow")
-                 */
                 #[WorkflowMethod(name: 'AwaitWorkflow')]
                 public function handler(): iterable
                 {
@@ -65,16 +57,8 @@ final class AwaitWithTimeoutTestCase extends UnitTestCase
 
         $this->worker->registerWorkflowObject(
             new
-            /**
-             * Support for PHP7.4
-             * @Workflow\WorkflowInterface
-             */
             #[Workflow\WorkflowInterface]
             class {
-                /**
-                 * Support for PHP7.4
-                 * @Workflow\WorkflowMethod(name="AwaitWorkflow")
-                 */
                 #[WorkflowMethod(name: 'AwaitWorkflow')]
                 public function handler(): iterable
                 {

--- a/tests/Unit/WorkflowContext/AwaitWithTimeoutTestCase.php
+++ b/tests/Unit/WorkflowContext/AwaitWithTimeoutTestCase.php
@@ -94,16 +94,8 @@ final class AwaitWithTimeoutTestCase extends UnitTestCase
     {
         $this->worker->registerWorkflowObject(
             new
-            /**
-             * Support for PHP7.4
-             * @Workflow\WorkflowInterface
-             */
             #[Workflow\WorkflowInterface]
             class {
-                /**
-                 * Support for PHP7.4
-                 * @Workflow\WorkflowMethod(name="AwaitWorkflow")
-                 */
                 #[WorkflowMethod(name: 'AwaitWorkflow')]
                 public function handler(): iterable
                 {
@@ -124,26 +116,15 @@ final class AwaitWithTimeoutTestCase extends UnitTestCase
         $this->addToAssertionCount(1);
         $this->worker->registerWorkflowObject(
             new
-            /**
-             * Support for PHP7.4
-             * @Workflow\WorkflowInterface
-             */
             #[Workflow\WorkflowInterface]
             class {
-                /**
-                 * Support for PHP7.4
-                 * @Workflow\WorkflowMethod(name="AwaitWorkflow")
-                 */
+                private bool $doCancel = false;
                 #[WorkflowMethod(name: 'AwaitWorkflow')]
                 public function handler(): iterable
                 {
-                    $this->doCancel = false;
-
                     yield Workflow::awaitWithTimeout(
                         50,
-                        function() {
-                            return $this->doCancel;
-                        }
+                        fn () => $this->doCancel,
                     );
 
                     if ($this->doCancel) {
@@ -153,10 +134,6 @@ final class AwaitWithTimeoutTestCase extends UnitTestCase
                     return 'OK';
                 }
 
-                /**
-                 * Support for PHP7.4
-                 * @Workflow\SignalMethod()
-                 */
                 #[Workflow\SignalMethod]
                 public function cancel(): void
                 {

--- a/tests/Unit/WorkflowContext/AwaitWithTimeoutTestCase.php
+++ b/tests/Unit/WorkflowContext/AwaitWithTimeoutTestCase.php
@@ -106,10 +106,11 @@ final class AwaitWithTimeoutTestCase extends UnitTestCase
                 #[WorkflowMethod(name: 'AwaitWorkflow')]
                 public function handler(): iterable
                 {
-                    yield Workflow::awaitWithTimeout(
+                    $result = yield Workflow::awaitWithTimeout(
                         50,
                         fn () => $this->doCancel,
                     );
+                    assertTrue($result);
 
                     if ($this->doCancel) {
                         return 'CANCEL';


### PR DESCRIPTION
## What was changed

- Fixed memory leaks in the case when an uncompleted workflow with an active internal timer (see awaitWithTimeout) is destroyed.
- Call `gc_collect_cycles()` after each Workflow destroy.
- Remove the `WorkflowContext::$timers` collection. Ut is unnecessary since Temporal PHP SDK 2.0 .
- Remove the `WorkflowContext::$asyncAwaits` collection because it is unnecessary.
- Remove unused $loop parameter from the `Temporal\Internal\Transport\Client` constructor.
- Other small improvements.

## Why?

In the case when the Workflow Worker processes many workflows at the same time
and their number exceeds the value of the `cache_size` parameter, the Workflow Worker will destroy some waiting workflows.
But the Workflow Worker incorrectly destroys workflows with active internal timers: timer promises
will remain in memory. This leads to memory leak.

## Checklist

1. Closes #177
2. Autotests added
