### PR TITLE
feat: unmarshalling of nested DTOs

### DIFF
--- a/src/Internal/Marshaller/Mapper/AttributeMapper.php
+++ b/src/Internal/Marshaller/Mapper/AttributeMapper.php
@@ -153,7 +153,7 @@ class AttributeMapper implements MapperInterface
             return null;
         }
 
-        // For object-typed properties: remember property type FQCN to make object nesting possible
+        // For object-typed properties: remember property type FQN to make object nesting possible
         if ($type === ObjectType::class && $meta->of === null) {
             $meta->of = $property->getType()?->getName();
         }

--- a/src/Internal/Marshaller/Mapper/AttributeMapper.php
+++ b/src/Internal/Marshaller/Mapper/AttributeMapper.php
@@ -12,9 +12,9 @@ declare(strict_types=1);
 namespace Temporal\Internal\Marshaller\Mapper;
 
 use Spiral\Attributes\ReaderInterface;
-use Temporal\Internal\Marshaller\MarshallerInterface;
 use Temporal\Internal\Marshaller\Meta\Marshal;
 use Temporal\Internal\Marshaller\Meta\Scope;
+use Temporal\Internal\Marshaller\Type\ObjectType;
 use Temporal\Internal\Marshaller\Type\TypeInterface;
 use Temporal\Internal\Marshaller\TypeFactoryInterface;
 
@@ -151,6 +151,11 @@ class AttributeMapper implements MapperInterface
 
         if ($type === null) {
             return null;
+        }
+
+        // For object-typed properties: remember property type FQCN to make object nesting possible
+        if ($type === ObjectType::class && $meta->of === null) {
+            $meta->of = $property->getType()?->getName();
         }
 
         return $this->factory->create($type, $meta->of ? [$meta->of] : []);

--- a/src/Internal/Marshaller/Type/ObjectType.php
+++ b/src/Internal/Marshaller/Type/ObjectType.php
@@ -50,7 +50,7 @@ class ObjectType extends Type implements DetectableTypeInterface
         }
 
         if ($current === null) {
-            $current = $this->instance((array)$value);
+            $current = $this->instance();
         }
 
         return $this->marshaller->unmarshal($value, $current);
@@ -65,12 +65,11 @@ class ObjectType extends Type implements DetectableTypeInterface
     }
 
     /**
-     * @param array $data
      * @return object
      * @throws \ReflectionException
      */
-    protected function instance(array $data): object
+    protected function instance(): object
     {
-        return $this->marshaller->unmarshal($data, $this->reflection->newInstanceWithoutConstructor());
+        return $this->reflection->newInstanceWithoutConstructor();
     }
 }

--- a/src/Internal/Marshaller/Type/ObjectType.php
+++ b/src/Internal/Marshaller/Type/ObjectType.php
@@ -13,16 +13,19 @@ namespace Temporal\Internal\Marshaller\Type;
 
 use Temporal\Internal\Marshaller\MarshallerInterface;
 
+/**
+ * @template TClass
+ */
 class ObjectType extends Type implements DetectableTypeInterface
 {
     /**
-     * @var \ReflectionClass
+     * @var \ReflectionClass<TClass>
      */
     private \ReflectionClass $reflection;
 
     /**
      * @param MarshallerInterface $marshaller
-     * @param string|null $class
+     * @param class-string<TClass>|null $class
      * @throws \ReflectionException
      */
     public function __construct(MarshallerInterface $marshaller, string $class = null)
@@ -50,7 +53,7 @@ class ObjectType extends Type implements DetectableTypeInterface
         }
 
         if ($current === null) {
-            $current = $this->instance();
+            $current = $this->emptyInstance();
         }
 
         return $this->marshaller->unmarshal($value, $current);
@@ -65,11 +68,24 @@ class ObjectType extends Type implements DetectableTypeInterface
     }
 
     /**
-     * @return object
+     * @return TClass
      * @throws \ReflectionException
      */
-    protected function instance(): object
+    protected function emptyInstance(): object
     {
         return $this->reflection->newInstanceWithoutConstructor();
+    }
+
+    /**
+     * @param array $data
+     *
+     * @return TClass
+     * @throws \ReflectionException
+     *
+     * @deprecated This method is not used anymore and will be removed in the next major release.
+     */
+    protected function instance(array $data): object
+    {
+        return $this->marshaller->unmarshal($data, $this->reflection->newInstanceWithoutConstructor());
     }
 }

--- a/src/Internal/Support/Inheritance.php
+++ b/src/Internal/Support/Inheritance.php
@@ -62,9 +62,13 @@ class Inheritance
     }
 
     /**
+     * @template A
+     *
      * @param class-string $haystack
-     * @param class-string $interface
+     * @param class-string<A> $interface
+     *
      * @return bool
+     * @psalm-assert-if-true class-string<A> $haystack
      */
     public static function implements(string $haystack, string $interface): bool
     {

--- a/tests/Unit/DTO/DeepDTO/ChildDTO.php
+++ b/tests/Unit/DTO/DeepDTO/ChildDTO.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\DTO\DeepDTO;
+
+final class ChildDTO
+{
+    public function __construct(
+        public readonly string $foo,
+    ) {
+    }
+}

--- a/tests/Unit/DTO/DeepDTO/DeepDTOTestCase.php
+++ b/tests/Unit/DTO/DeepDTO/DeepDTOTestCase.php
@@ -18,10 +18,6 @@ final class DeepDTOTestCase extends DTOMarshallingTestCase
      */
     public function testMarshalAndUnmarshal(): void
     {
-        if (PHP_VERSION_ID < 80104) {
-            $this->markTestSkipped();
-        }
-
         $manuallyCreatedParent = new ParentDTO(
             new ChildDTO('foo')
         );

--- a/tests/Unit/DTO/DeepDTO/DeepDTOTestCase.php
+++ b/tests/Unit/DTO/DeepDTO/DeepDTOTestCase.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\DTO\DeepDTO;
+
+use ReflectionClass;
+use ReflectionException;
+use Temporal\Tests\Unit\DTO\DTOMarshallingTestCase;
+
+/**
+ * @requires PHP >= 8.1
+ */
+final class DeepDTOTestCase extends DTOMarshallingTestCase
+{
+    /**
+     * @throws ReflectionException
+     */
+    public function testMarshalAndUnmarshal(): void
+    {
+        if (PHP_VERSION_ID < 80104) {
+            $this->markTestSkipped();
+        }
+
+        $manuallyCreatedParent = new ParentDTO(
+            new ChildDTO('foo')
+        );
+
+        $parentDTOReflection = new ReflectionClass(ParentDTO::class);
+
+        $marshalled = $this->marshal($manuallyCreatedParent);
+
+        $unmarshalledParent = $this->unmarshal(
+            $marshalled,
+            $parentDTOReflection->newInstanceWithoutConstructor()
+        );
+
+        self::assertEquals($manuallyCreatedParent, $unmarshalledParent);
+    }
+}

--- a/tests/Unit/DTO/DeepDTO/ParentDTO.php
+++ b/tests/Unit/DTO/DeepDTO/ParentDTO.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\DTO\DeepDTO;
+
+final class ParentDTO
+{
+    public function __construct(
+        public readonly ChildDTO $child,
+    ) {
+    }
+}


### PR DESCRIPTION
## What was changed

1. In case of ObjectType: remember FQCN as `meta->of` if not set.
2. Fixed double unmarshalling in [ObjectType](https://github.com/temporalio/sdk-php/blob/12bfeda200c32fd38e0485a229f4518064d6678e/src/Internal/Marshaller/Type/ObjectType.php#L46)

## Why?
To add an ability of unmarshalling nested DTOs.

1. Closes #274 

3. How was this tested: 
Added DeepDTOTestCase

4. Any docs updates needed?
No