### PR TITLE
Make java sdk release url configurable in Downloader

### DIFF
--- a/testing/Readme.md
+++ b/testing/Readme.md
@@ -43,7 +43,7 @@ $environment = new Environment(
     new Downloader(
         new Filesystem(),
         HttpClient::create(),
-        'https://api.github.com/repos/temporalio/sdk-java/releases/tags/v1.17.0',
+        'v1.17.0',  // use a specific release tag or `latest` to get the latest version
     ),
     SystemInfo::detect(),
 );

--- a/testing/Readme.md
+++ b/testing/Readme.md
@@ -36,6 +36,19 @@ $environment->startRoadRunner('./rr serve -c .rr.silent.yaml -w tests');
 register_shutdown_function(fn() => $environment->stop());
 ```
 
+Also, you can configure java sdk version:
+```php
+$environment = new Environment(
+    new ConsoleOutput(),
+    new Downloader(
+        new Filesystem(),
+        HttpClient::create(),
+        'https://api.github.com/repos/temporalio/sdk-java/releases/tags/v1.17.0',
+    ),
+    SystemInfo::detect(),
+);
+```
+
 2. Add environment variable and `bootstrap.php` to your `phpunit.xml`:
 
 ```xml

--- a/testing/src/Downloader.php
+++ b/testing/src/Downloader.php
@@ -12,11 +12,13 @@ final class Downloader
     private const LATEST_JAVA_SDK_RELEASE = 'https://api.github.com/repos/temporalio/sdk-java/releases/latest';
     private Filesystem $filesystem;
     private HttpClientInterface $httpClient;
+    private string $javaSdkReleaseUrl;
 
-    public function __construct(Filesystem $filesystem, HttpClientInterface $httpClient)
+    public function __construct(Filesystem $filesystem, HttpClientInterface $httpClient, ?string $javaSdkReleaseUrl = null)
     {
         $this->filesystem = $filesystem;
         $this->httpClient = $httpClient;
+        $this->javaSdkReleaseUrl = $javaSdkReleaseUrl ?? self::LATEST_JAVA_SDK_RELEASE;
     }
 
     private function findAsset(array $assets, string $systemPlatform, string $systemArch): array
@@ -74,7 +76,7 @@ final class Downloader
 
     private function getAsset(string $systemPlatform, string $systemArch): array
     {
-        $response = $this->httpClient->request('GET', self::LATEST_JAVA_SDK_RELEASE);
+        $response = $this->httpClient->request('GET', $this->javaSdkReleaseUrl);
         $assets = $response->toArray()['assets'];
 
         return $this->findAsset($assets, $systemPlatform, $systemArch);

--- a/testing/src/Downloader.php
+++ b/testing/src/Downloader.php
@@ -9,19 +9,23 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class Downloader
 {
-    private const LATEST_JAVA_SDK_RELEASE = 'https://api.github.com/repos/temporalio/sdk-java/releases/latest';
+    public const TAG_LATEST = 'latest';
+    private const JAVA_SDK_URL_RELEASES = 'https://api.github.com/repos/temporalio/sdk-java/releases/';
     private Filesystem $filesystem;
     private HttpClientInterface $httpClient;
-    private string $javaSdkReleaseUrl;
+    private string $javaSdkUrl;
 
     public function __construct(
         Filesystem $filesystem,
         HttpClientInterface $httpClient,
-        string $javaSdkReleaseUrl = self::LATEST_JAVA_SDK_RELEASE,
+        string $javaSdkVersion = self::TAG_LATEST,
     ) {
         $this->filesystem = $filesystem;
         $this->httpClient = $httpClient;
-        $this->javaSdkReleaseUrl = $javaSdkReleaseUrl;
+        $this->javaSdkUrl = self::JAVA_SDK_URL_RELEASES . match (true) {
+            $javaSdkVersion === self::TAG_LATEST => self::TAG_LATEST,
+            default => "tags/$javaSdkVersion",
+        };
     }
 
     private function findAsset(array $assets, string $systemPlatform, string $systemArch): array
@@ -79,7 +83,7 @@ final class Downloader
 
     private function getAsset(string $systemPlatform, string $systemArch): array
     {
-        $response = $this->httpClient->request('GET', $this->javaSdkReleaseUrl);
+        $response = $this->httpClient->request('GET', $this->javaSdkUrl);
         $assets = $response->toArray()['assets'];
 
         return $this->findAsset($assets, $systemPlatform, $systemArch);

--- a/testing/src/Downloader.php
+++ b/testing/src/Downloader.php
@@ -14,11 +14,14 @@ final class Downloader
     private HttpClientInterface $httpClient;
     private string $javaSdkReleaseUrl;
 
-    public function __construct(Filesystem $filesystem, HttpClientInterface $httpClient, ?string $javaSdkReleaseUrl = null)
-    {
+    public function __construct(
+        Filesystem $filesystem,
+        HttpClientInterface $httpClient,
+        string $javaSdkReleaseUrl = self::LATEST_JAVA_SDK_RELEASE,
+    ) {
         $this->filesystem = $filesystem;
         $this->httpClient = $httpClient;
-        $this->javaSdkReleaseUrl = $javaSdkReleaseUrl ?? self::LATEST_JAVA_SDK_RELEASE;
+        $this->javaSdkReleaseUrl = $javaSdkReleaseUrl;
     }
 
     private function findAsset(array $assets, string $systemPlatform, string $systemArch): array


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Add javaSdkReleaseUrl parameter to `Temporal\Testing\Downloader`

## Why?
got error with new version of temporalio/sdk-java v1.18.0-RC1
`/temporal-test-server: /usr/x86_64-linux-gnu/lib/libc.so.6: version 'GLIBC_2.32' not found (required by ./temporal-test-server)`

<img width="1362" alt="image" src="https://user-images.githubusercontent.com/16839017/215554376-95f3e565-6890-4995-9784-cb9069c37146.png">


## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
