### PR TITLE
Maintenance: improve RoadRunner starting detection

### DIFF
--- a/testing/src/Environment.php
+++ b/testing/src/Environment.php
@@ -80,7 +80,12 @@ final class Environment
         $this->roadRunnerProcess->setTimeout($commandTimeout);
 
         $this->output->write('Starting RoadRunner... ');
-        $this->roadRunnerProcess->start();
+        $roadRunnerStarted = false;
+        $this->roadRunnerProcess->start(static function ($type, $output) use (&$roadRunnerStarted) {
+            if ($type === Process::OUT && \str_contains($output, 'RoadRunner server started')) {
+                $roadRunnerStarted = true;
+            }
+        });
 
         if (!$this->roadRunnerProcess->isRunning()) {
             $this->output->writeln('<error>error</error>');
@@ -88,9 +93,13 @@ final class Environment
             exit(1);
         }
 
-        $roadRunnerStarted = $this->roadRunnerProcess->waitUntil(
-            fn($type, $output) => strpos($output, 'RoadRunner server started') !== false
-        );
+        // wait for roadrunner to start
+        $ticks = $commandTimeout * 10;
+        while (!$roadRunnerStarted && $ticks > 0) {
+            $this->roadRunnerProcess->getStatus();
+            \usleep(100000);
+            --$ticks;
+        }
 
         if (!$roadRunnerStarted) {
             $this->output->writeln('<error>error</error>');


### PR DESCRIPTION
## What was changed

RoadRunner starting detection improved.
Updated `proto` submodule.

## Why?

Sometimes RoadRunner starts so fast and PHP fails to catch the moment of launch.
