### PR TITLE
Add `EnumType` by default for PHP >=8.1

### DIFF
--- a/src/Internal/Marshaller/Type/EnumType.php
+++ b/src/Internal/Marshaller/Type/EnumType.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Temporal\Internal\Marshaller\Type;
 
+use BackedEnum;
 use Temporal\Internal\Marshaller\MarshallerInterface;
 use Temporal\Internal\Marshaller\MarshallingRule;
 
@@ -90,8 +91,15 @@ class EnumType extends Type implements RuleFactoryInterface
      *
      * @return \UnitEnum|null
      */
-    public function serialize($value)
+    public function serialize($value): array
     {
-        return $value;
+        return $value instanceof BackedEnum
+            ? [
+                'name' => $value->name,
+                'value' => $value->value,
+            ]
+            : [
+                'name' => $value->name,
+            ];
     }
 }

--- a/src/Internal/Marshaller/TypeFactory.php
+++ b/src/Internal/Marshaller/TypeFactory.php
@@ -15,6 +15,7 @@ use Temporal\Internal\Marshaller\Type\ArrayType;
 use Temporal\Internal\Marshaller\Type\DateIntervalType;
 use Temporal\Internal\Marshaller\Type\DateTimeType;
 use Temporal\Internal\Marshaller\Type\DetectableTypeInterface;
+use Temporal\Internal\Marshaller\Type\EnumType;
 use Temporal\Internal\Marshaller\Type\ObjectType;
 use Temporal\Internal\Marshaller\Type\RuleFactoryInterface as TypeRuleFactoryInterface;
 use Temporal\Internal\Marshaller\Type\TypeInterface;
@@ -134,6 +135,10 @@ class TypeFactory implements RuleFactoryInterface
      */
     private function getDefaultMatchers(): iterable
     {
+        if (PHP_VERSION_ID >= 80104) {
+            yield EnumType::class;
+        }
+
         yield DateTimeType::class;
         yield DateIntervalType::class;
         yield ArrayType::class;

--- a/tests/Fixtures/src/Activity/SimpleActivity.php
+++ b/tests/Fixtures/src/Activity/SimpleActivity.php
@@ -18,6 +18,7 @@ use Temporal\Api\Common\V1\WorkflowExecution;
 use Temporal\DataConverter\Bytes;
 use Temporal\Tests\DTO\Message;
 use Temporal\Tests\DTO\User;
+use Temporal\Tests\DTO\WithEnum;
 use Temporal\Tests\Unit\DTO\Type\EnumType\Stub\ScalarEnum;
 use Temporal\Tests\Unit\DTO\Type\EnumType\Stub\SimpleEnum;
 
@@ -112,5 +113,11 @@ class SimpleActivity
     public function scalarEnum(ScalarEnum $enum): ScalarEnum
     {
         return $enum;
+    }
+
+    #[ActivityMethod]
+    public function simpleEnumDto(WithEnum $dto): WithEnum
+    {
+        return $dto;
     }
 }

--- a/tests/Fixtures/src/DTO/WithEnum.php
+++ b/tests/Fixtures/src/DTO/WithEnum.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\DTO;
+
+use Temporal\Tests\Unit\DTO\Type\EnumType\Stub\SimpleEnum;
+
+class WithEnum
+{
+    public function __construct(
+        public SimpleEnum $simple,
+    ) {
+    }
+}

--- a/tests/Fixtures/src/Workflow/EnumDtoWorkflow.php
+++ b/tests/Fixtures/src/Workflow/EnumDtoWorkflow.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Workflow;
+
+use Temporal\Activity\ActivityOptions;
+use Temporal\Common\RetryOptions;
+use Temporal\Tests\Activity\SimpleActivity;
+use Temporal\Tests\DTO\WithEnum;
+use Temporal\Workflow;
+use Temporal\Workflow\WorkflowMethod;
+
+#[Workflow\WorkflowInterface]
+class EnumDtoWorkflow
+{
+    #[WorkflowMethod]
+    public function handler(WithEnum $enum): iterable
+    {
+        $simple = Workflow::newActivityStub(
+            SimpleActivity::class,
+            ActivityOptions::new()
+                ->withStartToCloseTimeout(5)
+                ->withRetryOptions(
+                    RetryOptions::new()->withMaximumAttempts(2)
+                )
+        );
+
+        return yield $simple->simpleEnumDto($enum);
+    }
+}

--- a/tests/Functional/Client/EnumTestCase.php
+++ b/tests/Functional/Client/EnumTestCase.php
@@ -11,8 +11,10 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Functional\Client;
 
+use Temporal\Tests\DTO\WithEnum;
 use Temporal\Tests\Unit\DTO\Type\EnumType\Stub\ScalarEnum;
 use Temporal\Tests\Unit\DTO\Type\EnumType\Stub\SimpleEnum;
+use Temporal\Tests\Workflow\EnumDtoWorkflow;
 use Temporal\Tests\Workflow\ScalarEnumWorkflow;
 use Temporal\Tests\Workflow\SimpleEnumWorkflow;
 
@@ -42,5 +44,15 @@ class EnumTestCase extends ClientTestCase
         $result = $client->start($workflow, ScalarEnum::TESTED_ENUM);
 
         $this->assertSame(ScalarEnum::TESTED_ENUM, $result->getResult(ScalarEnum::class));
+    }
+
+    public function testDtoNestedEnum(): void
+    {
+        $client = $this->createClient();
+        $workflow = $client->newWorkflowStub(EnumDtoWorkflow::class);
+
+        $result = $client->start($workflow, $input = new WithEnum(SimpleEnum::TEST));
+
+        $this->assertEquals($input, $result->getResult(WithEnum::class));
     }
 }

--- a/tests/Unit/DTO/Type/EnumType/EnumTestCase.php
+++ b/tests/Unit/DTO/Type/EnumType/EnumTestCase.php
@@ -33,10 +33,10 @@ class EnumTestCase extends DTOMarshallingTestCase
         $dto->nullable = null;
 
         $result = $this->marshal($dto);
-        $this->assertEquals($dto->simpleEnum, $result['simpleEnum']);
-        $this->assertEquals($dto->scalarEnum, $result['scalarEnum']);
-        $this->assertEquals($dto->autoSimpleEnum, $result['autoSimpleEnum']);
-        $this->assertEquals($dto->autoScalarEnum, $result['autoScalarEnum']);
+        $this->assertSame(['name' => 'TEST'], $result['simpleEnum']);
+        $this->assertSame(['name' => 'TESTED_ENUM', 'value' => 'tested'], $result['scalarEnum']);
+        $this->assertSame(['name' => 'TEST'], $result['autoSimpleEnum']);
+        $this->assertSame(['name' => 'TESTED_ENUM', 'value' => 'tested'], $result['autoScalarEnum']);
         $this->assertNull($result['nullable']);
     }
 
@@ -46,7 +46,7 @@ class EnumTestCase extends DTOMarshallingTestCase
         $dto->nullable = ScalarEnum::TESTED_ENUM;
 
         $result = $this->marshal($dto);
-        $this->assertEquals(ScalarEnum::TESTED_ENUM, $result['nullable']);
+        $this->assertSame(['name' => 'TESTED_ENUM', 'value' => 'tested'], $result['nullable']);
     }
 
     public function testUnmarshalBackedEnumUsingScalarValue(): void


### PR DESCRIPTION
## What was changed

Added `EnumType` into type list of TypeFactory for PHP >=8.1.
Aslo `EnumType` was fixed because dataconverters can't encode nested enums.

## Why?

To support PHP 8.1 enumirations from the box

## Checklist

1. Closes #281, instead of #282
2. How was this tested:
Added feature test with Enum nested into DTO
