### PR TITLE
Fix mapping for the `Memo` field

### DIFF
--- a/src/Workflow/WorkflowInfo.php
+++ b/src/Workflow/WorkflowInfo.php
@@ -112,7 +112,7 @@ final class WorkflowInfo
     /**
      * @var array|null
      */
-    #[Marshal(name: 'SearchAttributes', type: NullableType::class, of: ArrayType::class)]
+    #[Marshal(name: 'Memo', type: NullableType::class, of: ArrayType::class)]
     public ?array $memo = null;
 
     /**

--- a/tests/Unit/DTO/WorkflowInfoTestCase.php
+++ b/tests/Unit/DTO/WorkflowInfoTestCase.php
@@ -41,6 +41,7 @@ class WorkflowInfoTestCase extends DTOMarshallingTestCase
             'ParentWorkflowNamespace' => null,
             'ParentWorkflowExecution' => null,
             'SearchAttributes' => null,
+            'Memo' => null,
             'BinaryChecksum' => '',
         ];
 


### PR DESCRIPTION
Fixes the problem where WorkflowInfo doesnt retrieve the correct info when using Worker::getInfo().
This also fixes the problem where Workflow::getInfo()->searchableAttributes is null.

I dont know why, but the duplicate Marshal keys of "SearchAttributes" breaks the normal searchAttributes property aswell

## What was changed
Marshal key of Memo property in WorkerInfo

## Why?
When calling Workflow::getInfo() in a Workflow or an activity, it doesnt return the memo

1. How was this tested:
Manually by creating a new Workflow and using Workflow::getInfo()->memo to retrieve the memo properties.

3. Any docs updates needed?
No, this is a purely a bug
