### PR TITLE
Replacing NamedArgumentConstructorAttribute with NamedArgumentConstructor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "nesbot/carbon": "^2.55.0",
         "psr/log": "^1.0.1 || ^2.0 || ^3.0",
         "react/promise": "^2.8",
-        "spiral/attributes": "^2.7 || ^3.0",
+        "spiral/attributes": "^2.8 || ^3.0",
         "spiral/roadrunner-cli": "^2.2",
         "spiral/roadrunner-kv": "^2.1 || ^3.0",
         "spiral/roadrunner-worker": "^2.1.3",

--- a/src/Activity/ActivityInterface.php
+++ b/src/Activity/ActivityInterface.php
@@ -13,7 +13,7 @@ namespace Temporal\Activity;
 
 use Doctrine\Common\Annotations\Annotation\Target;
 use JetBrains\PhpStorm\Immutable;
-use Spiral\Attributes\NamedArgumentConstructorAttribute;
+use Spiral\Attributes\NamedArgumentConstructor;
 
 /**
  * Indicates that an interface is an activity interface. Only interfaces
@@ -29,10 +29,11 @@ use Spiral\Attributes\NamedArgumentConstructorAttribute;
  * distinct.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target({ "CLASS" })
  */
-#[\Attribute(\Attribute::TARGET_CLASS)]
-class ActivityInterface implements NamedArgumentConstructorAttribute
+#[\Attribute(\Attribute::TARGET_CLASS), NamedArgumentConstructor]
+class ActivityInterface
 {
     /**
      * Prefix to prepend to method names to generate activity types. Default is

--- a/src/Activity/ActivityMethod.php
+++ b/src/Activity/ActivityMethod.php
@@ -13,14 +13,15 @@ namespace Temporal\Activity;
 
 use Doctrine\Common\Annotations\Annotation\Target;
 use JetBrains\PhpStorm\Immutable;
-use Spiral\Attributes\NamedArgumentConstructorAttribute;
+use Spiral\Attributes\NamedArgumentConstructor;
 
 /**
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target({ "METHOD" })
  */
-#[\Attribute(\Attribute::TARGET_METHOD)]
-final class ActivityMethod implements NamedArgumentConstructorAttribute
+#[\Attribute(\Attribute::TARGET_METHOD), NamedArgumentConstructor]
+final class ActivityMethod
 {
     /**
      * Name of the activity type.

--- a/src/Activity/LocalActivityInterface.php
+++ b/src/Activity/LocalActivityInterface.php
@@ -13,7 +13,7 @@ namespace Temporal\Activity;
 
 use Doctrine\Common\Annotations\Annotation\Target;
 use JetBrains\PhpStorm\Immutable;
-use Spiral\Attributes\NamedArgumentConstructorAttribute;
+use Spiral\Attributes\NamedArgumentConstructor;
 
 /**
  * Indicates that an interface is a local activity interface. Only interfaces
@@ -29,9 +29,10 @@ use Spiral\Attributes\NamedArgumentConstructorAttribute;
  * distinct.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target({ "CLASS" })
  */
-#[\Attribute(\Attribute::TARGET_CLASS)]
+#[\Attribute(\Attribute::TARGET_CLASS), NamedArgumentConstructor]
 final class LocalActivityInterface extends ActivityInterface
 {
     /**

--- a/src/Common/CronSchedule.php
+++ b/src/Common/CronSchedule.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace Temporal\Common;
 
 use JetBrains\PhpStorm\Immutable;
-use Spiral\Attributes\NamedArgumentConstructorAttribute;
+use Spiral\Attributes\NamedArgumentConstructor;
 use Temporal\Internal\Support\DateInterval;
 
 /**
@@ -30,10 +30,11 @@ use Temporal\Internal\Support\DateInterval;
  * @see DateInterval
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target({ "METHOD" })
  */
-#[\Attribute(\Attribute::TARGET_METHOD)]
-final class CronSchedule implements NamedArgumentConstructorAttribute, \Stringable
+#[\Attribute(\Attribute::TARGET_METHOD), NamedArgumentConstructor]
+final class CronSchedule implements \Stringable
 {
     /**
      * The cron spec is as following:

--- a/src/Common/MethodRetry.php
+++ b/src/Common/MethodRetry.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace Temporal\Common;
 
-use Spiral\Attributes\NamedArgumentConstructorAttribute;
+use Spiral\Attributes\NamedArgumentConstructor;
 use Temporal\Internal\Support\DateInterval;
 
 /**
@@ -27,10 +27,11 @@ use Temporal\Internal\Support\DateInterval;
  * @psalm-import-type ExceptionsList from RetryOptions
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target({ "METHOD" })
  */
-#[\Attribute(\Attribute::TARGET_METHOD)]
-final class MethodRetry extends RetryOptions implements NamedArgumentConstructorAttribute
+#[\Attribute(\Attribute::TARGET_METHOD), NamedArgumentConstructor]
+final class MethodRetry extends RetryOptions
 {
     /**
      * @param DateIntervalValue|null $initialInterval

--- a/src/Internal/Marshaller/Meta/Marshal.php
+++ b/src/Internal/Marshaller/Meta/Marshal.php
@@ -11,16 +11,17 @@ declare(strict_types=1);
 
 namespace Temporal\Internal\Marshaller\Meta;
 
-use Spiral\Attributes\NamedArgumentConstructorAttribute;
+use Spiral\Attributes\NamedArgumentConstructor;
 use Temporal\Internal\Marshaller\MarshallingRule;
 use Temporal\Internal\Marshaller\Type\NullableType;
 
 /**
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target({ "PROPERTY" })
  */
-#[\Attribute(\Attribute::TARGET_PROPERTY)]
-class Marshal extends MarshallingRule implements NamedArgumentConstructorAttribute
+#[\Attribute(\Attribute::TARGET_PROPERTY), NamedArgumentConstructor]
+class Marshal extends MarshallingRule
 {
     /**
      * @param string|null $name

--- a/src/Internal/Marshaller/Meta/MarshalArray.php
+++ b/src/Internal/Marshaller/Meta/MarshalArray.php
@@ -11,13 +11,15 @@ declare(strict_types=1);
 
 namespace Temporal\Internal\Marshaller\Meta;
 
+use Spiral\Attributes\NamedArgumentConstructor;
 use Temporal\Internal\Marshaller\Type\ArrayType;
 
 /**
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target({ "PROPERTY", "METHOD" })
  */
-#[\Attribute(\Attribute::TARGET_PROPERTY)]
+#[\Attribute(\Attribute::TARGET_PROPERTY), NamedArgumentConstructor]
 final class MarshalArray extends Marshal
 {
     /**

--- a/src/Internal/Marshaller/Meta/Scope.php
+++ b/src/Internal/Marshaller/Meta/Scope.php
@@ -12,16 +12,17 @@ declare(strict_types=1);
 namespace Temporal\Internal\Marshaller\Meta;
 
 use JetBrains\PhpStorm\ExpectedValues;
-use Spiral\Attributes\NamedArgumentConstructorAttribute;
+use Spiral\Attributes\NamedArgumentConstructor;
 
 /**
  * @psalm-type ExportScope = Scope::VISIBILITY_*
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target({ "CLASS" })
  */
-#[\Attribute(\Attribute::TARGET_CLASS)]
-class Scope implements NamedArgumentConstructorAttribute
+#[\Attribute(\Attribute::TARGET_CLASS), NamedArgumentConstructor]
+class Scope
 {
     /**
      * @var int

--- a/src/Workflow/QueryMethod.php
+++ b/src/Workflow/QueryMethod.php
@@ -13,7 +13,7 @@ namespace Temporal\Workflow;
 
 use Doctrine\Common\Annotations\Annotation\Target;
 use JetBrains\PhpStorm\Immutable;
-use Spiral\Attributes\NamedArgumentConstructorAttribute;
+use Spiral\Attributes\NamedArgumentConstructor;
 
 /**
  * Indicates that the method is a query method. Query method can be used to
@@ -24,10 +24,11 @@ use Spiral\Attributes\NamedArgumentConstructorAttribute;
  * activities or block threads in any way.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target({ "METHOD" })
  */
-#[\Attribute(\Attribute::TARGET_METHOD)]
-final class QueryMethod implements NamedArgumentConstructorAttribute
+#[\Attribute(\Attribute::TARGET_METHOD), NamedArgumentConstructor]
+final class QueryMethod
 {
     /**
      * Name of the query type. Default is method name.

--- a/src/Workflow/ReturnType.php
+++ b/src/Workflow/ReturnType.php
@@ -13,15 +13,16 @@ namespace Temporal\Workflow;
 
 use JetBrains\PhpStorm\ExpectedValues;
 use JetBrains\PhpStorm\Immutable;
-use Spiral\Attributes\NamedArgumentConstructorAttribute;
+use Spiral\Attributes\NamedArgumentConstructor;
 use Temporal\DataConverter\Type;
 
 /**
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target({ "METHOD" })
  */
-#[\Attribute(\Attribute::TARGET_METHOD)]
-final class ReturnType implements NamedArgumentConstructorAttribute
+#[\Attribute(\Attribute::TARGET_METHOD), NamedArgumentConstructor]
+final class ReturnType
 {
     public const TYPE_ANY    = Type::TYPE_ANY;
     public const TYPE_STRING = Type::TYPE_STRING;

--- a/src/Workflow/SignalMethod.php
+++ b/src/Workflow/SignalMethod.php
@@ -13,7 +13,7 @@ namespace Temporal\Workflow;
 
 use Doctrine\Common\Annotations\Annotation\Target;
 use JetBrains\PhpStorm\Immutable;
-use Spiral\Attributes\NamedArgumentConstructorAttribute;
+use Spiral\Attributes\NamedArgumentConstructor;
 
 /**
  * Indicates that the method is a signal handler method. Signal method is
@@ -21,10 +21,11 @@ use Spiral\Attributes\NamedArgumentConstructorAttribute;
  * workflow interface methods.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target({ "METHOD" })
  */
-#[\Attribute(\Attribute::TARGET_METHOD)]
-final class SignalMethod implements NamedArgumentConstructorAttribute
+#[\Attribute(\Attribute::TARGET_METHOD), NamedArgumentConstructor]
+final class SignalMethod
 {
     /**
      * Name of the signal type. Default is method name.

--- a/src/Workflow/WorkflowInterface.php
+++ b/src/Workflow/WorkflowInterface.php
@@ -17,16 +17,7 @@ use Doctrine\Common\Annotations\Annotation\Target;
  * @Annotation
  * @Target({ "CLASS" })
  *
- * Note: We can not implement "NamedArgumentConstructorAttribute" interface
- *  on attribute classes without "__construct" method.
- *
- *  Otherwise, we may receive a NPE inside DocParser class, like:
- *   > Call to a member function getParameters() on null
- *   > in vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/DocParser.php:518
- *
- *  Problem is relevant for doctrine/annotations 1.11 or lower on PHP 7.4 or lower.
- *
- * Note #2: We can not comment this problematic piece of code, because
+ * Note: We can not comment this problematic piece of code, because
  *  otherwise a second doctrine bug occurs (WTF!111?) due to which the doctrine
  *  cannot correctly read the annotations (like "Annotation") in the class.
  *

--- a/src/Workflow/WorkflowMethod.php
+++ b/src/Workflow/WorkflowMethod.php
@@ -13,14 +13,15 @@ namespace Temporal\Workflow;
 
 use Doctrine\Common\Annotations\Annotation\Target;
 use JetBrains\PhpStorm\Immutable;
-use Spiral\Attributes\NamedArgumentConstructorAttribute;
+use Spiral\Attributes\NamedArgumentConstructor;
 
 /**
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target({ "METHOD" })
  */
-#[\Attribute(\Attribute::TARGET_METHOD)]
-final class WorkflowMethod implements NamedArgumentConstructorAttribute
+#[\Attribute(\Attribute::TARGET_METHOD), NamedArgumentConstructor]
+final class WorkflowMethod
 {
     /**
      * Name of the workflow type. Default is "{class_name :: method_name}".


### PR DESCRIPTION
## What was changed

Replaced `Spiral\Attributes\NamedArgumentConstructorAttribute` with `Spiral\Attributes\NamedArgumentConstructor` in all attributes.

## Why?

The **NamedArgumentConstructorAttribute** interface inherits from **Doctrine\Common\Annotations\NamedArgumentConstructorAnnotation** which was removed in version 2.0 of the package: 
https://github.com/doctrine/annotations/pull/470.
