### PR TITLE
Update PHP RoadRunner packages versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,9 +31,9 @@
         "psr/log": "^1.0.1 || ^2.0 || ^3.0",
         "react/promise": "^2.8",
         "spiral/attributes": "^2.8 || ^3.0",
-        "spiral/roadrunner-cli": "^2.2",
-        "spiral/roadrunner-kv": "^2.1 || ^3.0",
-        "spiral/roadrunner-worker": "^2.1.3",
+        "spiral/roadrunner-cli": "^2.2 || ^3.0",
+        "spiral/roadrunner-kv": "^2.1 || ^3.0 || ^4.0",
+        "spiral/roadrunner-worker": "^2.1.3 || ^3.0",
         "symfony/filesystem": "^4.4.20 || ^5.0 || ^6.0",
         "symfony/http-client": "^4.4.20 || ^5.0 || ^6.0",
         "symfony/process": "^4.4.20 || ^5.0 || ^6.0"


### PR DESCRIPTION
## What was changed

Updated versions of RoadRunner PHP packages

## Why?

To better compatibility with RoadRunner 2023.1
