### PR TITLE
Expand list of retryable gRPC errors

### DIFF
--- a/src/Client/GRPC/BaseClient.php
+++ b/src/Client/GRPC/BaseClient.php
@@ -139,7 +139,6 @@ abstract class BaseClient implements ServiceClientInterface
                 [$result, $status] = $call->wait();
 
                 if ($status->code !== 0) {
-                    echo $status->code . "\n";
                     throw new ServiceClientException($status);
                 }
 

--- a/src/Client/GRPC/BaseClient.php
+++ b/src/Client/GRPC/BaseClient.php
@@ -21,7 +21,6 @@ abstract class BaseClient implements ServiceClientInterface
 {
     const RETRYABLE_ERRORS = [
         StatusCode::RESOURCE_EXHAUSTED,
-        StatusCode::INTERNAL,
         StatusCode::UNAVAILABLE,
         StatusCode::UNKNOWN,
     ];
@@ -140,6 +139,7 @@ abstract class BaseClient implements ServiceClientInterface
                 [$result, $status] = $call->wait();
 
                 if ($status->code !== 0) {
+                    echo $status->code . "\n";
                     throw new ServiceClientException($status);
                 }
 

--- a/src/Exception/Client/ServiceClientException.php
+++ b/src/Exception/Client/ServiceClientException.php
@@ -36,7 +36,7 @@ class ServiceClientException extends \RuntimeException
             $this->status->mergeFromString($status->metadata['grpc-status-details-bin'][0]);
         }
 
-        parent::__construct($status->details, $status->code, $previous);
+        parent::__construct($status->details . " (code: $status->code)", $status->code, $previous);
     }
 
     /**


### PR DESCRIPTION
## What was changed

UNAVAILABLE and UNKNOWN gRPC errors now are retryable.

> **Note**:
> In the case when a Temporal server is unavailable and by the reason a Client call can't be completed, without a limited retry gRPC call policy it might retry infinitely.

## Why?

In some cases gRPC connection might be broken or not initialized. In this case we should follow our retry policy.

## Checklist

1. Closes #296 

2. How was this tested:
Manually using [proxy](https://github.com/Shopify/toxiproxy)

