### PR TITLE
[CI] Add Windows tests

### DIFF
--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -27,8 +27,11 @@ jobs:
       fail-fast: ${{ inputs.fail-fast }}
       matrix:
         php: [ 8.1, 8.2 ]
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-latest, windows-latest ]
         dependencies: [ lowest , highest ]
+        exclude:
+          - os: windows-latest
+            php: 8.2
     steps:
       - name: Set Git To Use LF
         run: |

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -16,6 +16,11 @@ on:
         required: false
         type: boolean
         default: true
+  push:
+    branches:
+      - 'master'
+      - '2.*'
+  pull_request: null
 
 jobs:
   test:

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -73,7 +73,9 @@ jobs:
 
       - name: Install lowest dependencies from composer.json
         if: matrix.dependencies == 'lowest'
-        run: COMPOSER_POOL_OPTIMIZER=0 composer update --no-interaction --no-progress --prefer-lowest
+        run: composer update --no-interaction --no-progress --prefer-lowest
+        env:
+          COMPOSER_POOL_OPTIMIZER: 0
 
       - name: Validate lowest dependencies
         if: matrix.dependencies == 'lowest'

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -20,7 +20,21 @@ on:
     branches:
       - 'master'
       - '2.*'
-  pull_request: null
+    paths-ignore:
+      - 'README.md'
+      - '.gitignore'
+      - '.gitattributes'
+      - 'psalm.xml'
+      - 'psalm-baseline.xml'
+      - '.editorconfig'
+  pull_request:
+    paths-ignore:
+      - 'README.md'
+      - '.gitignore'
+      - '.gitattributes'
+      - 'psalm.xml'
+      - 'psalm-baseline.xml'
+      - '.editorconfig'
 
 jobs:
   test:


### PR DESCRIPTION
## What was changed

Add Windows tests in CI

## Why?

Windows tests was removed with #287 because there are [no gRPC binaries in PECL repository](https://pecl.php.net/package/grpc) for PHP 8.2

### Related issues:
- https://github.com/php/php-src/issues/10850
- https://github.com/grpc/grpc/issues/32304

### Links:
- Related thread [Windows PECL build machine died](https://externals.io/message/117494) on PHP Externals
