### PR TITLE
Add supporting for RoadRunner `UndefinedResponse` command

### DIFF
--- a/src/Internal/Transport/Client.php
+++ b/src/Internal/Transport/Client.php
@@ -15,12 +15,12 @@ use React\Promise\Deferred;
 use React\Promise\PromiseInterface;
 use Temporal\Exception\Failure\CanceledFailure;
 use Temporal\Internal\Queue\QueueInterface;
+use Temporal\Internal\Transport\Request\UndefinedResponse;
 use Temporal\Worker\Transport\Command\CommandInterface;
 use Temporal\Worker\Transport\Command\FailureResponseInterface;
 use Temporal\Worker\Transport\Command\RequestInterface;
 use Temporal\Worker\Transport\Command\ResponseInterface;
 use Temporal\Worker\Transport\Command\SuccessResponseInterface;
-use Temporal\Worker\LoopInterface;
 
 /**
  * @internal Client is an internal library class, please do not use it in your code.
@@ -54,7 +54,10 @@ final class Client implements ClientInterface
     public function dispatch(ResponseInterface $response): void
     {
         if (!isset($this->requests[$response->getID()])) {
-            throw new \LogicException(sprintf('Got the response to undefined request %s', $response->getID()));
+            $this->request(new UndefinedResponse(
+                \sprintf('Got the response to undefined request %s', $response->getID()),
+            ));
+            return;
         }
 
         $deferred = $this->fetch($response->getID());

--- a/src/Internal/Transport/Request/UndefinedResponse.php
+++ b/src/Internal/Transport/Request/UndefinedResponse.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Internal\Transport\Request;
+
+use Temporal\Worker\Transport\Command\Request;
+
+final class UndefinedResponse extends Request
+{
+    public const NAME = 'UndefinedResponse';
+
+    /**
+     * @param non-empty-string $message Error message
+     */
+    public function __construct(string $message)
+    {
+        parent::__construct(self::NAME, ['message' => $message]);
+    }
+}


### PR DESCRIPTION
## What was changed

Added `UndefinedResponse` command instead of logic exception.
The command is available since RoadRunner 2023.1

## Why?

The command was added to avoid side effects when workflow worker is restarted.
Before that response to undefined request resulted in a logic exception being thrown.

## Checklist

1. Related with #289 

2. How was this tested:
Tested manually using [that e2e test](https://github.com/roadrunner-server/rr-e2e-tests/tree/undefined-response/php_test_files/temporal/undefined_response)
