### PR TITLE
Fix deprecated interpolation

### DIFF
--- a/src/Activity/ActivityCancellationType.php
+++ b/src/Activity/ActivityCancellationType.php
@@ -63,7 +63,7 @@ final class ActivityCancellationType extends Type
                 return false;
 
             default:
-                $error = "Option #${value} is currently not supported";
+                $error = "Option #{$value} is currently not supported";
                 throw new \InvalidArgumentException($error);
         }
     }

--- a/src/Workflow/ChildWorkflowCancellationType.php
+++ b/src/Workflow/ChildWorkflowCancellationType.php
@@ -71,7 +71,7 @@ final class ChildWorkflowCancellationType extends Type
                 return false;
 
             default:
-                $error = "Option #${value} is currently not supported";
+                $error = "Option #{$value} is currently not supported";
                 throw new \InvalidArgumentException($error);
         }
     }


### PR DESCRIPTION
## What was changed
Replace `${var}` with `{$var}`

## Why?

Since version 8.2 string interpolation ${var} is deprecated - https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation

## Checklist
<!--- add/delete as needed --->

1. Closes #308  
