### PR TITLE
Adding Marshaller UuidType

### DIFF
--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Install lowest dependencies from composer.json
         if: matrix.dependencies == 'lowest'
-        run: composer update --no-interaction --no-progress --prefer-lowest
+        run: COMPOSER_POOL_OPTIMIZER=0 composer update --no-interaction --no-progress --prefer-lowest
 
       - name: Validate lowest dependencies
         if: matrix.dependencies == 'lowest'

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,8 @@
         "phpunit/phpunit": "^9.5.21",
         "symfony/translation": "^6.0",
         "symfony/var-dumper": "^6.0",
-        "vimeo/psalm": "^4.30 || ^5.4"
+        "vimeo/psalm": "^4.30 || ^5.4",
+        "ramsey/uuid": "4.7"
     },
     "autoload-dev": {
         "psr-4": {

--- a/src/Internal/Marshaller/Type/UuidType.php
+++ b/src/Internal/Marshaller/Type/UuidType.php
@@ -18,13 +18,17 @@ use Temporal\Internal\Support\Inheritance;
 
 final class UuidType extends Type implements DetectableTypeInterface, RuleFactoryInterface
 {
+    private static ?bool $interfaceExists = null;
+
     public static function match(\ReflectionNamedType $type): bool
     {
-        if (!\interface_exists(UuidInterface::class)) {
-            return false;
+        if (self::$interfaceExists === null) {
+            self::$interfaceExists = \interface_exists(UuidInterface::class);
         }
 
-        return !$type->isBuiltin() && Inheritance::implements($type->getName(), UuidInterface::class);
+        return self::$interfaceExists &&
+            !$type->isBuiltin() &&
+            Inheritance::implements($type->getName(), UuidInterface::class);
     }
 
     public static function makeRule(\ReflectionProperty $property): ?MarshallingRule

--- a/src/Internal/Marshaller/Type/UuidType.php
+++ b/src/Internal/Marshaller/Type/UuidType.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Internal\Marshaller\Type;
+
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
+use Temporal\Internal\Marshaller\MarshallingRule;
+use Temporal\Internal\Support\Inheritance;
+
+final class UuidType extends Type implements DetectableTypeInterface, RuleFactoryInterface
+{
+    public static function match(\ReflectionNamedType $type): bool
+    {
+        return !$type->isBuiltin() && Inheritance::implements($type->getName(), UuidInterface::class);
+    }
+
+    public static function makeRule(\ReflectionProperty $property): ?MarshallingRule
+    {
+        $type = $property->getType();
+
+        if ($type->isBuiltin() || !Inheritance::implements($type->getName(), UuidInterface::class)) {
+            return null;
+        }
+
+        return $type->allowsNull()
+            ? new MarshallingRule(
+                $property->getName(),
+                NullableType::class,
+                new MarshallingRule(type: self::class, of: $type->getName()),
+            )
+            : new MarshallingRule($property->getName(), self::class, $type->getName());
+    }
+
+    /**
+     * @psalm-assert string $value
+     */
+    public function parse(mixed $value, mixed $current): UuidInterface
+    {
+        return Uuid::fromString($value);
+    }
+
+    /**
+     * @psalm-assert UuidInterface $value
+     */
+    public function serialize(mixed $value): string
+    {
+        return $value->toString();
+    }
+}

--- a/src/Internal/Marshaller/Type/UuidType.php
+++ b/src/Internal/Marshaller/Type/UuidType.php
@@ -20,6 +20,10 @@ final class UuidType extends Type implements DetectableTypeInterface, RuleFactor
 {
     public static function match(\ReflectionNamedType $type): bool
     {
+        if (!\interface_exists(UuidInterface::class)) {
+            return false;
+        }
+
         return !$type->isBuiltin() && Inheritance::implements($type->getName(), UuidInterface::class);
     }
 

--- a/src/Internal/Marshaller/TypeFactory.php
+++ b/src/Internal/Marshaller/TypeFactory.php
@@ -19,6 +19,7 @@ use Temporal\Internal\Marshaller\Type\EnumType;
 use Temporal\Internal\Marshaller\Type\ObjectType;
 use Temporal\Internal\Marshaller\Type\RuleFactoryInterface as TypeRuleFactoryInterface;
 use Temporal\Internal\Marshaller\Type\TypeInterface;
+use Temporal\Internal\Marshaller\Type\UuidType;
 
 /**
  * @psalm-type CallableTypeMatcher = \Closure(\ReflectionNamedType): ?string
@@ -141,6 +142,7 @@ class TypeFactory implements RuleFactoryInterface
 
         yield DateTimeType::class;
         yield DateIntervalType::class;
+        yield UuidType::class;
         yield ArrayType::class;
         yield ObjectType::class;
     }

--- a/tests/Unit/Internal/Marshaller/Fixture/PropertyType.php
+++ b/tests/Unit/Internal/Marshaller/Fixture/PropertyType.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\Internal\Marshaller\Fixture;
+
+use Ramsey\Uuid\UuidInterface;
+
+final class PropertyType
+{
+    public string $string;
+    public int $int;
+    public float $float;
+    public bool $bool;
+    public array $array;
+    public ?string $nullableString;
+    public ?int $nullableInt;
+    public ?float $nullableFloat;
+    public ?bool $nullableBool;
+    public ?array $nullableArray;
+    public UuidInterface $uuid;
+    public ?UuidInterface $nullableUuid;
+}

--- a/tests/Unit/Internal/Marshaller/Fixture/Uuid.php
+++ b/tests/Unit/Internal/Marshaller/Fixture/Uuid.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\Internal\Marshaller\Fixture;
+
+use Ramsey\Uuid\UuidInterface;
+
+final class Uuid
+{
+    public function __construct(
+        public UuidInterface $uuid,
+        public ?UuidInterface $nullableUuid = null
+    ) {
+    }
+}

--- a/tests/Unit/Internal/Marshaller/MarshallerTestCase.php
+++ b/tests/Unit/Internal/Marshaller/MarshallerTestCase.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Temporal\Tests\Unit\Internal\Marshaller;
 
 use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Rfc4122\UuidV4;
 use Spiral\Attributes\AttributeReader;
 use Temporal\Internal\Marshaller\Mapper\AttributeMapperFactory;
 use Temporal\Internal\Marshaller\Marshaller;
 use Temporal\Tests\Unit\Internal\Marshaller\Fixture\A;
 use Temporal\Tests\Unit\Internal\Marshaller\Fixture\B;
+use Temporal\Tests\Unit\Internal\Marshaller\Fixture\Uuid;
 
 /**
  * @internal
@@ -28,5 +30,55 @@ final class MarshallerTestCase extends TestCase
     {
         $marshaller = new Marshaller(new AttributeMapperFactory(new AttributeReader()));
         self::assertEquals(['x' => 'x', 'b' => ['code' => 'y', 'description' => null]], $marshaller->marshal(new A('x', new B('y'))));
+    }
+
+    public function testMarshalUuid(): void
+    {
+        $marshaller = new Marshaller(new AttributeMapperFactory(new AttributeReader()));
+
+        $this->assertSame(
+            ['uuid' => 'd1fb065d-f118-477d-a62a-ef93dc7ee03f', 'nullableUuid' => null],
+            $marshaller->marshal(new Uuid(UuidV4::fromString('d1fb065d-f118-477d-a62a-ef93dc7ee03f')))
+        );
+
+        $this->assertSame(
+            [
+                'uuid' => 'd1fb065d-f118-477d-a62a-ef93dc7ee03f',
+                'nullableUuid' => 'c4cf52f6-32ba-428c-ae7d-25aaa4057f5b'
+            ],
+            $marshaller->marshal(new Uuid(
+                UuidV4::fromString('d1fb065d-f118-477d-a62a-ef93dc7ee03f'),
+                UuidV4::fromString('c4cf52f6-32ba-428c-ae7d-25aaa4057f5b'),
+            ))
+        );
+    }
+
+    public function testUnmarshalUuid(): void
+    {
+        $marshaller = new Marshaller(new AttributeMapperFactory(new AttributeReader()));
+
+        $ref = new \ReflectionClass(Uuid::class);
+
+        $this->assertEquals(
+            new Uuid(UuidV4::fromString('d1fb065d-f118-477d-a62a-ef93dc7ee03f'), null),
+            $marshaller->unmarshal(
+                ['uuid' => 'd1fb065d-f118-477d-a62a-ef93dc7ee03f', 'nullableUuid' => null],
+                $ref->newInstanceWithoutConstructor()
+            )
+        );
+
+        $this->assertEquals(
+            new Uuid(
+                UuidV4::fromString('d1fb065d-f118-477d-a62a-ef93dc7ee03f'),
+                UuidV4::fromString('c4cf52f6-32ba-428c-ae7d-25aaa4057f5b'),
+            ),
+            $marshaller->unmarshal(
+                [
+                    'uuid' => 'd1fb065d-f118-477d-a62a-ef93dc7ee03f',
+                    'nullableUuid' => 'c4cf52f6-32ba-428c-ae7d-25aaa4057f5b'
+                ],
+                $ref->newInstanceWithoutConstructor()
+            )
+        );
     }
 }

--- a/tests/Unit/Internal/Marshaller/Type/UuidTypeTestCase.php
+++ b/tests/Unit/Internal/Marshaller/Type/UuidTypeTestCase.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\Internal\Marshaller\Type;
+
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
+use Spiral\Attributes\AttributeReader;
+use Temporal\Internal\Marshaller\Mapper\AttributeMapperFactory;
+use Temporal\Internal\Marshaller\Marshaller;
+use Temporal\Internal\Marshaller\MarshallingRule;
+use Temporal\Internal\Marshaller\Type\NullableType;
+use Temporal\Internal\Marshaller\Type\UuidType;
+use Temporal\Tests\Unit\Internal\Marshaller\Fixture\PropertyType;
+
+final class UuidTypeTestCase extends TestCase
+{
+    private Marshaller $marshaller;
+
+    protected function setUp(): void
+    {
+        $this->marshaller = new Marshaller(new AttributeMapperFactory(new AttributeReader()));
+    }
+
+    /**
+     * @dataProvider matchDataProvider
+     */
+    public function testMatch(string $property, bool $expected): void
+    {
+        $this->assertSame(
+            UuidType::match((new \ReflectionProperty(PropertyType::class, $property))->getType()),
+            $expected
+        );
+    }
+
+    /**
+     * @dataProvider makeRuleDataProvider
+     */
+    public function testMakeRule(string $property, mixed $expected): void
+    {
+        $this->assertEquals(
+            UuidType::makeRule(new \ReflectionProperty(PropertyType::class, $property)),
+            $expected
+        );
+    }
+
+    public function testParse(): void
+    {
+        $type = new UuidType($this->marshaller);
+
+        $this->assertEquals(
+            Uuid::fromString('d1fb065d-f118-477d-a62a-ef93dc7ee03f'),
+            $type->parse('d1fb065d-f118-477d-a62a-ef93dc7ee03f', null)
+        );
+    }
+
+    public function testSerialize(): void
+    {
+        $type = new UuidType($this->marshaller);
+
+        $this->assertEquals(
+            'd1fb065d-f118-477d-a62a-ef93dc7ee03f',
+            $type->serialize(Uuid::fromString('d1fb065d-f118-477d-a62a-ef93dc7ee03f'))
+        );
+    }
+
+    public static function matchDataProvider(): \Traversable
+    {
+        yield ['string', false];
+        yield ['int', false];
+        yield ['float', false];
+        yield ['bool', false];
+        yield ['array', false];
+        yield ['nullableString', false];
+        yield ['nullableInt', false];
+        yield ['nullableFloat', false];
+        yield ['nullableBool', false];
+        yield ['nullableArray', false];
+        yield ['uuid', true];
+        yield ['nullableUuid', true];
+    }
+
+    public static function makeRuleDataProvider(): \Traversable
+    {
+        yield ['string', null];
+        yield ['int', null];
+        yield ['float', null];
+        yield ['bool', null];
+        yield ['array', null];
+        yield ['nullableString', null];
+        yield ['nullableInt', null];
+        yield ['nullableFloat', null];
+        yield ['nullableBool', null];
+        yield ['nullableArray', null];
+        yield [
+            'uuid',
+            new MarshallingRule('uuid', UuidType::class, UuidInterface::class)
+        ];
+        yield [
+            'nullableUuid',
+            new MarshallingRule(
+                'nullableUuid',
+                NullableType::class,
+                new MarshallingRule(type: UuidType::class, of: UuidInterface::class),
+            )
+        ];
+    }
+}


### PR DESCRIPTION
## What was changed

Added new **Temporal\Internal\Marshaller\Type\UuidType**.

## Why?

This type allows the uuid to be used in classes that are serialized by the Marshaller.

## Checklist

- Fix #317
