### PR TITLE
Provide PHP-SDK version for RoadRunner and Temporal Server

### DIFF
--- a/src/Client/GRPC/Context.php
+++ b/src/Client/GRPC/Context.php
@@ -14,6 +14,7 @@ namespace Temporal\Client\GRPC;
 use Carbon\CarbonInterval;
 use Composer\InstalledVersions;
 use Temporal\Common\RetryOptions;
+use Temporal\Common\SdkVersion;
 use Temporal\Internal\Support\DateInterval;
 
 final class Context implements ContextInterface
@@ -32,14 +33,9 @@ final class Context implements ContextInterface
             ->withMaximumAttempts(0)
             ->withInitialInterval(CarbonInterval::millisecond(500));
 
-        $sdkVersion = '';
-        if (\preg_match('/^(\d++\.\d++\.\d++)/', InstalledVersions::getVersion('temporal/sdk') ?? '', $matches) === 1) {
-            $sdkVersion = $matches[1];
-        }
-
         $this->metadata = [
             'client-name' => ['temporal-php-2'],
-            'client-version' => [$sdkVersion],
+            'client-version' => [SdkVersion::getSdkVersion()],
         ];
     }
 

--- a/src/Client/GRPC/Context.php
+++ b/src/Client/GRPC/Context.php
@@ -19,8 +19,8 @@ use Temporal\Internal\Support\DateInterval;
 final class Context implements ContextInterface
 {
     private ?\DateTimeInterface $deadline = null;
-    private array $options;
-    private array $metadata = [];
+    private array $options = [];
+    private array $metadata;
     private RetryOptions $retryOptions;
 
     /**
@@ -32,9 +32,14 @@ final class Context implements ContextInterface
             ->withMaximumAttempts(0)
             ->withInitialInterval(CarbonInterval::millisecond(500));
 
-        $this->options = [
-            'client-name' => 'temporal-php',
-            'client-version' => InstalledVersions::getVersion('temporal/sdk'),
+        $sdkVersion = '';
+        if (\preg_match('/^(\d++\.\d++\.\d++)/', InstalledVersions::getVersion('temporal/sdk') ?? '', $matches) === 1) {
+            $sdkVersion = $matches[1];
+        }
+
+        $this->metadata = [
+            'client-name' => ['temporal-php-2'],
+            'client-version' => [$sdkVersion],
         ];
     }
 

--- a/src/Common/SdkVersion.php
+++ b/src/Common/SdkVersion.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Common;
+
+use Composer\InstalledVersions;
+
+final class SdkVersion
+{
+    public const VERSION_REGX = '/^(\d++\.\d++\.\d++(?:-[\\w\\-.]+)?)/';
+    public const PACKAGE_NAME = 'temporal/sdk';
+
+    public static function getSdkVersion(): string
+    {
+        $version = InstalledVersions::getVersion(SdkVersion::PACKAGE_NAME);
+
+        if ($version === null || \preg_match(self::VERSION_REGX, $version, $matches) !== 1) {
+            return '';
+        }
+
+        return $matches[1];
+    }
+}

--- a/src/Common/SdkVersion.php
+++ b/src/Common/SdkVersion.php
@@ -13,12 +13,17 @@ final class SdkVersion
 
     public static function getSdkVersion(): string
     {
+        static $cache = null;
+        if ($cache !== null) {
+            return $cache;
+        }
+
         $version = InstalledVersions::getVersion(SdkVersion::PACKAGE_NAME);
 
         if ($version === null || \preg_match(self::VERSION_REGX, $version, $matches) !== 1) {
-            return '';
+            return $cache = '';
         }
 
-        return $matches[1];
+        return $cache = $matches[1];
     }
 }

--- a/src/Internal/Transport/Router/GetWorkerInfo.php
+++ b/src/Internal/Transport/Router/GetWorkerInfo.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Temporal\Internal\Transport\Router;
 
+use Composer\InstalledVersions;
 use React\Promise\Deferred;
 use Temporal\DataConverter\EncodedValues;
 use Temporal\Internal\Declaration\Prototype\ActivityPrototype;
@@ -74,11 +75,17 @@ final class GetWorkerInfo extends Route
             'Name' => $activity->getID(),
         ];
 
+        $sdkVersion = '';
+        if (\preg_match('/^(\d++\.\d++\.\d++)/', InstalledVersions::getVersion('temporal/sdk') ?? '', $matches) !== 1) {
+            $sdkVersion = $matches[1];
+        }
+
         return [
             'TaskQueue'  => $worker->getID(),
             'Options'    => $this->marshaller->marshal($worker->getOptions()),
             'Workflows'  => $this->map($worker->getWorkflows(), $workflowMap),
             'Activities' => $this->map($worker->getActivities(), $activityMap),
+            'php_sdk_version' => $sdkVersion,
         ];
     }
 

--- a/src/Internal/Transport/Router/GetWorkerInfo.php
+++ b/src/Internal/Transport/Router/GetWorkerInfo.php
@@ -76,7 +76,7 @@ final class GetWorkerInfo extends Route
         ];
 
         $sdkVersion = '';
-        if (\preg_match('/^(\d++\.\d++\.\d++)/', InstalledVersions::getVersion('temporal/sdk') ?? '', $matches) !== 1) {
+        if (\preg_match('/^(\d++\.\d++\.\d++)/', InstalledVersions::getVersion('temporal/sdk') ?? '', $matches) === 1) {
             $sdkVersion = $matches[1];
         }
 

--- a/src/Internal/Transport/Router/GetWorkerInfo.php
+++ b/src/Internal/Transport/Router/GetWorkerInfo.php
@@ -13,6 +13,7 @@ namespace Temporal\Internal\Transport\Router;
 
 use Composer\InstalledVersions;
 use React\Promise\Deferred;
+use Temporal\Common\SdkVersion;
 use Temporal\DataConverter\EncodedValues;
 use Temporal\Internal\Declaration\Prototype\ActivityPrototype;
 use Temporal\Internal\Declaration\Prototype\WorkflowPrototype;
@@ -75,17 +76,12 @@ final class GetWorkerInfo extends Route
             'Name' => $activity->getID(),
         ];
 
-        $sdkVersion = '';
-        if (\preg_match('/^(\d++\.\d++\.\d++)/', InstalledVersions::getVersion('temporal/sdk') ?? '', $matches) === 1) {
-            $sdkVersion = $matches[1];
-        }
-
         return [
             'TaskQueue'  => $worker->getID(),
             'Options'    => $this->marshaller->marshal($worker->getOptions()),
             'Workflows'  => $this->map($worker->getWorkflows(), $workflowMap),
             'Activities' => $this->map($worker->getActivities(), $activityMap),
-            'PhpSdkVersion' => $sdkVersion,
+            'PhpSdkVersion' => SdkVersion::getSdkVersion(),
         ];
     }
 

--- a/src/Internal/Transport/Router/GetWorkerInfo.php
+++ b/src/Internal/Transport/Router/GetWorkerInfo.php
@@ -85,7 +85,7 @@ final class GetWorkerInfo extends Route
             'Options'    => $this->marshaller->marshal($worker->getOptions()),
             'Workflows'  => $this->map($worker->getWorkflows(), $workflowMap),
             'Activities' => $this->map($worker->getActivities(), $activityMap),
-            'php_sdk_version' => $sdkVersion,
+            'PhpSdkVersion' => $sdkVersion,
         ];
     }
 

--- a/tests/Unit/Common/SdkVersionTest.php
+++ b/tests/Unit/Common/SdkVersionTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Temporal\Tests\Unit\Common;
+
+use PHPUnit\Framework\TestCase;
+use Temporal\Common\SdkVersion;
+
+class SdkVersionTest extends TestCase
+{
+    /**
+     * @dataProvider versionProvider
+     */
+    public function testVersionRegx(string $version, string $matched): void
+    {
+        $result = preg_match(SdkVersion::VERSION_REGX, $version, $matches);
+        if ($matched === '') {
+            $this->assertNotSame(1, $result);
+        } else {
+            $this->assertEquals($matched, $matches[1]);
+        }
+    }
+
+    public function versionProvider(): iterable
+    {
+        return [
+            ['dev-master', ''],
+            ['1.2.3-x-dev', '1.2.3-x-dev'],
+            ['1.2.3-beta', '1.2.3-beta'],
+            ['1.2.3-beta-1', '1.2.3-beta-1'],
+            ['1.2.3-beta.1', '1.2.3-beta.1'],
+            ['1.2.3-valhalla', '1.2.3-valhalla'],
+            ['1.foo', ''],
+            ['feature/interceptors', ''],
+        ];
+    }
+}

--- a/tests/Unit/Common/SdkVersionTest.php
+++ b/tests/Unit/Common/SdkVersionTest.php
@@ -23,12 +23,14 @@ class SdkVersionTest extends TestCase
     public function versionProvider(): iterable
     {
         return [
-            ['dev-master', ''],
+            ['1.2.3.0', '1.2.3'],
+            ['1.2.3', '1.2.3'],
             ['1.2.3-x-dev', '1.2.3-x-dev'],
             ['1.2.3-beta', '1.2.3-beta'],
             ['1.2.3-beta-1', '1.2.3-beta-1'],
             ['1.2.3-beta.1', '1.2.3-beta.1'],
             ['1.2.3-valhalla', '1.2.3-valhalla'],
+            ['dev-master', ''],
             ['1.foo', ''],
             ['feature/interceptors', ''],
         ];


### PR DESCRIPTION
## What was changed

PHP SDK now sends its version in each client request correctly - in the request context.
Context fields are:

```
client-name = temporal-php-2
client-version = 2.5.2
```

The client name is changed to `temporal-php-2`, because Temporal Server [doesn't support `temporal-php` client of >= 2.0.0 version](https://github.com/temporalio/temporal/blob/1ca6979915406eaced06c05458380e38e19e2a28/common/headers/version_checker.go#L70C13-L70C13).

For `dev-master` empty string will be sent as a version.
For `2.6.3-beta`, `2.6.3-beta.1`, `2.6.3-beta-1` or `2.6.3-x-dev` the full version will be sent.

The same version rules are applied to the version that sent to RoadRunner.


## Why?

https://github.com/temporalio/roadrunner-temporal/pull/387/

## Checklist

How was this tested: manually
