### PR TITLE
Fix stdClasses unmarshalling

### DIFF
--- a/src/Internal/Marshaller/Marshaller.php
+++ b/src/Internal/Marshaller/Marshaller.php
@@ -70,8 +70,17 @@ class Marshaller implements MarshallerInterface
      */
     public function unmarshal(array $from, object $to): object
     {
-        $mapper = $this->getMapper(\get_class($to));
+        $class = $to::class;
 
+        if ($class === \stdClass::class) {
+            foreach ($from as $key => $value) {
+                $to->{$key} = $value;
+            }
+
+            return $to;
+        }
+
+        $mapper = $this->getMapper($class);
         $result = $mapper->isCopyOnWrite() ? clone $to : $to;
 
         foreach ($mapper->getSetters() as $field => $setter) {

--- a/tests/Unit/DTO/Type/ObjectType/ObjectTypeTestCase.php
+++ b/tests/Unit/DTO/Type/ObjectType/ObjectTypeTestCase.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Temporal\Tests\Unit\DTO\Type\ObjectType;
 
 use ReflectionClass;
+use stdClass;
 use Temporal\Internal\Marshaller\Type\ObjectType;
 use Temporal\Tests\Unit\DTO\Type\ObjectType\Stub\ChildDto;
 use Temporal\Tests\Unit\DTO\Type\ObjectType\Stub\Nested1;
@@ -21,6 +22,7 @@ use Temporal\Tests\Unit\DTO\Type\ObjectType\Stub\NestedParent;
 use Temporal\Tests\Unit\DTO\Type\ObjectType\Stub\ParentDto;
 use Temporal\Tests\Unit\DTO\DTOMarshallingTestCase;
 use Temporal\Tests\Unit\DTO\Type\ObjectType\Stub\ReadonlyProperty;
+use Temporal\Tests\Unit\DTO\Type\ObjectType\Stub\StdClassObjectProp;
 
 final class ObjectTypeTestCase extends DTOMarshallingTestCase
 {
@@ -58,6 +60,32 @@ final class ObjectTypeTestCase extends DTOMarshallingTestCase
         $result = $this->marshal($dto);
 
         $this->assertEquals(['child' => ['foo' => 'foo']], $result);
+    }
+
+    public function testStdClassParamUnmarshal(): void
+    {
+        $dto = $this->unmarshal([
+            'object' => ['foo' => 'bar'],
+            'class' => ['foo' => 'bar'],
+        ], (new ReflectionClass(StdClassObjectProp::class))->newInstanceWithoutConstructor());
+
+        self::assertEquals(new StdClassObjectProp(
+            (object)['foo' => 'bar'],
+            (object)['foo' => 'bar'],
+        ), $dto);
+    }
+
+    public function testStdClassUnmarshal(): void
+    {
+        $dto = $this->unmarshal([
+            'object' => ['foo' => 'bar'],
+            'class' => ['foo' => 'bar'],
+        ], new stdClass());
+
+        self::assertEquals((object)[
+            'object' => ['foo' => 'bar'],
+            'class' => ['foo' => 'bar'],
+        ], $dto);
     }
 
     /**

--- a/tests/Unit/DTO/Type/ObjectType/Stub/StdClassObjectProp.php
+++ b/tests/Unit/DTO/Type/ObjectType/Stub/StdClassObjectProp.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\DTO\Type\ObjectType\Stub;
+
+use stdClass;
+
+final class StdClassObjectProp
+{
+    public function __construct(
+        public object $object,
+        public stdClass $class,
+    ) {
+    }
+}


### PR DESCRIPTION
## What was changed

The Marshaller will now hydrate a stdClass object without any mappers because it's impossible to get setters for stdClass.
ObjectType now detects the `object` type and works with it. Also made a special way to make and hydrate stdClass there.

## Checklist

1. Closes #199
2. How was this tested: manually; added autotests
3. Any docs updates needed? Actually no.
