### PR TITLE
[Fix] PHP 8.2 types (null, false, true)

### DIFF
--- a/src/DataConverter/DataConverter.php
+++ b/src/DataConverter/DataConverter.php
@@ -46,8 +46,12 @@ final class DataConverter implements DataConverterInterface
         }
 
         $type = Type::create($type);
-        if ($type->getName() === Type::TYPE_VOID) {
-            return null;
+        if (\in_array($type->getName(),  [Type::TYPE_VOID, Type::TYPE_NULL, Type::TYPE_FALSE, Type::TYPE_TRUE], true)) {
+            return match($type->getName()) {
+                Type::TYPE_VOID, Type::TYPE_NULL => null,
+                Type::TYPE_TRUE => true,
+                Type::TYPE_FALSE => false,
+            };
         }
 
         return $this->converters[$encoding]->fromPayload($payload, $type);

--- a/src/DataConverter/Type.php
+++ b/src/DataConverter/Type.php
@@ -26,6 +26,9 @@ final class Type
     public const TYPE_INT       = 'int';
     public const TYPE_FLOAT     = 'float';
     public const TYPE_VOID      = 'void';
+    public const TYPE_NULL      = 'null';
+    public const TYPE_TRUE      = 'true';
+    public const TYPE_FALSE     = 'false';
 
     /**
      * @var string
@@ -46,7 +49,7 @@ final class Type
         $this->name = $name;
 
         $this->allowsNull = $allowsNull ?? (
-            $name === self::TYPE_ANY || $name === self::TYPE_VOID
+            $name === self::TYPE_ANY || $name === self::TYPE_VOID || $name === self::TYPE_NULL
         );
     }
 

--- a/tests/Fixtures/src/Activity/Php82TypesActivity.php
+++ b/tests/Fixtures/src/Activity/Php82TypesActivity.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Activity;
+
+use Temporal\Activity\ActivityInterface;
+use Temporal\Activity\ActivityMethod;
+
+#[ActivityInterface(prefix: "Php82.")]
+class Php82TypesActivity
+{
+    #[ActivityMethod]
+    public function returnNull(null $value): null
+    {
+        return $value;
+    }
+
+    #[ActivityMethod]
+    public function returnTrue(true $value): true
+    {
+        return $value;
+    }
+
+    #[ActivityMethod]
+    public function returnFalse(false $value): false
+    {
+        return $value;
+    }
+}

--- a/tests/Fixtures/src/Activity/Php82TypesActivity.php
+++ b/tests/Fixtures/src/Activity/Php82TypesActivity.php
@@ -13,7 +13,8 @@ namespace Temporal\Tests\Activity;
 
 use Temporal\Activity\ActivityInterface;
 use Temporal\Activity\ActivityMethod;
-
+/*
+todo: uncomment this with min php 8.2 requirement or when we can skip activities loading depending on php version
 #[ActivityInterface(prefix: "Php82.")]
 class Php82TypesActivity
 {
@@ -34,4 +35,4 @@ class Php82TypesActivity
     {
         return $value;
     }
-}
+}*/

--- a/tests/Fixtures/src/Workflow/Php82TypesWorkflow.php
+++ b/tests/Fixtures/src/Workflow/Php82TypesWorkflow.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Workflow;
+
+use Temporal\Activity\ActivityOptions;
+use Temporal\Common\RetryOptions;
+use Temporal\Tests\Activity\Php82TypesActivity;
+use Temporal\Workflow;
+use Temporal\Workflow\WorkflowMethod;
+
+#[Workflow\WorkflowInterface]
+class Php82TypesWorkflow
+{
+    #[WorkflowMethod(name: 'Php82TypesWorkflow')]
+    public function handler(): iterable
+    {
+        $simple = Workflow::newActivityStub(
+            Php82TypesActivity::class,
+            ActivityOptions::new()
+                ->withStartToCloseTimeout(5)
+                ->withRetryOptions(
+                    RetryOptions::new()->withMaximumAttempts(2),
+                ),
+        );
+
+        return [
+            yield $simple->returnNull(null),
+            yield $simple->returnTrue(true),
+            yield $simple->returnFalse(false),
+        ];
+    }
+}

--- a/tests/Functional/Client/TypedStubTestCase.php
+++ b/tests/Functional/Client/TypedStubTestCase.php
@@ -17,6 +17,7 @@ use Temporal\Tests\DTO\User;
 use Temporal\Tests\Unit\Declaration\Fixture\WorkflowWithoutHandler;
 use Temporal\Tests\Workflow\ActivityReturnTypeWorkflow;
 use Temporal\Tests\Workflow\GeneratorWorkflow;
+use Temporal\Tests\Workflow\Php82TypesWorkflow;
 use Temporal\Tests\Workflow\QueryWorkflow;
 use Temporal\Tests\Workflow\SignalledWorkflowReusable;
 use Temporal\Tests\Workflow\SignalledWorkflowWithInheritance;
@@ -158,5 +159,19 @@ class TypedStubTestCase extends ClientTestCase
 
         $result = $workflowRun->getResult();
         $this->assertEquals(['test1'], $result);
+    }
+
+    /**
+     * @requires PHP >= 8.2
+     */
+    public function testPhp82Types(): void
+    {
+        $client = $this->createClient();
+
+        $workflow = $client->newWorkflowStub(Php82TypesWorkflow::class);
+        $workflowRun = $client->start($workflow);
+        $result = $workflowRun->getResult();
+
+        $this->assertSame([null, true, false], $result);
     }
 }

--- a/tests/Functional/Client/TypedStubTestCase.php
+++ b/tests/Functional/Client/TypedStubTestCase.php
@@ -163,15 +163,16 @@ class TypedStubTestCase extends ClientTestCase
 
     /**
      * @requires PHP >= 8.2
+     * todo: uncomment this with min php 8.2 requirement or when we can skip activities loading depending on php version
      */
-    public function testPhp82Types(): void
-    {
-        $client = $this->createClient();
-
-        $workflow = $client->newWorkflowStub(Php82TypesWorkflow::class);
-        $workflowRun = $client->start($workflow);
-        $result = $workflowRun->getResult();
-
-        $this->assertSame([null, true, false], $result);
-    }
+    // public function testPhp82Types(): void
+    // {
+    //     $client = $this->createClient();
+    //
+    //     $workflow = $client->newWorkflowStub(Php82TypesWorkflow::class);
+    //     $workflowRun = $client->start($workflow);
+    //     $result = $workflowRun->getResult();
+    //
+    //     $this->assertSame([null, true, false], $result);
+    // }
 }

--- a/tests/Unit/DataConverter/DataConverterTestCase.php
+++ b/tests/Unit/DataConverter/DataConverterTestCase.php
@@ -37,6 +37,9 @@ class DataConverterTestCase extends UnitTestCase
             Type::TYPE_VOID . ' => ' . Type::TYPE_ANY   => [Type::TYPE_ANY, null],
             Type::TYPE_ARRAY . ' => ' . Type::TYPE_ANY  => [Type::TYPE_ANY, []],
             Type::TYPE_OBJECT . ' => ' . Type::TYPE_ANY => [Type::TYPE_ANY, (object)[]],
+            Type::TYPE_NULL . ' => ' . Type::TYPE_ANY   => [Type::TYPE_ANY, null],
+            Type::TYPE_TRUE . ' => ' . Type::TYPE_ANY   => [Type::TYPE_ANY, true],
+            Type::TYPE_FALSE . ' => ' . Type::TYPE_ANY  => [Type::TYPE_ANY, false],
 
             Type::TYPE_ARRAY  => [Type::TYPE_ARRAY, [1, 2, 3]],
             Type::TYPE_OBJECT => [Type::TYPE_OBJECT, (object)['field' => 'value']],
@@ -45,6 +48,9 @@ class DataConverterTestCase extends UnitTestCase
             Type::TYPE_INT    => [Type::TYPE_INT, 42],
             Type::TYPE_FLOAT  => [Type::TYPE_FLOAT, 0.1],
             Type::TYPE_VOID   => [Type::TYPE_VOID, null],
+            Type::TYPE_NULL   => [Type::TYPE_NULL, null],
+            Type::TYPE_TRUE   => [Type::TYPE_TRUE, true],
+            Type::TYPE_FALSE  => [Type::TYPE_FALSE, false],
 
             Type::TYPE_ARRAY . ' (associative)  => ' . Type::TYPE_ARRAY => [Type::TYPE_ARRAY, ['field' => 'value']],
         ];
@@ -60,7 +66,8 @@ class DataConverterTestCase extends UnitTestCase
             Type::TYPE_ARRAY . ' => ' . Type::TYPE_STRING  => [Type::TYPE_STRING, [1, 2, 3]],
             Type::TYPE_FLOAT . ' => ' . Type::TYPE_STRING  => [Type::TYPE_STRING, .42],
             Type::TYPE_INT . ' => ' . Type::TYPE_STRING    => [Type::TYPE_STRING, 42],
-            Type::TYPE_BOOL . ' => ' . Type::TYPE_STRING   => [Type::TYPE_STRING, true],
+            Type::TYPE_TRUE . ' => ' . Type::TYPE_STRING   => [Type::TYPE_STRING, true],
+            Type::TYPE_FALSE . ' => ' . Type::TYPE_STRING  => [Type::TYPE_STRING, false],
             Type::TYPE_VOID . ' => ' . Type::TYPE_STRING   => [Type::TYPE_STRING, null],
 
             Type::TYPE_OBJECT . ' => ' . Type::TYPE_BOOL => [Type::TYPE_BOOL, (object)['field' => 'value']],
@@ -74,14 +81,16 @@ class DataConverterTestCase extends UnitTestCase
             Type::TYPE_ARRAY . ' => ' . Type::TYPE_INT  => [Type::TYPE_INT, [1, 2, 3]],
             Type::TYPE_FLOAT . ' => ' . Type::TYPE_INT  => [Type::TYPE_INT, .42],
             Type::TYPE_STRING . ' => ' . Type::TYPE_INT => [Type::TYPE_INT, 'string'],
-            Type::TYPE_BOOL . ' => ' . Type::TYPE_INT   => [Type::TYPE_INT, true],
+            Type::TYPE_TRUE . ' => ' . Type::TYPE_INT   => [Type::TYPE_INT, true],
+            Type::TYPE_FALSE . ' => ' . Type::TYPE_INT  => [Type::TYPE_INT, false],
             Type::TYPE_VOID . ' => ' . Type::TYPE_INT   => [Type::TYPE_INT, null],
 
             Type::TYPE_OBJECT . ' => ' . Type::TYPE_FLOAT => [Type::TYPE_FLOAT, (object)['field' => 'value']],
             Type::TYPE_ARRAY . ' => ' . Type::TYPE_FLOAT  => [Type::TYPE_FLOAT, [1, 2, 3]],
             Type::TYPE_INT . ' => ' . Type::TYPE_FLOAT    => [Type::TYPE_FLOAT, 42],
             Type::TYPE_STRING . ' => ' . Type::TYPE_FLOAT => [Type::TYPE_FLOAT, 'string'],
-            Type::TYPE_BOOL . ' => ' . Type::TYPE_FLOAT   => [Type::TYPE_FLOAT, true],
+            Type::TYPE_TRUE . ' => ' . Type::TYPE_FLOAT   => [Type::TYPE_FLOAT, true],
+            Type::TYPE_FALSE . ' => ' . Type::TYPE_FLOAT  => [Type::TYPE_FLOAT, false],
             Type::TYPE_VOID . ' => ' . Type::TYPE_FLOAT   => [Type::TYPE_FLOAT, null],
 
             Type::TYPE_ARRAY . ' => ' . Type::TYPE_OBJECT  => [Type::TYPE_OBJECT, [1, 2, 3]],
@@ -90,11 +99,14 @@ class DataConverterTestCase extends UnitTestCase
             Type::TYPE_STRING . ' => ' . Type::TYPE_OBJECT => [Type::TYPE_OBJECT, 'string'],
             Type::TYPE_BOOL . ' => ' . Type::TYPE_OBJECT   => [Type::TYPE_OBJECT, true],
             Type::TYPE_VOID . ' => ' . Type::TYPE_OBJECT   => [Type::TYPE_OBJECT, null],
+            Type::TYPE_TRUE . ' => ' . Type::TYPE_OBJECT   => [Type::TYPE_OBJECT, true],
+            Type::TYPE_FALSE . ' => ' . Type::TYPE_OBJECT  => [Type::TYPE_OBJECT, false],
 
             Type::TYPE_FLOAT . ' => ' . Type::TYPE_ARRAY  => [Type::TYPE_ARRAY, .42],
             Type::TYPE_INT . ' => ' . Type::TYPE_ARRAY    => [Type::TYPE_ARRAY, 42],
             Type::TYPE_STRING . ' => ' . Type::TYPE_ARRAY => [Type::TYPE_ARRAY, 'string'],
-            Type::TYPE_BOOL . ' => ' . Type::TYPE_ARRAY   => [Type::TYPE_ARRAY, true],
+            Type::TYPE_TRUE . ' => ' . Type::TYPE_ARRAY   => [Type::TYPE_ARRAY, true],
+            Type::TYPE_FALSE . ' => ' . Type::TYPE_ARRAY  => [Type::TYPE_ARRAY, false],
             Type::TYPE_VOID . ' => ' . Type::TYPE_ARRAY   => [Type::TYPE_ARRAY, null],
         ];
     }
@@ -111,7 +123,8 @@ class DataConverterTestCase extends UnitTestCase
             Type::TYPE_FLOAT . ' => ' . Type::TYPE_VOID  => [Type::TYPE_VOID, .42],
             Type::TYPE_INT . ' => ' . Type::TYPE_VOID    => [Type::TYPE_VOID, 42],
             Type::TYPE_STRING . ' => ' . Type::TYPE_VOID => [Type::TYPE_VOID, 'string'],
-            Type::TYPE_BOOL . ' => ' . Type::TYPE_VOID   => [Type::TYPE_VOID, true],
+            Type::TYPE_TRUE . ' => ' . Type::TYPE_VOID   => [Type::TYPE_VOID, true],
+            Type::TYPE_FALSE . ' => ' . Type::TYPE_VOID   => [Type::TYPE_VOID, false],
         ];
     }
 


### PR DESCRIPTION
## What was changed

Added `null`, `false`, `true` types in the `DataConverter`

## Why?

Since PHP 8.2 it is possible to use standalone `true`, `false` and `null`:
https://wiki.php.net/rfc/null-false-standalone-types
https://wiki.php.net/rfc/true-type

We need to support.

I think it's not a new feature an we can release it as a fix.

## Checklist

- Closes #328 
- How was this tested:
  - added Unit tests and Functional tests
  - Functional tests were commented because they break testing with PH <8.2
- Any docs updates needed? no