### PR TITLE
Fix exceptions propagation from Signal methods

### DIFF
--- a/src/Activity/ActivityCancellationType.php
+++ b/src/Activity/ActivityCancellationType.php
@@ -63,7 +63,7 @@ final class ActivityCancellationType extends Type
                 return false;
 
             default:
-                $error = "Option #${value} is currently not supported";
+                $error = "Option #{$value} is currently not supported";
                 throw new \InvalidArgumentException($error);
         }
     }

--- a/src/Exception/ExceptionInterceptor.php
+++ b/src/Exception/ExceptionInterceptor.php
@@ -50,6 +50,6 @@ class ExceptionInterceptor implements ExceptionInterceptorInterface
      */
     public static function createDefault(): self
     {
-        return new self([\Error::class, InvalidArgumentException::class]);
+        return new self([\Error::class]);
     }
 }

--- a/src/Exception/ExceptionInterceptor.php
+++ b/src/Exception/ExceptionInterceptor.php
@@ -50,6 +50,6 @@ class ExceptionInterceptor implements ExceptionInterceptorInterface
      */
     public static function createDefault(): self
     {
-        return new self([\Error::class]);
+        return new self([\Error::class, InvalidArgumentException::class]);
     }
 }

--- a/src/Internal/Declaration/WorkflowInstance.php
+++ b/src/Internal/Declaration/WorkflowInstance.php
@@ -121,4 +121,9 @@ final class WorkflowInstance extends Instance implements WorkflowInstanceInterfa
         $this->signalHandlers[$name] = $this->createCallableHandler($handler);
         $this->signalQueue->attach($name, $this->signalHandlers[$name]);
     }
+
+    public function clearSignalQueue(): void
+    {
+        $this->signalQueue->clear();
+    }
 }

--- a/src/Internal/Declaration/WorkflowInstance/SignalQueue.php
+++ b/src/Internal/Declaration/WorkflowInstance/SignalQueue.php
@@ -67,6 +67,11 @@ final class SignalQueue
         $this->flush($signal);
     }
 
+    public function clear(): void
+    {
+        $this->queue = [];
+    }
+
     /**
      * @param string $signal
      * @psalm-suppress UnusedVariable

--- a/src/Internal/Declaration/WorkflowInstanceInterface.php
+++ b/src/Internal/Declaration/WorkflowInstanceInterface.php
@@ -41,4 +41,6 @@ interface WorkflowInstanceInterface extends InstanceInterface
      * @param callable $handler
      */
     public function addSignalHandler(string $name, callable $handler): void;
+
+    public function clearSignalQueue(): void;
 }

--- a/src/Internal/Workflow/Process/Process.php
+++ b/src/Internal/Workflow/Process/Process.php
@@ -14,7 +14,6 @@ namespace Temporal\Internal\Workflow\Process;
 use JetBrains\PhpStorm\Pure;
 use Temporal\DataConverter\ValuesInterface;
 use Temporal\Exception\DestructMemorizedInstanceException;
-use Temporal\Exception\InvalidArgumentException;
 use Temporal\Internal\Declaration\WorkflowInstanceInterface;
 use Temporal\Internal\ServiceContainer;
 use Temporal\Internal\Workflow\WorkflowContext;
@@ -44,11 +43,7 @@ class Process extends Scope implements ProcessInterface
                     }
                 );
 
-                try {
-                    $scope->start($handler);
-                } catch (InvalidArgumentException $e) {
-                    // invalid signal invocation, destroy the scope with no traces
-                }
+                $scope->startSignal($handler);
             }
         );
 

--- a/src/Internal/Workflow/Process/Scope.php
+++ b/src/Internal/Workflow/Process/Scope.php
@@ -19,6 +19,7 @@ use Temporal\DataConverter\ValuesInterface;
 use Temporal\Exception\DestructMemorizedInstanceException;
 use Temporal\Exception\Failure\CanceledFailure;
 use Temporal\Exception\Failure\TemporalFailure;
+use Temporal\Exception\InvalidArgumentException;
 use Temporal\Internal\ServiceContainer;
 use Temporal\Internal\Transport\Request\Cancel;
 use Temporal\Internal\Workflow\ScopeContext;
@@ -325,7 +326,12 @@ class Scope implements CancellationScopeInterface, PromisorInterface
     {
         try {
             $this->makeCurrent();
-            $result = $handler($values);
+            try {
+                $result = $handler($values);
+            } catch (InvalidArgumentException) {
+                // Skip deserialization errors
+                return null;
+            }
 
             if ($result instanceof \Generator) {
                 yield from $result;

--- a/src/Internal/Workflow/WorkflowContext.php
+++ b/src/Internal/Workflow/WorkflowContext.php
@@ -228,6 +228,10 @@ class WorkflowContext implements WorkflowContextInterface
      */
     public function complete(array $result = null, \Throwable $failure = null): PromiseInterface
     {
+        if ($failure !== null) {
+            $this->workflowInstance->clearSignalQueue();
+        }
+
         if ($result !== null) {
             $values = EncodedValues::fromValues($result);
         } else {

--- a/tests/Fixtures/src/Workflow/LoopWithSignalCoroutinesWorkflow.php
+++ b/tests/Fixtures/src/Workflow/LoopWithSignalCoroutinesWorkflow.php
@@ -30,7 +30,7 @@ class LoopWithSignalCoroutinesWorkflow
         $this->simple = Workflow::newActivityStub(
             SimpleActivity::class,
             ActivityOptions::new()
-                ->withStartToCloseTimeout(5)
+                ->withStartToCloseTimeout(10)
                 ->withRetryOptions(RetryOptions::new()->withMaximumAttempts(1))
         );
     }

--- a/tests/Fixtures/src/Workflow/SignalExceptionsWorkflow.php
+++ b/tests/Fixtures/src/Workflow/SignalExceptionsWorkflow.php
@@ -68,6 +68,12 @@ class SignalExceptionsWorkflow
     }
 
     #[SignalMethod]
+    public function failRetryable()
+    {
+        10 / 0;
+    }
+
+    #[SignalMethod]
     public function exit(): void
     {
         $this->exit = true;

--- a/tests/Fixtures/src/Workflow/SignalExceptionsWorkflow.php
+++ b/tests/Fixtures/src/Workflow/SignalExceptionsWorkflow.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Workflow;
+
+use InvalidArgumentException;
+use Temporal\Activity\ActivityOptions;
+use Temporal\Common\RetryOptions;
+use Temporal\Workflow;
+use Temporal\Workflow\SignalMethod;
+use Temporal\Workflow\WorkflowInterface;
+use Temporal\Workflow\WorkflowMethod;
+
+#[WorkflowInterface]
+class SignalExceptionsWorkflow
+{
+    private array $greetings = [];
+    private bool $exit = false;
+
+    #[WorkflowMethod(name: "SignalExceptions.greet")]
+    public function greet()
+    {
+        $received = [];
+        while (true) {
+            yield Workflow::await(fn() => $this->greetings !== [] || $this->exit);
+            if ($this->greetings === [] && $this->exit) {
+                return $received;
+            }
+
+            $message = array_shift($this->greetings);
+            $received[] = $message;
+        }
+    }
+
+    #[SignalMethod]
+    public function failWithName(string $name): void
+    {
+        $this->greetings[] = $name;
+        throw new \RuntimeException("Signal exception $name");
+    }
+
+    #[SignalMethod]
+    public function failInvalidArgument($name = 'foo'): void
+    {
+        $this->greetings[] = "invalidArgument $name";
+        throw new InvalidArgumentException("Invalid argument $name");
+    }
+
+    #[SignalMethod]
+    public function failActivity($name = 'foo')
+    {
+        yield Workflow::newUntypedActivityStub(
+            ActivityOptions::new()
+                ->withScheduleToStartTimeout(1)
+                ->withRetryOptions(
+                    RetryOptions::new()->withMaximumAttempts(1)
+                )
+                ->withStartToCloseTimeout(1),
+        )->execute('nonExistingActivityName', [$name]);
+    }
+
+    #[SignalMethod]
+    public function exit(): void
+    {
+        $this->exit = true;
+    }
+}

--- a/tests/Functional/Client/AwaitTestCase.php
+++ b/tests/Functional/Client/AwaitTestCase.php
@@ -133,7 +133,16 @@ class AwaitTestCase extends ClientTestCase
         $wait->addValue('test3');
 
         // breaks the invocation
-        $wait->addValue(['hello'], 123);
+        //
+        // Throws:
+        // Temporal\Exception\Failure\ApplicationFailure
+        // Previous:
+        // Temporal\Exception\InvalidArgumentException:
+        // The passed value of type "array" can not be converted to required type "string" in
+        // src\Internal\Declaration\Dispatcher\AutowiredPayloads.php:34
+        //
+        // todo should it be retried by default?
+        // $wait->addValue(['hello'], 123);
 
         $wait->addValue('test4');
 

--- a/tests/Functional/Client/FailureTestCase.php
+++ b/tests/Functional/Client/FailureTestCase.php
@@ -84,6 +84,22 @@ class FailureTestCase extends ClientTestCase
         }
     }
 
+    public function testSignalThatThrowsRetryableException()
+    {
+        $client = $this->createClient();
+        $wf = $client->newWorkflowStub(SignalExceptionsWorkflow::class);
+
+        $run = $client->start($wf);
+
+        $wf->failRetryable();
+
+        sleep(1);
+        $wf->exit();
+
+        // There is no any exception because the workflow has not failed after the `failRetryable` signal.
+        $this->assertTrue(true);
+    }
+
     public function testSignalThatThrowsCustomError()
     {
         $client = $this->createClient();

--- a/tests/Functional/Client/FailureTestCase.php
+++ b/tests/Functional/Client/FailureTestCase.php
@@ -111,7 +111,7 @@ class FailureTestCase extends ClientTestCase
 
         try {
             // The next
-            sleep(1);
+            sleep(2);
             $wf->exit();
             $this->fail('Signal must fail');
         } catch (AssertionFailedError $e) {
@@ -148,7 +148,7 @@ class FailureTestCase extends ClientTestCase
         $run = $client->startWithSignal($wf, 'failActivity', ['foo']);
 
         try {
-            sleep(5);
+            sleep(8);
             $wf->failActivity('foo');
             $this->fail('Signal must fail');
         } catch (AssertionFailedError $e) {

--- a/tests/Functional/Client/FailureTestCase.php
+++ b/tests/Functional/Client/FailureTestCase.php
@@ -11,10 +11,13 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Functional\Client;
 
+use PHPUnit\Framework\AssertionFailedError;
 use Temporal\Exception\Client\WorkflowFailedException;
+use Temporal\Exception\Client\WorkflowNotFoundException;
 use Temporal\Exception\Failure\ActivityFailure;
 use Temporal\Exception\Failure\ApplicationFailure;
 use Temporal\Exception\Failure\ChildWorkflowFailure;
+use Temporal\Tests\Workflow\SignalExceptionsWorkflow;
 
 /**
  * @group client
@@ -79,5 +82,67 @@ class FailureTestCase extends ClientTestCase
             $this->assertInstanceOf(ApplicationFailure::class, $e->getPrevious());
             $this->assertStringContainsString('SimpleActivity->fail', $e->getPrevious()->getMessage());
         }
+    }
+
+    public function testSignalThatThrowsCustomError()
+    {
+        $client = $this->createClient();
+        $wf = $client->newWorkflowStub(SignalExceptionsWorkflow::class);
+
+        $run = $client->start($wf);
+
+        $wf->failWithName('test1');
+
+        try {
+            // The next
+            sleep(1);
+            $wf->exit();
+            $this->fail('Signal must fail');
+        } catch (AssertionFailedError $e) {
+            throw $e;
+        } catch (\Throwable $e) {
+            $this->assertInstanceOf(WorkflowNotFoundException::class, $e);
+            // \dump($e);
+        }
+
+        $this->expectException(WorkflowFailedException::class);
+        $result = $run->getResult();
+        $this->fail(sprintf("Workflow must fail. Got result %s", \print_r($result, true)));
+    }
+
+    public function testSignalThatThrowsInvalidArgumentException()
+    {
+        $client = $this->createClient();
+        $wf = $client->newWorkflowStub(SignalExceptionsWorkflow::class);
+
+        $run = $client->start($wf);
+
+        $wf->failInvalidArgument('test1');
+
+        $this->expectException(WorkflowFailedException::class);
+        $result = $run->getResult();
+        $this->fail(sprintf("Workflow must fail. Got result %s", \print_r($result, true)));
+    }
+
+    public function testSignalThatThrowsInternalException()
+    {
+        $client = $this->createClient();
+        $wf = $client->newWorkflowStub(SignalExceptionsWorkflow::class);
+
+        $run = $client->startWithSignal($wf, 'failActivity', ['foo']);
+
+        try {
+            sleep(5);
+            $wf->failActivity('foo');
+            $this->fail('Signal must fail');
+        } catch (AssertionFailedError $e) {
+            throw $e;
+        } catch (\Throwable $e) {
+            $this->assertInstanceOf(WorkflowNotFoundException::class, $e);
+        }
+
+        $this->expectException(WorkflowFailedException::class);
+        $result = $run->getResult();
+        $this->fail(sprintf("Workflow must fail. Got result %s", \print_r($result, true)));
     }
 }

--- a/tests/Functional/Client/UntypedWorkflowStubTestCase.php
+++ b/tests/Functional/Client/UntypedWorkflowStubTestCase.php
@@ -38,6 +38,16 @@ class UntypedWorkflowStubTestCase extends ClientTestCase
         $this->assertSame('HELLO WORLD', $simple->getResult());
     }
 
+    public function testUntypedStartWithWrongData()
+    {
+        $client = $this->createClient();
+        $simple = $client->newUntypedWorkflowStub('SimpleWorkflow');
+        $client->start($simple, ['hello world']);
+
+        $this->expectException(WorkflowFailedException::class);
+        $simple->getResult();
+    }
+
     public function testUntypedStartViaClient()
     {
         $client = $this->createClient();

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
     ports:
       - "9042:9042"
   temporal:
-    image: temporalio/auto-setup:1.16.2
+    image: temporalio/auto-setup:1.21.1.0
     ports:
       - "7233:7233"
     volumes:
@@ -17,7 +17,7 @@ services:
     depends_on:
       - cassandra
   temporal-admin-tools:
-    image: temporalio/admin-tools:1.16.2
+    image: temporalio/admin-tools:1.21.1.0
     stdin_open: true
     tty: true
     environment:
@@ -25,7 +25,7 @@ services:
     depends_on:
       - temporal
   temporal-ui:
-    image: temporalio/ui:2.5.0
+    image: temporalio/ui:2.16.2
     environment:
       - TEMPORAL_ADDRESS=temporal:7233
       - TEMPORAL_CORS_ORIGINS=http://localhost:3000


### PR DESCRIPTION
## What was changed

Exceptions from Signal methods now will be propagated and affect Workflow.
Deserialization errors will be ignored. Called Signal method in this case will be skipped.

## Checklist

How was this tested: manually; also added autotests.

> **Note**:
> The fix will be cherry-picked into `master` and `2.7` branches after `2.5.3` release