### PR TITLE
Fix CI badge in readme

### DIFF
--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -1,3 +1,5 @@
+name: Unit
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
## What was changed

Add CI workflow name

## Why?

Because CI status badge doesn't work well
![{BA278319-8599-4BF1-8749-8C371AD8A28A}](https://github.com/temporalio/sdk-php/assets/4152481/a1804b8f-b5d3-42c5-9ee1-4eb7079f08e7)

