### PR TITLE
Fixes potential issue when signal coroutine won't trigger await due to failed activity call

### DIFF
--- a/src/Internal/Workflow/Process/Scope.php
+++ b/src/Internal/Workflow/Process/Scope.php
@@ -435,6 +435,7 @@ class Scope implements CancellationScopeInterface, PromisorInterface
         }
 
         $current = $this->coroutine->current();
+        $this->context->resolveConditions();
 
         switch (true) {
             case $current instanceof PromiseInterface:

--- a/tests/Fixtures/src/Workflow/Case335Workflow.php
+++ b/tests/Fixtures/src/Workflow/Case335Workflow.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Temporal\Tests\Workflow;
+
+use Temporal\Workflow;
+use Temporal\Workflow\SignalMethod;
+use Temporal\Workflow\WorkflowMethod;
+
+#[Workflow\WorkflowInterface]
+class Case335Workflow
+{
+    private bool $exit = false;
+    private bool $timerRun = false;
+
+    #[SignalMethod('signal')]
+    public function signal()
+    {
+        $this->exit = true;
+
+        yield Workflow::timer(1);
+
+        $this->timerRun = true;
+    }
+
+    #[WorkflowMethod('case335_workflow')]
+    public function run()
+    {
+        yield Workflow::await(fn() => $this->exit);
+        return $this->timerRun;
+    }
+}

--- a/tests/Functional/Client/TypedStubTestCase.php
+++ b/tests/Functional/Client/TypedStubTestCase.php
@@ -16,6 +16,7 @@ use Temporal\Tests\DTO\Message;
 use Temporal\Tests\DTO\User;
 use Temporal\Tests\Unit\Declaration\Fixture\WorkflowWithoutHandler;
 use Temporal\Tests\Workflow\ActivityReturnTypeWorkflow;
+use Temporal\Tests\Workflow\Case335Workflow;
 use Temporal\Tests\Workflow\GeneratorWorkflow;
 use Temporal\Tests\Workflow\QueryWorkflow;
 use Temporal\Tests\Workflow\SignalledWorkflowReusable;
@@ -158,5 +159,16 @@ class TypedStubTestCase extends ClientTestCase
 
         $result = $workflowRun->getResult();
         $this->assertEquals(['test1'], $result);
+    }
+
+    public function testSignalResolvesCondidtionsBeforePromiseRun()
+    {
+        $client = $this->createClient();
+
+        $workflow = $client->newWorkflowStub(Case335Workflow::class);
+        $workflowRun = $client->startWithSignal($workflow, 'signal');
+
+        $result = $workflowRun->getResult('bool', 5);
+        $this->assertFalse($result);
     }
 }


### PR DESCRIPTION
## What was changed
Added additional trigger to flush awaits when coroutine spawns value. Previously only handled when the spawned value was a promise and that promise was handled properly.

## Why?
Potential issues with awaits being blocked when the signal changes any value and locks with invalid activity call.

## Checklist
1. Closes [no issue]

2. How was this tested: tested via local stand + test suite

3. Any docs updates needed?
none