### PR TITLE
Apply changes from 2.7.0 related with HistoryLength to 2.6.0

### DIFF
--- a/src/Internal/Transport/Client.php
+++ b/src/Internal/Transport/Client.php
@@ -21,6 +21,7 @@ use Temporal\Worker\Transport\Command\FailureResponseInterface;
 use Temporal\Worker\Transport\Command\RequestInterface;
 use Temporal\Worker\Transport\Command\ResponseInterface;
 use Temporal\Worker\Transport\Command\SuccessResponseInterface;
+use Temporal\Workflow\WorkflowInfo;
 
 /**
  * @internal Client is an internal library class, please do not use it in your code.
@@ -36,15 +37,17 @@ final class Client implements ClientInterface
         'Unable to receive a request with id %d because ' .
         'a request with that identifier was not sent';
 
-    private QueueInterface $queue;
+    /**
+     * @var array<int, array{Deferred, WorkflowInfo|null}>
+     */
     private array $requests = [];
 
     /**
      * @param QueueInterface $queue
      */
-    public function __construct(QueueInterface $queue)
-    {
-        $this->queue = $queue;
+    public function __construct(
+        private QueueInterface $queue,
+    ) {
     }
 
     /**
@@ -53,14 +56,21 @@ final class Client implements ClientInterface
      */
     public function dispatch(ResponseInterface $response): void
     {
-        if (!isset($this->requests[$response->getID()])) {
+        $id = $response->getID();
+        if (!isset($this->requests[$id])) {
             $this->request(new UndefinedResponse(
-                \sprintf('Got the response to undefined request %s', $response->getID()),
+                \sprintf('Got the response to undefined request %s', $id),
             ));
             return;
         }
 
-        $deferred = $this->fetch($response->getID());
+        [$deferred, $info] = $this->requests[$id];
+        unset($this->requests[$id]);
+
+        if ($info !== null && $response->getHistoryLength() > $info->historyLength) {
+            /** @psalm-suppress InaccessibleProperty */
+            $info->historyLength = $response->getHistoryLength();
+        }
 
         if ($response instanceof FailureResponseInterface) {
             $deferred->reject($response->getFailure());
@@ -71,9 +81,11 @@ final class Client implements ClientInterface
 
     /**
      * @param RequestInterface $request
+     * @param null|WorkflowInfo $workflowInfo
+     *
      * @return PromiseInterface
      */
-    public function request(RequestInterface $request): PromiseInterface
+    public function request(RequestInterface $request, ?WorkflowInfo $workflowInfo = null): PromiseInterface
     {
         $this->queue->push($request);
 
@@ -83,7 +95,8 @@ final class Client implements ClientInterface
             throw new \OutOfBoundsException(\sprintf(self::ERROR_REQUEST_ID_DUPLICATION, $id));
         }
 
-        $this->requests[$id] = $deferred = new Deferred();
+        $deferred = new Deferred();
+        $this->requests[$id] = [$deferred, $workflowInfo];
 
         return $deferred->promise();
     }
@@ -106,7 +119,7 @@ final class Client implements ClientInterface
     {
         // remove from queue
         $this->queue->pull($command->getID());
-        $this->fetch($command->getID())->reject(new CanceledFailure('internal cancel'));
+        $this->reject($command, new CanceledFailure('internal cancel'));
     }
 
     /**
@@ -117,8 +130,7 @@ final class Client implements ClientInterface
      */
     public function reject(CommandInterface $command, \Throwable $reason): void
     {
-        $request = $this->fetch($command->getID());
-        $request->reject($reason);
+        $this->fetch($command->getID())->reject($reason);
     }
 
     /**
@@ -146,6 +158,6 @@ final class Client implements ClientInterface
             throw new \UnderflowException(\sprintf(self::ERROR_REQUEST_NOT_FOUND, $id));
         }
 
-        return $this->requests[$id];
+        return $this->requests[$id][0];
     }
 }

--- a/src/Internal/Transport/ClientInterface.php
+++ b/src/Internal/Transport/ClientInterface.php
@@ -14,14 +14,17 @@ namespace Temporal\Internal\Transport;
 use React\Promise\PromiseInterface;
 use Temporal\Worker\Transport\Command\CommandInterface;
 use Temporal\Worker\Transport\Command\RequestInterface;
+use Temporal\Workflow\WorkflowInfo;
 
 interface ClientInterface
 {
     /**
      * @param RequestInterface $request
+     * @param null|WorkflowInfo $workflowInfo
+     *
      * @return PromiseInterface
      */
-    public function request(RequestInterface $request): PromiseInterface;
+    public function request(RequestInterface $request, ?WorkflowInfo $workflowInfo = null): PromiseInterface;
 
     /**
      * @param CommandInterface $command

--- a/src/Internal/Transport/Router/InvokeSignal.php
+++ b/src/Internal/Transport/Router/InvokeSignal.php
@@ -35,6 +35,7 @@ final class InvokeSignal extends WorkflowProcessAwareRoute
     {
         $instance = $this->findInstanceOrFail($request->getID());
         $handler = $instance->getSignalHandler($request->getOptions()['name']);
+        $instance->getContext()->historyLength = $request->getHistoryLength();
 
         $handler($request->getPayloads());
 

--- a/src/Internal/Transport/Router/StartWorkflow.php
+++ b/src/Internal/Transport/Router/StartWorkflow.php
@@ -55,9 +55,12 @@ final class StartWorkflow extends Route
             $payloads = EncodedValues::sliceValues($this->services->dataConverter, $payloads, 0, $offset);
         }
 
+        /** @var Input $input */
         $input = $this->services->marshaller->unmarshal($options, new Input());
         /** @psalm-suppress InaccessibleProperty */
         $input->input = $payloads;
+        /** @psalm-suppress InaccessibleProperty */
+        $input->info->historyLength = $request->getHistoryLength();
 
         $instance = $this->instantiator->instantiate($this->findWorkflowOrFail($input->info));
 
@@ -68,7 +71,7 @@ final class StartWorkflow extends Route
             $input,
             $lastCompletionResult
         );
-        $runId = $request->getID() ?? $context->getRunId();
+        $runId = $request->getID();
 
         $process = new Process($this->services, $context, runId: $runId);
         $this->services->running->add($process);

--- a/src/Internal/Workflow/Process/Scope.php
+++ b/src/Internal/Workflow/Process/Scope.php
@@ -447,7 +447,7 @@ class Scope implements CancellationScopeInterface, PromisorInterface
                 break;
 
             case $current instanceof RequestInterface:
-                $this->nextPromise($this->context->getClient()->request($current));
+                $this->nextPromise($this->context->getClient()->request($current, $this->scopeContext->getInfo()));
                 break;
 
             case $current instanceof \Generator:

--- a/src/Internal/Workflow/WorkflowContext.php
+++ b/src/Internal/Workflow/WorkflowContext.php
@@ -406,7 +406,7 @@ class WorkflowContext implements WorkflowContextInterface
     public function request(RequestInterface $request, bool $cancellable = true): PromiseInterface
     {
         $this->recordTrace();
-        return $this->client->request($request);
+        return $this->client->request($request, $this->getInfo());
     }
 
     /**

--- a/src/Worker/Transport/Codec/JsonCodec/Decoder.php
+++ b/src/Worker/Transport/Codec/JsonCodec/Decoder.php
@@ -63,21 +63,13 @@ class Decoder
         }
         $header = null;
 
-        $request = new ServerRequest(
+        return new ServerRequest(
             name: $data['command'],
-            id: $data['runId'] ?? null,
             options: $data['options'] ?? [],
             payloads: EncodedValues::fromPayloads($payloads, $this->converter),
+            id: $data['runId'] ?? null,
             header: $header,
         );
-
-        if (isset($data['failure'])) {
-            $failure = new Failure();
-            $failure->mergeFromString(base64_decode($data['failure']));
-            $request->setFailure(FailureConverter::mapFailureToException($failure, $this->converter));
-        }
-
-        return $request;
     }
 
     /**

--- a/src/Worker/Transport/Codec/ProtoCodec/Decoder.php
+++ b/src/Worker/Transport/Codec/ProtoCodec/Decoder.php
@@ -80,8 +80,9 @@ class Decoder
     private function parseFailureResponse(Message $msg): FailureResponseInterface
     {
         return new FailureResponse(
-            FailureConverter::mapFailureToException($msg->getFailure(), $this->converter),
-            $msg->getId()
+            failure: FailureConverter::mapFailureToException($msg->getFailure(), $this->converter),
+            id: $msg->getId(),
+            historyLength: (int)$msg->getHistoryLength()
         );
     }
 
@@ -96,6 +97,10 @@ class Decoder
             $payloads = EncodedValues::fromPayloads($msg->getPayloads(), $this->converter);
         }
 
-        return new SuccessResponse($payloads, $msg->getId());
+        return new SuccessResponse(
+            values: $payloads,
+            id: $msg->getId(),
+            historyLength: (int)$msg->getHistoryLength(),
+        );
     }
 }

--- a/src/Worker/Transport/Command/FailureResponse.php
+++ b/src/Worker/Transport/Command/FailureResponse.php
@@ -16,11 +16,15 @@ namespace Temporal\Worker\Transport\Command;
  */
 final class FailureResponse extends Response implements FailureResponseInterface
 {
+    /**
+     * @param int<0, max> $historyLength
+     */
     public function __construct(
         private readonly \Throwable $failure,
         string|int $id,
+        int $historyLength = 0,
     ) {
-        parent::__construct(id: $id);
+        parent::__construct(id: $id, historyLength: $historyLength);
     }
 
     public function getFailure(): \Throwable

--- a/src/Worker/Transport/Command/RequestInterface.php
+++ b/src/Worker/Transport/Command/RequestInterface.php
@@ -14,7 +14,7 @@ namespace Temporal\Worker\Transport\Command;
 use Temporal\DataConverter\ValuesInterface;
 
 /**
- * @psalm-import-type RequestOptions from RequestInterface
+ * @psalm-type RequestOptions = array<non-empty-string, mixed>
  */
 interface RequestInterface extends CommandInterface
 {

--- a/src/Worker/Transport/Command/Response.php
+++ b/src/Worker/Transport/Command/Response.php
@@ -13,13 +13,22 @@ namespace Temporal\Worker\Transport\Command;
 
 abstract class Response implements ResponseInterface
 {
+    /**
+     * @param int<0, max> $historyLength
+     */
     public function __construct(
         private readonly string|int $id,
+        private readonly int $historyLength,
     ) {
     }
 
     public function getID(): string|int
     {
         return $this->id;
+    }
+
+    public function getHistoryLength(): int
+    {
+        return $this->historyLength;
     }
 }

--- a/src/Worker/Transport/Command/ResponseInterface.php
+++ b/src/Worker/Transport/Command/ResponseInterface.php
@@ -13,4 +13,8 @@ namespace Temporal\Worker\Transport\Command;
 
 interface ResponseInterface extends CommandInterface
 {
+    /**
+     * @return int<0, max>
+     */
+    public function getHistoryLength(): int;
 }

--- a/src/Worker/Transport/Command/ServerRequest.php
+++ b/src/Worker/Transport/Command/ServerRequest.php
@@ -15,7 +15,7 @@ use Temporal\DataConverter\EncodedValues;
 use Temporal\DataConverter\ValuesInterface;
 
 /**
- * Carries request to perform host action with payloads and failure as context. Can be cancelled if allows
+ * A request from RoadRunner to the worker.
  *
  * @psalm-import-type RequestOptions from RequestInterface
  * @psalm-immutable
@@ -29,9 +29,8 @@ class ServerRequest implements ServerRequestInterface
 
     /**
      * @param non-empty-string $name
-     * @param non-empty-string $id
+     * @param non-empty-string|null $id
      * @param RequestOptions $options
-     * @param object|null $header
      * @param int<0, max> $historyLength
      */
     public function __construct(
@@ -41,10 +40,9 @@ class ServerRequest implements ServerRequestInterface
         ?string $id = null,
         ?object $header = null,
         private int $historyLength = 0,
-        private ?string $runId = null,
     ) {
         $this->payloads = $payloads ?? EncodedValues::empty();
-        $this->id = $id ?? $this->options['info']['WorkflowExecution']['RunID'] ?? $this->options['runId'] ?? '';
+        $this->id = $id ?? $options['info']['WorkflowExecution']['RunID'] ?? $options['runId'] ?? '';
     }
 
     public function getID(): string

--- a/src/Worker/Transport/Command/ServerRequestInterface.php
+++ b/src/Worker/Transport/Command/ServerRequestInterface.php
@@ -35,5 +35,8 @@ interface ServerRequestInterface extends CommandInterface
      */
     public function getPayloads(): ValuesInterface;
 
+    /**
+     * @return int<0, max>
+     */
     public function getHistoryLength(): int;
 }

--- a/src/Worker/Transport/Command/SuccessResponse.php
+++ b/src/Worker/Transport/Command/SuccessResponse.php
@@ -18,10 +18,13 @@ class SuccessResponse extends Response implements SuccessResponseInterface
 {
     protected ValuesInterface $values;
 
-    public function __construct(?ValuesInterface $values, string|int $id)
+    /**
+     * @param int<0, max> $historyLength
+     */
+    public function __construct(?ValuesInterface $values, string|int $id, int $historyLength = 0)
     {
         $this->values = $values ?? EncodedValues::empty();
-        parent::__construct(id: $id);
+        parent::__construct(id: $id, historyLength: $historyLength);
     }
 
     /**

--- a/src/WorkerFactory.php
+++ b/src/WorkerFactory.php
@@ -340,7 +340,7 @@ class WorkerFactory implements WorkerFactoryInterface, LoopInterface
     #[Pure]
     private function createClient(): ClientInterface
     {
-        return new Client($this->responses, $this);
+        return new Client($this->responses);
     }
 
     /**

--- a/src/Workflow/WorkflowInfo.php
+++ b/src/Workflow/WorkflowInfo.php
@@ -78,6 +78,17 @@ final class WorkflowInfo
     public int $attempt = 1;
 
     /**
+     * Contains the count of history events.
+     * The counter is automatically incremented in the background.
+     *
+     * @var int<0, max>
+     * @since 2.6.0
+     * @since RoadRunner 2023.2. With lower versions, this field is always 0.
+     */
+    #[Marshal(name: 'HistoryLength')]
+    public int $historyLength = 0;
+
+    /**
      * @see CronSchedule::$interval for more info about cron format.
      *
      * @var string|null

--- a/testing/src/WorkerFactory.php
+++ b/testing/src/WorkerFactory.php
@@ -195,7 +195,7 @@ class WorkerFactory implements WorkerFactoryInterface, LoopInterface
         $this->queues = new ArrayRepository();
         $this->router = $this->createRouter();
         $this->responses = new ArrayQueue();
-        $this->client = new Client($this->responses, $this);
+        $this->client = new Client($this->responses);
         $this->server = $this->createServer();
         $this->env = new Environment();
     }

--- a/tests/Feature/Testing/CapturedClient.php
+++ b/tests/Feature/Testing/CapturedClient.php
@@ -15,6 +15,7 @@ use React\Promise\PromiseInterface;
 use Temporal\Internal\Transport\ClientInterface;
 use Temporal\Worker\Transport\Command\CommandInterface;
 use Temporal\Worker\Transport\Command\RequestInterface;
+use Temporal\Workflow\WorkflowInfo;
 
 class CapturedClient implements ClientInterface
 {
@@ -40,7 +41,7 @@ class CapturedClient implements ClientInterface
      * @param RequestInterface $request
      * @return PromiseInterface
      */
-    public function request(RequestInterface $request): PromiseInterface
+    public function request(RequestInterface $request, ?WorkflowInfo $workflowInfo = null): PromiseInterface
     {
         return $this->requests[$request->getID()] = $this->parent->request($request)
             ->then($this->onFulfilled($request), $this->onRejected($request));

--- a/tests/Feature/Testing/TestingClient.php
+++ b/tests/Feature/Testing/TestingClient.php
@@ -19,6 +19,7 @@ use Temporal\Worker\LoopInterface;
 use Temporal\Worker\Transport\Command\FailureResponse;
 use Temporal\Worker\Transport\Command\RequestInterface;
 use Temporal\Worker\Transport\Command\SuccessResponse;
+use Temporal\Workflow\WorkflowInfo;
 
 class TestingClient extends CapturedClient
 {
@@ -69,12 +70,12 @@ class TestingClient extends CapturedClient
     /**
      * {@inheritDoc}
      */
-    public function request(RequestInterface $request): PromiseInterface
+    public function request(RequestInterface $request, ?WorkflowInfo $workflowInfo = null): PromiseInterface
     {
         if (!$request instanceof TestingRequest) {
             $request = new TestingRequest($request);
         }
 
-        return parent::request($request);
+        return parent::request($request, $workflowInfo);
     }
 }

--- a/tests/Fixtures/src/Workflow/HistoryLengthWorkflow.php
+++ b/tests/Fixtures/src/Workflow/HistoryLengthWorkflow.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Workflow;
+
+use Temporal\Activity\ActivityOptions;
+use Temporal\Tests\Activity\SimpleActivity;
+use Temporal\Workflow;
+use Temporal\Workflow\WorkflowMethod;
+
+#[Workflow\WorkflowInterface]
+class HistoryLengthWorkflow
+{
+    #[WorkflowMethod(name: 'HistoryLengthWorkflow')]
+    public function handler(string $input): iterable
+    {
+        $result = [Workflow::getInfo()->historyLength];
+        $simple = Workflow::newActivityStub(
+            SimpleActivity::class,
+            ActivityOptions::new()->withStartToCloseTimeout(5),
+        );
+
+        $str = yield Workflow::sideEffect(
+            function () use ($input) {
+                return $input . '-42';
+            },
+        );
+        $result[] = Workflow::getInfo()->historyLength;
+
+        yield $simple->lower($str);
+        $result[] = Workflow::getInfo()->historyLength;
+
+        yield $simple->lower($str);
+        $result[] = Workflow::getInfo()->historyLength;
+
+        yield $simple->lower($str);
+        $result[] = Workflow::getInfo()->historyLength;
+
+        return $result;
+    }
+}

--- a/tests/Functional/HistoryLengthWorkflowTestCase.php
+++ b/tests/Functional/HistoryLengthWorkflowTestCase.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Functional;
+
+use Temporal\Client\GRPC\ServiceClient;
+use Temporal\Client\WorkflowClient;
+use Temporal\Testing\ActivityMocker;
+use Temporal\Tests\TestCase;
+use Temporal\Tests\Workflow\HistoryLengthWorkflow;
+
+final class HistoryLengthWorkflowTestCase extends TestCase
+{
+    private WorkflowClient $workflowClient;
+    private ActivityMocker $activityMocks;
+
+    protected function setUp(): void
+    {
+        $this->workflowClient = new WorkflowClient(
+            ServiceClient::create('localhost:7233')
+        );
+        $this->activityMocks = new ActivityMocker();
+
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->activityMocks->clear();
+        parent::tearDown();
+    }
+
+    public function testHistoryLengthIsUpdated(): void
+    {
+        $workflow = $this->workflowClient->newWorkflowStub(HistoryLengthWorkflow::class);
+        $run = $this->workflowClient->start($workflow, 'hello');
+
+        $result = $run->getResult('array');
+
+        $this->assertGreaterThan($result[1], $result[2]);
+        $this->assertGreaterThan($result[2], $result[3]);
+        $this->assertGreaterThan($result[3], $result[4]);
+    }
+}

--- a/tests/Unit/DTO/WorkflowInfoTestCase.php
+++ b/tests/Unit/DTO/WorkflowInfoTestCase.php
@@ -36,6 +36,7 @@ class WorkflowInfoTestCase extends DTOMarshallingTestCase
             'WorkflowTaskTimeout' => 290304000000000000,
             'Namespace' => 'default',
             'Attempt' => 1,
+            'HistoryLength' => 0,
             'CronSchedule' => null,
             'ContinuedExecutionRunID' => null,
             'ParentWorkflowNamespace' => null,

--- a/tests/Unit/Framework/ClientMock.php
+++ b/tests/Unit/Framework/ClientMock.php
@@ -15,6 +15,7 @@ use Temporal\Worker\Transport\Command\FailureResponseInterface;
 use Temporal\Worker\Transport\Command\RequestInterface;
 use Temporal\Worker\Transport\Command\ResponseInterface;
 use Temporal\Worker\Transport\Command\SuccessResponseInterface;
+use Temporal\Workflow\WorkflowInfo;
 
 /**
  * @internal
@@ -56,7 +57,7 @@ final class ClientMock implements ClientInterface
         }
     }
 
-    public function request(RequestInterface $request): PromiseInterface
+    public function request(RequestInterface $request, ?WorkflowInfo $workflowInfo = null): PromiseInterface
     {
         $this->queue->push($request);
 

--- a/tests/Unit/Framework/Server/ServerMock.php
+++ b/tests/Unit/Framework/Server/ServerMock.php
@@ -16,6 +16,8 @@ final class ServerMock
     private CommandHandlerFactory $commandHandlerFactory;
     private Carbon $currentTime;
     private array $queue = [];
+    /** @var int<0, max> */
+    private int $historyLength = 0;
 
     /** @var ExpectationInterface[] */
     private array $expectations = [];
@@ -47,6 +49,7 @@ final class ServerMock
 
     public function handleCommand(CommandInterface $command): ?CommandInterface
     {
+        ++$this->historyLength;
         $expectation = $this->checkExpectation($command);
         if ($expectation !== null) {
             return $expectation->run($command);
@@ -58,6 +61,14 @@ final class ServerMock
         }
 
         return $handler->handle($command);
+    }
+
+    /**
+     * @return int<0, max>
+     */
+    public function getHistoryLength(): int
+    {
+        return $this->historyLength;
     }
 
     private function checkExpectation(CommandInterface $command): ?ExpectationInterface


### PR DESCRIPTION
## What was changed

HistoryLength from #315 (2.7.0) was applied to 2.6.0.

## Why?

Users should be able to have a more direct way to check if it's time to call continue-as-new than guessing how many events their code produces and counting the loops.

The stable RoadRunner v2023.2 already sends HistoryLength values. After #340 it is easy to provide the feature bit early.

## Checklist

- Closes #222 
- Added autotest.
