### PR TITLE
Fixing RoadRunner Version Checker unit tests

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -34,6 +34,5 @@
         <ini name="error_reporting" value="-1"/>
         <ini name="memory_limit" value="-1"/>
         <env name="TEMPORAL_ADDRESS" value="127.0.0.1:7233" />
-        <env name="RR_VERSION" value="2023.1.0" />
     </php>
 </phpunit>

--- a/tests/Unit/Worker/Transport/RoadRunnerTestCase.php
+++ b/tests/Unit/Worker/Transport/RoadRunnerTestCase.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Unit\Worker\Transport;
 
 use RoadRunner\VersionChecker\Version\ComparatorInterface;
+use RoadRunner\VersionChecker\Version\InstalledInterface;
+use RoadRunner\VersionChecker\Version\RequiredInterface;
 use RoadRunner\VersionChecker\VersionChecker;
 use Temporal\Tests\Unit\UnitTestCase;
 use Temporal\Worker\Transport\RoadRunner;
@@ -17,14 +19,30 @@ final class RoadRunnerTestCase extends UnitTestCase
 {
     public function testCreateShouldCallVersionCheck(): void
     {
+        $installed = $this->createMock(InstalledInterface::class);
+        $installed
+            ->expects($this->once())
+            ->method('getInstalledVersion')
+            ->willReturn('2023.1.0');
+
+        $required = $this->createMock(RequiredInterface::class);
+        $required
+            ->expects($this->once())
+            ->method('getRequiredVersion')
+            ->willReturn('2023.1.0');
+
         $comparator = $this->createMock(ComparatorInterface::class);
         $comparator
             ->expects($this->once())
             ->method('greaterThan')
-            ->with('2023.1.0.0-dev', '2023.1.0')
+            ->with('2023.1.0', '2023.1.0')
             ->willReturn(true);
 
-        $checker = new RoadRunnerVersionChecker(checker: new VersionChecker(comparator: $comparator));
+        $checker = new RoadRunnerVersionChecker(checker: new VersionChecker(
+            installedVersion: $installed,
+            requiredVersion: $required,
+            comparator: $comparator
+        ));
 
         RoadRunner::create(versionChecker: $checker);
 


### PR DESCRIPTION
## What was changed

Fixed unit tests for the RoadRunner Version Checker. Now the unit tests use mocks and are no longer tied to the RoadRunner version, which was previously specified in the PHPUnit configuration.
