### PR TITLE
Adding RoadRunner Version Checker

### DIFF
--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Download RoadRunner
         if: inputs.run-temporal-test-server == true
         run: |
-          vendor/bin/rr get --no-interaction
+          vendor/bin/rr get --no-interaction --stability=beta
 
       - name: Run tests with Temporal test server
         if: inputs.run-temporal-test-server == true

--- a/composer.json
+++ b/composer.json
@@ -32,13 +32,14 @@
         "react/promise": "^2.9",
         "roadrunner-php/roadrunner-api-dto": "^1.3",
         "spiral/attributes": "^2.8 || ^3.0",
-        "spiral/roadrunner-cli": "^2.2 || ^3.0",
-        "spiral/roadrunner-kv": "^2.1 || ^3.0 || ^4.0",
-        "spiral/roadrunner-worker": "^2.1.3 || ^3.0",
+        "spiral/roadrunner-cli": "^2.5",
+        "spiral/roadrunner-kv": "^4.0",
+        "spiral/roadrunner-worker": "^3.0",
         "symfony/filesystem": "^4.4.20 || ^5.0 || ^6.0",
         "symfony/http-client": "^4.4.20 || ^5.0 || ^6.0",
         "symfony/process": "^4.4.20 || ^5.0 || ^6.0",
-        "roadrunner-php/version-checker": "^1.0"
+        "roadrunner-php/version-checker": "^1.0",
+        "spiral/roadrunner": "^v2023.2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
         "spiral/roadrunner-worker": "^2.1.3 || ^3.0",
         "symfony/filesystem": "^4.4.20 || ^5.0 || ^6.0",
         "symfony/http-client": "^4.4.20 || ^5.0 || ^6.0",
-        "symfony/process": "^4.4.20 || ^5.0 || ^6.0"
+        "symfony/process": "^4.4.20 || ^5.0 || ^6.0",
+        "roadrunner-php/version-checker": "^1.0"
     },
     "autoload": {
         "psr-4": {
@@ -76,6 +77,7 @@
         "doctrine/annotations": "^1.11 for Doctrine metadata driver support"
     },
     "scripts": {
+        "post-update-cmd": "Temporal\\Worker\\Transport\\RoadRunnerVersionChecker::postUpdate",
         "tests": [
             "phpunit --testsuite=Unit --testdox",
             "phpunit --testsuite=Feature --testdox",

--- a/src/Worker/Transport/RoadRunner.php
+++ b/src/Worker/Transport/RoadRunner.php
@@ -52,8 +52,13 @@ final class RoadRunner implements HostConnectionInterface
      * @param EnvironmentInterface|null $env
      * @return HostConnectionInterface
      */
-    public static function create(EnvironmentInterface $env = null): HostConnectionInterface
-    {
+    public static function create(
+        EnvironmentInterface $env = null,
+        RoadRunnerVersionChecker $versionChecker = null
+    ): HostConnectionInterface {
+        $versionChecker ??= new RoadRunnerVersionChecker();
+        $versionChecker->check();
+
         $env ??= Environment::fromGlobals();
 
         return new self(new Worker(Relay::create($env->getRelayAddress())));

--- a/src/Worker/Transport/RoadRunnerVersionChecker.php
+++ b/src/Worker/Transport/RoadRunnerVersionChecker.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Worker\Transport;
+
+use Composer\Script\Event;
+use Psr\Log\LoggerInterface;
+use RoadRunner\VersionChecker\Exception\RoadrunnerNotInstalledException;
+use RoadRunner\VersionChecker\Exception\UnsupportedVersionException;
+use RoadRunner\VersionChecker\VersionChecker;
+use Spiral\RoadRunner\Logger;
+
+final class RoadRunnerVersionChecker
+{
+    private VersionChecker $checker;
+    private LoggerInterface $logger;
+
+    public function __construct(
+        VersionChecker $checker = null,
+        LoggerInterface $logger = null
+    ) {
+        $this->checker = $checker ?? new VersionChecker();
+        $this->logger = $logger ?? new Logger();
+    }
+
+    public function check(): void
+    {
+        try {
+            $this->checker->greaterThan();
+        } catch (UnsupportedVersionException|RoadrunnerNotInstalledException $e) {
+            $this->logger->warning($e->getMessage());
+        }
+    }
+
+    public static function postUpdate(Event $event): void
+    {
+        $checker = new VersionChecker();
+
+        try {
+            $checker->greaterThan();
+        } catch (UnsupportedVersionException|RoadrunnerNotInstalledException $e) {
+            $event->getIO()->warning($e->getMessage());
+        }
+    }
+}

--- a/tests/Unit/Worker/Transport/RoadRunnerTestCase.php
+++ b/tests/Unit/Worker/Transport/RoadRunnerTestCase.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Unit\Worker\Transport;
+
+use RoadRunner\VersionChecker\Version\ComparatorInterface;
+use RoadRunner\VersionChecker\Version\InstalledInterface;
+use RoadRunner\VersionChecker\Version\RequiredInterface;
+use RoadRunner\VersionChecker\VersionChecker;
+use Temporal\Tests\Unit\UnitTestCase;
+use Temporal\Worker\Transport\RoadRunner;
+use Temporal\Worker\Transport\RoadRunnerVersionChecker;
+
+/**
+ * @group unit
+ */
+final class RoadRunnerTestCase extends UnitTestCase
+{
+    public function testCreateShouldCallVersionCheck(): void
+    {
+        $installed = $this->createMock(InstalledInterface::class);
+        $installed
+            ->expects($this->once())
+            ->method('getInstalledVersion')
+            ->willReturn('2023.1.0');
+
+        $required = $this->createMock(RequiredInterface::class);
+        $required
+            ->expects($this->once())
+            ->method('getRequiredVersion')
+            ->willReturn('2023.1.0');
+
+        $comparator = $this->createMock(ComparatorInterface::class);
+        $comparator
+            ->expects($this->once())
+            ->method('greaterThan')
+            ->with('2023.1.0', '2023.1.0')
+            ->willReturn(true);
+
+        $checker = new RoadRunnerVersionChecker(checker: new VersionChecker(
+            installedVersion: $installed,
+            requiredVersion: $required,
+            comparator: $comparator
+        ));
+
+        RoadRunner::create(versionChecker: $checker);
+
+        \ob_get_clean();
+    }
+}

--- a/tests/Unit/Worker/Transport/RoadRunnerVersionCheckerTestCase.php
+++ b/tests/Unit/Worker/Transport/RoadRunnerVersionCheckerTestCase.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\Worker\Transport;
+
+use Psr\Log\LoggerInterface;
+use RoadRunner\VersionChecker\Exception\RoadrunnerNotInstalledException;
+use RoadRunner\VersionChecker\Version\InstalledInterface;
+use RoadRunner\VersionChecker\Version\RequiredInterface;
+use RoadRunner\VersionChecker\VersionChecker;
+use Temporal\Tests\Unit\UnitTestCase;
+use Temporal\Worker\Transport\RoadRunnerVersionChecker;
+
+/**
+ * @group unit
+ */
+final class RoadRunnerVersionCheckerTestCase extends UnitTestCase
+{
+    public function testCheckSuccess(): void
+    {
+        $installed = $this->createMock(InstalledInterface::class);
+        $installed
+            ->expects($this->once())
+            ->method('getInstalledVersion')
+            ->willReturn('2023.1.0');
+
+        $required = $this->createMock(RequiredInterface::class);
+        $required
+            ->expects($this->once())
+            ->method('getRequiredVersion')
+            ->willReturn('2023.1.0');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger
+            ->expects($this->never())
+            ->method('warning');
+
+        $checker = new RoadRunnerVersionChecker(
+            checker: new VersionChecker(installedVersion: $installed, requiredVersion: $required),
+            logger: $logger
+        );
+        $checker->check();
+    }
+
+    public function testRoadRunnerIsNotInstalled(): void
+    {
+        $installed = $this->createMock(InstalledInterface::class);
+        $installed
+            ->expects($this->once())
+            ->method('getInstalledVersion')
+            ->willThrowException(new RoadrunnerNotInstalledException('Roadrunner is not installed.'));
+
+        $required = $this->createMock(RequiredInterface::class);
+        $required
+            ->expects($this->once())
+            ->method('getRequiredVersion')
+            ->willReturn('2023.1.0');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger
+            ->expects($this->once())
+            ->method('warning')
+            ->with('Roadrunner is not installed.');
+
+        $checker = new RoadRunnerVersionChecker(
+            checker: new VersionChecker(installedVersion: $installed, requiredVersion: $required),
+            logger: $logger
+        );
+        $checker->check();
+    }
+
+    public function testCheckFail(): void
+    {
+        $installed = $this->createMock(InstalledInterface::class);
+        $installed
+            ->expects($this->once())
+            ->method('getInstalledVersion')
+            ->willReturn('2.12.2');
+
+        $required = $this->createMock(RequiredInterface::class);
+        $required
+            ->expects($this->once())
+            ->method('getRequiredVersion')
+            ->willReturn('2023.1.0');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger
+            ->expects($this->once())
+            ->method('warning')
+            ->with('Installed RoadRunner version `2.12.2` not supported. Requires version `2023.1.0` or higher.');
+
+        $checker = new RoadRunnerVersionChecker(
+            checker: new VersionChecker(installedVersion: $installed, requiredVersion: $required),
+            logger: $logger
+        );
+        $checker->check();
+    }
+}


### PR DESCRIPTION
## What was changed

1. Added installed RoadRunner version checking.
2. Added loading beta version of RoadRunner in tests. The stable version of RoadRunner does not have the necessary functionality for the SDK v2.6.0

See: https://github.com/temporalio/sdk-php/pull/307