### PR TITLE
Better UUID support (passing without nesting)

### DIFF
--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -90,11 +90,11 @@ jobs:
       - name: Install lowest dependencies from composer.json
         if: matrix.dependencies == 'lowest'
         run: composer update --no-interaction --no-progress --prefer-lowest
-        env:
-          COMPOSER_POOL_OPTIMIZER: 0
 
       - name: Validate lowest dependencies
         if: matrix.dependencies == 'lowest'
+        env:
+          COMPOSER_POOL_OPTIMIZER: 0
         run: vendor/bin/validate-prefer-lowest
 
       - name: Install highest dependencies from composer.json

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "nesbot/carbon": "^2.66",
         "psr/log": "^2.0 || ^3.0",
         "react/promise": "^2.9",
+        "ramsey/uuid": "^4.7",
         "roadrunner-php/roadrunner-api-dto": "^1.3",
         "spiral/attributes": "^2.8 || ^3.0",
         "spiral/roadrunner-cli": "^2.5",
@@ -60,7 +61,6 @@
         "laminas/laminas-code": "^4.0",
         "monolog/monolog": "^2.1 || ^3.0",
         "phpunit/phpunit": "^9.5.21",
-        "ramsey/uuid": "^4.7",
         "symfony/translation": "^6.0",
         "symfony/var-dumper": "^6.0",
         "vimeo/psalm": "^4.30 || ^5.4"

--- a/src/Internal/Marshaller/Type/UuidType.php
+++ b/src/Internal/Marshaller/Type/UuidType.php
@@ -19,16 +19,9 @@ use Temporal\Internal\Support\Inheritance;
 
 final class UuidType extends Type implements DetectableTypeInterface, RuleFactoryInterface
 {
-    private static ?bool $interfaceExists = null;
-
     public static function match(\ReflectionNamedType $type): bool
     {
-        if (self::$interfaceExists === null) {
-            self::$interfaceExists = \interface_exists(UuidInterface::class);
-        }
-
-        return self::$interfaceExists &&
-            !$type->isBuiltin() &&
+        return !$type->isBuiltin() &&
             Inheritance::implements($type->getName(), UuidInterface::class);
     }
 

--- a/tests/.rr.silent.yaml
+++ b/tests/.rr.silent.yaml
@@ -1,4 +1,4 @@
-version: "2.7"
+version: "3"
 # Application configuration
 rpc:
     listen: tcp://127.0.0.1:6001

--- a/tests/.rr.yaml
+++ b/tests/.rr.yaml
@@ -1,4 +1,4 @@
-version: "2.7"
+version: "3"
 # Application configuration
 rpc:
     listen: tcp://127.0.0.1:6001

--- a/tests/Fixtures/src/Workflow/SimpleUuidWorkflow.php
+++ b/tests/Fixtures/src/Workflow/SimpleUuidWorkflow.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Workflow;
 
+use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
 use Temporal\Workflow;
 use Temporal\Workflow\WorkflowMethod;
@@ -20,8 +21,14 @@ class SimpleUuidWorkflow
 {
     #[WorkflowMethod(name: 'SimpleUuidWorkflow')]
     #[Workflow\ReturnType(UuidInterface::class)]
-    public function handler(UuidInterface $uuid): UuidInterface
+    public function handler(UuidInterface $uuid)
     {
+        $newUuid = yield Workflow::sideEffect(static fn(): UuidInterface => Uuid::uuid4());
+
+        if (!$newUuid instanceof UuidInterface) {
+            throw new \RuntimeException('Invalid type');
+        }
+
         return $uuid;
     }
 }

--- a/tests/Fixtures/src/Workflow/SimpleUuidWorkflow.php
+++ b/tests/Fixtures/src/Workflow/SimpleUuidWorkflow.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Workflow;
+
+use Ramsey\Uuid\UuidInterface;
+use Temporal\Workflow;
+use Temporal\Workflow\WorkflowMethod;
+
+#[Workflow\WorkflowInterface]
+class SimpleUuidWorkflow
+{
+    #[WorkflowMethod(name: 'SimpleUuidWorkflow')]
+    #[Workflow\ReturnType(UuidInterface::class)]
+    public function handler(UuidInterface $uuid): UuidInterface
+    {
+        return $uuid;
+    }
+}

--- a/tests/Functional/Client/UuidTestCase.php
+++ b/tests/Functional/Client/UuidTestCase.php
@@ -13,6 +13,7 @@ namespace Temporal\Tests\Functional\Client;
 
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
+use Temporal\Testing\Replay\WorkflowReplayer;
 use Temporal\Tests\Workflow\SimpleUuidWorkflow;
 
 /**
@@ -21,13 +22,31 @@ use Temporal\Tests\Workflow\SimpleUuidWorkflow;
  */
 class UuidTestCase extends ClientTestCase
 {
-    public function testSimpleEnum(): void
+    public function testUuidPassedAndReturned(): void
     {
         $client = $this->createClient();
         $workflow = $client->newWorkflowStub(SimpleUuidWorkflow::class);
 
         $uuid = Uuid::uuid4();
         $result = $workflow->handler($uuid);
+
+        $this->assertInstanceOf(UuidInterface::class, $result);
+        $this->assertSame((string)$uuid, (string)$result);
+    }
+
+    public function testSideEffectWithUuid(): void
+    {
+        $client = $this->createClient();
+        $workflow = $client->newWorkflowStub(SimpleUuidWorkflow::class);
+
+        $uuid = Uuid::uuid4();
+        $run = $client->start($workflow, $uuid);
+        $result = $run->getResult(UuidInterface::class);
+
+        (new WorkflowReplayer())->replayFromServer(
+            'SimpleUuidWorkflow',
+            $run->getExecution(),
+        );
 
         $this->assertInstanceOf(UuidInterface::class, $result);
         $this->assertSame((string)$uuid, (string)$result);

--- a/tests/Functional/Client/UuidTestCase.php
+++ b/tests/Functional/Client/UuidTestCase.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Functional\Client;
+
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
+use Temporal\Tests\Workflow\SimpleUuidWorkflow;
+
+/**
+ * @group client
+ * @group functional
+ */
+class UuidTestCase extends ClientTestCase
+{
+    public function testSimpleEnum(): void
+    {
+        $client = $this->createClient();
+        $workflow = $client->newWorkflowStub(SimpleUuidWorkflow::class);
+
+        $uuid = Uuid::uuid4();
+        $result = $workflow->handler($uuid);
+
+        $this->assertInstanceOf(UuidInterface::class, $result);
+        $this->assertSame((string)$uuid, (string)$result);
+    }
+}

--- a/tests/Unit/DTO/DTOMarshallingTestCase.php
+++ b/tests/Unit/DTO/DTOMarshallingTestCase.php
@@ -30,7 +30,7 @@ abstract class DTOMarshallingTestCase extends UnitTestCase
     /**
      * @var MarshallerInterface
      */
-    private MarshallerInterface $marshaller;
+    protected MarshallerInterface $marshaller;
 
     /**
      * @return void

--- a/tests/Unit/DTO/Type/UuidType/Stub/UuidObjectProp.php
+++ b/tests/Unit/DTO/Type/UuidType/Stub/UuidObjectProp.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\DTO\Type\UuidType\Stub;
+
+use Ramsey\Uuid\UuidInterface;
+
+final class UuidObjectProp
+{
+    public function __construct(
+        public UuidInterface $interface,
+    ) {
+    }
+}

--- a/tests/Unit/DTO/Type/UuidType/UuidTypeTestCase.php
+++ b/tests/Unit/DTO/Type/UuidType/UuidTypeTestCase.php
@@ -2,28 +2,20 @@
 
 declare(strict_types=1);
 
-namespace Temporal\Tests\Unit\Internal\Marshaller\Type;
+namespace Temporal\Tests\Unit\DTO\Type\UuidType;
 
-use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
-use Spiral\Attributes\AttributeReader;
-use Temporal\Internal\Marshaller\Mapper\AttributeMapperFactory;
-use Temporal\Internal\Marshaller\Marshaller;
+use ReflectionClass;
 use Temporal\Internal\Marshaller\MarshallingRule;
 use Temporal\Internal\Marshaller\Type\NullableType;
 use Temporal\Internal\Marshaller\Type\UuidType;
+use Temporal\Tests\Unit\DTO\DTOMarshallingTestCase;
+use Temporal\Tests\Unit\DTO\Type\UuidType\Stub\UuidObjectProp;
 use Temporal\Tests\Unit\Internal\Marshaller\Fixture\PropertyType;
 
-final class UuidTypeTestCase extends TestCase
+final class UuidTypeTestCase extends DTOMarshallingTestCase
 {
-    private Marshaller $marshaller;
-
-    protected function setUp(): void
-    {
-        $this->marshaller = new Marshaller(new AttributeMapperFactory(new AttributeReader()));
-    }
-
     /**
      * @dataProvider matchDataProvider
      */
@@ -105,6 +97,33 @@ final class UuidTypeTestCase extends TestCase
                 NullableType::class,
                 new MarshallingRule(type: UuidType::class, of: UuidInterface::class),
             )
+        ];
+    }
+
+    public function testMarshalUuidDto(): void
+    {
+        $string = '5e71ffd6-36e7-4e72-b3a5-f62dc46d35eb';
+        $dto = new UuidObjectProp(Uuid::fromString($string));
+
+        $result = $this->marshal($dto);
+        $this->assertSame(['interface' => $string], $result);
+    }
+
+    public function testUnmarshalUuidDto(): void
+    {
+        $string = '5e71ffd6-36e7-4e72-b3a5-f62dc46d35eb';
+        $dto = $this->unmarshal([
+            'interface' => $string,
+        ], (new ReflectionClass(UuidObjectProp::class))->newInstanceWithoutConstructor());
+
+        $this->assertSame($string, $dto->interface->toString());
+    }
+
+
+    protected function getTypeMatchers(): array
+    {
+        return [
+            UuidType::class,
         ];
     }
 }

--- a/tests/Unit/DataConverter/JsonConverterTestCase.php
+++ b/tests/Unit/DataConverter/JsonConverterTestCase.php
@@ -11,35 +11,35 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Unit\DataConverter;
 
+use Ramsey\Uuid\Uuid;
 use Temporal\DataConverter\EncodingKeys;
+use Temporal\DataConverter\JsonConverter;
 use Temporal\DataConverter\PayloadConverterInterface;
-use Temporal\DataConverter\ProtoJsonConverter;
 use Temporal\Tests\Unit\UnitTestCase;
 
 /**
  * @group unit
  * @group data-converter
  */
-class ProtoJsonConverterTestCase extends UnitTestCase
+class JsonConverterTestCase extends UnitTestCase
 {
     protected function create(): PayloadConverterInterface
     {
-        return new ProtoJsonConverter();
+        return new JsonConverter();
     }
 
-    public function testMessageType(): void
+    public function testUuidToPayload(): void
     {
         $converter = $this->create();
 
-        $message = new \Temporal\Tests\Proto\Test();
-        $message->setValue('foo');
+        $dto = Uuid::uuid4();
 
-        $payload = $converter->toPayload($message);
+        $payload = $converter->toPayload($dto);
 
         $this->assertNotNull($payload);
         $this->assertSame(
-            'tests.Test',
-            $payload->getMetadata()->offsetGet(EncodingKeys::METADATA_MESSAGE_TYPE),
+            \json_encode((string)$dto),
+            $payload->getData(),
         );
     }
 }

--- a/tests/Unit/DataConverter/ProtoConverterTestCase.php
+++ b/tests/Unit/DataConverter/ProtoConverterTestCase.php
@@ -9,7 +9,7 @@
 
 declare(strict_types=1);
 
-namespace DataConverter;
+namespace Temporal\Tests\Unit\DataConverter;
 
 use Temporal\DataConverter\EncodingKeys;
 use Temporal\DataConverter\PayloadConverterInterface;


### PR DESCRIPTION
## What was changed

- [ramsey/uuid](https://github.com/ramsey/uuid) was moved into the required section from the dev.
- Added tests where Uuid objects passed directly (not nested in DTO)
- Upgraded JsonDataConverter to support Uuid encoding/decoding.
- After DataConverter upgrade, SideEffect returns correct value

## Checklist

1. Closes #345
2. Closes #346
3. How was this tested: added auto-tests