### PR TITLE
Add supporting for React/Promises v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,18 +29,18 @@
         "grpc/grpc": "^1.42",
         "nesbot/carbon": "^2.66",
         "psr/log": "^2.0 || ^3.0",
-        "react/promise": "^2.9",
         "ramsey/uuid": "^4.7",
+        "react/promise": "2.9 || ^3.0",
         "roadrunner-php/roadrunner-api-dto": "^1.3",
+        "roadrunner-php/version-checker": "^1.0",
         "spiral/attributes": "^2.8 || ^3.0",
+        "spiral/roadrunner": "^v2023.2",
         "spiral/roadrunner-cli": "^2.5",
         "spiral/roadrunner-kv": "^4.0",
         "spiral/roadrunner-worker": "^3.0",
         "symfony/filesystem": "^4.4.20 || ^5.0 || ^6.0",
         "symfony/http-client": "^4.4.27 || ^5.0 || ^6.0",
-        "symfony/process": "^5.4 || ^6.0",
-        "roadrunner-php/version-checker": "^1.0",
-        "spiral/roadrunner": "^v2023.2"
+        "symfony/process": "^5.4 || ^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -783,6 +783,15 @@
       <code><![CDATA[$command->getID()]]></code>
     </PossiblyInvalidArgument>
   </file>
+  <file src="src/Internal/Transport/CompletableResult.php">
+    <InvalidArgument>
+      <code><![CDATA[$this->wrapContext($onFulfilledOrRejected)]]></code>
+      <code><![CDATA[$this->wrapContext($onFulfilledOrRejected)]]></code>
+    </InvalidArgument>
+    <PossiblyNullArgument>
+      <code>$value</code>
+    </PossiblyNullArgument>
+  </file>
   <file src="src/Internal/Transport/Request/NewTimer.php">
     <PossiblyNullPropertyFetch>
       <code><![CDATA[CarbonInterval::make($interval)->totalMilliseconds]]></code>
@@ -939,27 +948,18 @@
     </MoreSpecificReturnType>
   </file>
   <file src="src/Internal/Workflow/Process/Process.php">
-    <InternalClass>
-      <code>Scope</code>
-      <code>parent::__construct($services, $ctx)</code>
-      <code>parent::start($handler, $values)</code>
-    </InternalClass>
-    <InternalMethod>
-      <code>createScope</code>
-      <code>getContext</code>
-      <code>makeCurrent</code>
-      <code>onClose</code>
-      <code>parent::__construct($services, $ctx)</code>
-      <code>parent::start($handler, $values)</code>
-      <code>promise</code>
-      <code>startSignal</code>
-    </InternalMethod>
+    <InvalidDocblock>
+      <code>class Process extends Scope implements ProcessInterface</code>
+    </InvalidDocblock>
     <MissingClosureParamType>
       <code>$result</code>
     </MissingClosureParamType>
     <MissingParamType>
       <code>$result</code>
     </MissingParamType>
+    <MissingTemplateParam>
+      <code>ProcessInterface</code>
+    </MissingTemplateParam>
     <PropertyNotSetInConstructor>
       <code>Process</code>
     </PropertyNotSetInConstructor>
@@ -973,69 +973,10 @@
     <ArgumentTypeCoercion>
       <code><![CDATA[$this->context]]></code>
     </ArgumentTypeCoercion>
-    <InternalClass>
-      <code><![CDATA[new Scope($this->services, $this->context)]]></code>
-    </InternalClass>
-    <InternalMethod>
-      <code>attach</code>
-      <code>call</code>
-      <code>callSignalHandler</code>
-      <code>createScope</code>
-      <code>createScope</code>
-      <code>defer</code>
-      <code>defer</code>
-      <code>handleError</code>
-      <code>handleError</code>
-      <code>makeCurrent</code>
-      <code>makeCurrent</code>
-      <code>makeCurrent</code>
-      <code>makeCurrent</code>
-      <code>makeCurrent</code>
-      <code>makeCurrent</code>
-      <code>makeCurrent</code>
-      <code>makeCurrent</code>
-      <code><![CDATA[new Scope($this->services, $this->context)]]></code>
-      <code>next</code>
-      <code>next</code>
-      <code>next</code>
-      <code>next</code>
-      <code>next</code>
-      <code>nextPromise</code>
-      <code>nextPromise</code>
-      <code>nextPromise</code>
-      <code>nextPromise</code>
-      <code>onClose</code>
-      <code>onException</code>
-      <code>onException</code>
-      <code>onException</code>
-      <code>onException</code>
-      <code>onException</code>
-      <code>onResult</code>
-      <code>start</code>
-    </InternalMethod>
-    <InternalProperty>
-      <code><![CDATA[$scope->detached]]></code>
-      <code><![CDATA[$scope->layer]]></code>
-      <code><![CDATA[$this->cancelID]]></code>
-      <code><![CDATA[$this->cancelID]]></code>
-      <code><![CDATA[$this->cancelID]]></code>
-      <code><![CDATA[$this->cancelID]]></code>
-      <code><![CDATA[$this->cancelled]]></code>
-      <code><![CDATA[$this->context]]></code>
-      <code><![CDATA[$this->coroutine]]></code>
-      <code><![CDATA[$this->coroutine]]></code>
-      <code><![CDATA[$this->coroutine]]></code>
-      <code><![CDATA[$this->deferred]]></code>
-      <code><![CDATA[$this->exception]]></code>
-      <code><![CDATA[$this->onCancel]]></code>
-      <code><![CDATA[$this->onCancel]]></code>
-      <code><![CDATA[$this->onCancel]]></code>
-      <code><![CDATA[$this->onCancel]]></code>
-      <code><![CDATA[$this->onClose]]></code>
-      <code><![CDATA[$this->result]]></code>
-      <code><![CDATA[$this->scopeContext]]></code>
-      <code><![CDATA[$this->services]]></code>
-    </InternalProperty>
+    <InvalidArgument>
+      <code>$onFulfilled</code>
+      <code>$onRejected</code>
+    </InvalidArgument>
     <LessSpecificReturnStatement>
       <code><![CDATA[$this->context]]></code>
     </LessSpecificReturnStatement>
@@ -1067,6 +1008,9 @@
       <code>resolveConditions</code>
       <code>resolveConditions</code>
     </UndefinedInterfaceMethod>
+    <UnusedClosureParam>
+      <code>$e</code>
+    </UnusedClosureParam>
   </file>
   <file src="src/Internal/Workflow/ProcessCollection.php">
     <DocblockTypeContradiction>
@@ -1082,14 +1026,6 @@
     </PossiblyNullReference>
   </file>
   <file src="src/Internal/Workflow/ScopeContext.php">
-    <InternalMethod>
-      <code>getLayer</code>
-      <code>getLayer</code>
-      <code>isCancelled</code>
-      <code>onAwait</code>
-      <code>startScope</code>
-      <code>startScope</code>
-    </InternalMethod>
     <PropertyNotSetInConstructor>
       <code>$onRequest</code>
       <code>$parent</code>
@@ -1153,6 +1089,12 @@
       <code>$promiseOrValue</code>
       <code>$promiseOrValue</code>
     </MissingParamType>
+    <PossiblyInvalidArgument>
+      <code>$reasons</code>
+    </PossiblyInvalidArgument>
+    <TooManyArguments>
+      <code>$reduce($c, $value, $i++, $total)</code>
+    </TooManyArguments>
   </file>
   <file src="src/Worker/ActivityInvocationCache/ActivityInvocationCacheInterface.php">
     <MissingParamType>

--- a/src/Internal/Promise/CancellationQueue.php
+++ b/src/Internal/Promise/CancellationQueue.php
@@ -23,7 +23,7 @@ class CancellationQueue
         $this->drain();
     }
 
-    public function enqueue($cancellable): void
+    public function enqueue(mixed $cancellable): void
     {
         if (!\is_object($cancellable)
             || !\method_exists($cancellable, 'then')

--- a/src/Internal/Promise/CancellationQueue.php
+++ b/src/Internal/Promise/CancellationQueue.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Internal\Promise;
+
+/**
+ * @internal
+ * @psalm-internal Temporal
+ */
+class CancellationQueue
+{
+    private bool $started = false;
+    private array $queue = [];
+
+    public function __invoke()
+    {
+        if ($this->started) {
+            return;
+        }
+
+        $this->started = true;
+        $this->drain();
+    }
+
+    public function enqueue($cancellable): void
+    {
+        if (!\is_object($cancellable)
+            || !\method_exists($cancellable, 'then')
+            || !\method_exists($cancellable, 'cancel')
+        ) {
+            return;
+        }
+
+        $length = \array_push($this->queue, $cancellable);
+
+        if ($this->started && 1 === $length) {
+            $this->drain();
+        }
+    }
+
+    private function drain(): void
+    {
+        for ($i = \key($this->queue); isset($this->queue[$i]); $i++) {
+            $cancellable = $this->queue[$i];
+
+            $exception = null;
+
+            try {
+                $cancellable->cancel();
+            } catch (\Throwable $exception) {
+            }
+
+            unset($this->queue[$i]);
+
+            if ($exception) {
+                throw $exception;
+            }
+        }
+
+        $this->queue = [];
+    }
+}

--- a/src/Internal/Promise/Reasons.php
+++ b/src/Internal/Promise/Reasons.php
@@ -39,7 +39,7 @@ final class Reasons extends RuntimeException implements Iterator, ArrayAccess, C
         \next($this->collection);
     }
 
-    public function key(): mixed
+    public function key(): string|int|null
     {
         return \key($this->collection);
     }
@@ -59,7 +59,7 @@ final class Reasons extends RuntimeException implements Iterator, ArrayAccess, C
         return isset($this->collection[$offset]);
     }
 
-    public function offsetGet(mixed $offset): mixed
+    public function offsetGet(mixed $offset): Traversable
     {
         return $this->collection[$offset];
     }

--- a/src/Internal/Promise/Reasons.php
+++ b/src/Internal/Promise/Reasons.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Internal\Promise;
+
+use ArrayAccess;
+use Countable;
+use Iterator;
+use RuntimeException;
+use Traversable;
+
+/**
+ * @internal
+ * @psalm-internal Temporal
+ * @template TKey of array-key
+ * @template TValue of Traversable
+ * @implements Iterator<TKey, TValue>
+ * @implements ArrayAccess<TKey, TValue>
+ */
+final class Reasons extends RuntimeException implements Iterator, ArrayAccess, Countable
+{
+    /**
+     * @param array<array-key, Traversable> $collection
+     */
+    public function __construct(
+        public array $collection,
+    ) {
+        parent::__construct();
+    }
+
+    public function current(): mixed
+    {
+        return \current($this->collection);
+    }
+
+    public function next(): void
+    {
+        \next($this->collection);
+    }
+
+    public function key(): mixed
+    {
+        return \key($this->collection);
+    }
+
+    public function valid(): bool
+    {
+        return null !== \key($this->collection);
+    }
+
+    public function rewind(): void
+    {
+        \reset($this->collection);
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return isset($this->collection[$offset]);
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->collection[$offset];
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->collection[$offset] = $value;
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->collection[$offset]);
+    }
+
+    public function count(): int
+    {
+        return \count($this->collection);
+    }
+}

--- a/src/Internal/Promise/Reasons.php
+++ b/src/Internal/Promise/Reasons.php
@@ -21,7 +21,7 @@ use Traversable;
 final class Reasons extends RuntimeException implements Iterator, ArrayAccess, Countable
 {
     /**
-     * @param array<array-key, Traversable> $collection
+     * @param array<TKey, TValue> $collection
      */
     public function __construct(
         public array $collection,
@@ -59,11 +59,19 @@ final class Reasons extends RuntimeException implements Iterator, ArrayAccess, C
         return isset($this->collection[$offset]);
     }
 
+    /**
+     * @param TKey $offset
+     * @return TValue
+     */
     public function offsetGet(mixed $offset): Traversable
     {
         return $this->collection[$offset];
     }
 
+    /**
+     * @param TKey $offset
+     * @param TValue $value
+     */
     public function offsetSet(mixed $offset, mixed $value): void
     {
         $this->collection[$offset] = $value;

--- a/src/Internal/Transport/CompletableResult.php
+++ b/src/Internal/Transport/CompletableResult.php
@@ -17,6 +17,10 @@ use Temporal\Worker\LoopInterface;
 use Temporal\Workflow;
 use Temporal\Workflow\WorkflowContextInterface;
 
+/**
+ * @template T of mixed
+ * @implements CompletableResultInterface<T>
+ */
 class CompletableResult implements CompletableResultInterface
 {
     /**
@@ -95,7 +99,11 @@ class CompletableResult implements CompletableResultInterface
     }
 
     /**
-     * {@inheritDoc}
+     * @param (callable(mixed): mixed)|null $onFulfilled
+     * @param (callable(\Throwable): mixed)|null $onRejected
+     * @param callable|null $onProgress
+     *
+     * @return PromiseInterface
      */
     public function then(
         ?callable $onFulfilled = null,
@@ -108,7 +116,7 @@ class CompletableResult implements CompletableResultInterface
     }
 
     /**
-     * @return PromiseInterface
+     * @return PromiseInterface<T>
      */
     public function promise(): PromiseInterface
     {
@@ -173,6 +181,12 @@ class CompletableResult implements CompletableResultInterface
         return $this->finally($this->wrapContext($onFulfilledOrRejected));
     }
 
+    /**
+     * @template TParam of mixed
+     * @template TReturn of mixed
+     * @param (callable(TParam): TReturn)|null $callback
+     * @return ($callback is null ? null : (callable(TParam): TReturn))
+     */
     private function wrapContext(?callable $callback): ?callable
     {
         if ($callback === null) {

--- a/src/Internal/Transport/CompletableResult.php
+++ b/src/Internal/Transport/CompletableResult.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 
 namespace Temporal\Internal\Transport;
 
-use React\Promise\CancellablePromiseInterface;
 use React\Promise\Deferred;
 use React\Promise\PromiseInterface;
 use Temporal\Worker\LoopInterface;
@@ -73,7 +72,6 @@ class CompletableResult implements CompletableResultInterface
         $this->deferred = new Deferred();
         $this->layer = $layer;
 
-        /** @var CancellablePromiseInterface $current */
         $this->promise = $promise->then(
             \Closure::fromCallable([$this, 'onFulfilled']),
             \Closure::fromCallable([$this, 'onRejected']),
@@ -102,15 +100,12 @@ class CompletableResult implements CompletableResultInterface
     public function then(
         callable $onFulfilled = null,
         callable $onRejected = null,
-        callable $onProgress = null
+        callable $onProgress = null,
     ): PromiseInterface {
         Workflow::setCurrentContext($this->context);
 
-        /** @var CancellablePromiseInterface $promise */
-        $promise = $this->promise()
-            ->then($onFulfilled, $onRejected, $onProgress);
-
-        return $promise;
+        return $this->promise()
+            ->then($onFulfilled, $onRejected);
         //return new Future($promise, $this->worker);
     }
 
@@ -153,5 +148,34 @@ class CompletableResult implements CompletableResultInterface
                 $this->deferred->reject($e);
             }
         );
+    }
+
+    public function catch(callable $onRejected): PromiseInterface
+    {
+        return $this->promise()
+            ->catch($onRejected);
+    }
+
+    public function finally(callable $onFulfilledOrRejected): PromiseInterface
+    {
+        return $this->promise()
+            ->finally($onFulfilledOrRejected);
+    }
+
+    public function cancel(): void
+    {
+        Workflow::setCurrentContext($this->context);
+
+        $this->promise()->cancel();
+    }
+
+    public function otherwise(callable $onRejected): PromiseInterface
+    {
+        return $this->catch($onRejected);
+    }
+
+    public function always(callable $onFulfilledOrRejected): PromiseInterface
+    {
+        return $this->finally($onFulfilledOrRejected);
     }
 }

--- a/src/Internal/Transport/CompletableResult.php
+++ b/src/Internal/Transport/CompletableResult.php
@@ -98,9 +98,9 @@ class CompletableResult implements CompletableResultInterface
      * {@inheritDoc}
      */
     public function then(
-        callable $onFulfilled = null,
-        callable $onRejected = null,
-        callable $onProgress = null,
+        ?callable $onFulfilled = null,
+        ?callable $onRejected = null,
+        ?callable $onProgress = null,
     ): PromiseInterface {
         return $this->promise()
             ->then($this->wrapContext($onFulfilled), $this->wrapContext($onRejected));
@@ -115,10 +115,7 @@ class CompletableResult implements CompletableResultInterface
         return $this->deferred->promise();
     }
 
-    /**
-     * @param mixed $result
-     */
-    private function onFulfilled($result): void
+    private function onFulfilled(mixed $result): void
     {
         $this->resolved = true;
         $this->value = $result;
@@ -176,8 +173,12 @@ class CompletableResult implements CompletableResultInterface
         return $this->finally($this->wrapContext($onFulfilledOrRejected));
     }
 
-    private function wrapContext(callable $callback): callable
+    private function wrapContext(?callable $callback): ?callable
     {
+        if ($callback === null) {
+            return null;
+        }
+
         return function (mixed $value = null) use ($callback): mixed {
             Workflow::setCurrentContext($this->context);
             return $callback($value);

--- a/src/Internal/Transport/CompletableResultInterface.php
+++ b/src/Internal/Transport/CompletableResultInterface.php
@@ -12,9 +12,12 @@ declare(strict_types=1);
 namespace Temporal\Internal\Transport;
 
 use React\Promise\PromiseInterface;
-use React\Promise\PromisorInterface;
 
-interface CompletableResultInterface extends PromisorInterface, PromiseInterface
+/**
+ * @template T
+ * @extends PromiseInterface<T>
+ */
+interface CompletableResultInterface extends PromiseInterface
 {
     /**
      * @return bool

--- a/src/Internal/Workflow/Process/Process.php
+++ b/src/Internal/Workflow/Process/Process.php
@@ -18,8 +18,12 @@ use Temporal\Internal\Declaration\WorkflowInstanceInterface;
 use Temporal\Internal\ServiceContainer;
 use Temporal\Internal\Workflow\WorkflowContext;
 use Temporal\Worker\LoopInterface;
+use Temporal\Workflow\CancellationScopeInterface;
 use Temporal\Workflow\ProcessInterface;
 
+/**
+ * @implements CancellationScopeInterface<mixed>
+ */
 class Process extends Scope implements ProcessInterface
 {
     /**

--- a/src/Internal/Workflow/Process/Scope.php
+++ b/src/Internal/Workflow/Process/Scope.php
@@ -403,7 +403,7 @@ class Scope implements CancellationScopeInterface
      */
     protected function onRequest(RequestInterface $request, PromiseInterface $promise): void
     {
-        $this->onCancel[++$this->cancelID] = function (\Throwable $reason = null) use ($request): void {
+        $this->onCancel[++$this->cancelID] = function (?\Throwable $reason = null) use ($request): void {
             if ($reason instanceof DestructMemorizedInstanceException) {
                 // memory flush
                 $this->context->getClient()->reject($request, $reason);
@@ -521,7 +521,10 @@ class Scope implements CancellationScopeInterface
             throw $e;
         };
 
-        $promise->then($onFulfilled, $onRejected);
+        $promise
+            ->then($onFulfilled, $onRejected)
+            // Handle last error
+            ->then(null, fn (\Throwable $e) => null);
     }
 
     /**

--- a/src/Internal/Workflow/Process/Scope.php
+++ b/src/Internal/Workflow/Process/Scope.php
@@ -34,6 +34,7 @@ use Temporal\Workflow\WorkflowContextInterface;
  *
  * @internal CoroutineScope is an internal library class, please do not use it in your code.
  * @psalm-internal Temporal\Internal\Workflow
+ * @implements CancellationScopeInterface<mixed>
  */
 class Scope implements CancellationScopeInterface
 {

--- a/src/Internal/Workflow/WorkflowContext.php
+++ b/src/Internal/Workflow/WorkflowContext.php
@@ -507,7 +507,7 @@ class WorkflowContext implements WorkflowContextInterface
         foreach ($this->awaits as $awaitsGroupId => $awaitsGroup) {
             foreach ($awaitsGroup as $i => [$condition, $deferred]) {
                 if ($condition()) {
-                    $deferred->resolve();
+                    $deferred->resolve(null);
                     unset($this->awaits[$awaitsGroupId][$i]);
                     $this->resolveConditionGroup($awaitsGroupId);
                 }

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -11,16 +11,17 @@ declare(strict_types=1);
 
 namespace Temporal;
 
+use React\Promise\Exception\LengthException;
 use React\Promise\PromiseInterface;
+use Temporal\Internal\Promise\CancellationQueue;
+
+use Temporal\Internal\Promise\Reasons;
 
 use function React\Promise\all;
 use function React\Promise\any;
-use function React\Promise\map;
-use function React\Promise\reduce;
-use function React\Promise\some;
-use function React\Promise\resolve;
-use function React\Promise\reject;
 use function React\Promise\race;
+use function React\Promise\reject;
+use function React\Promise\resolve;
 
 /**
  * @psalm-type PromiseMapCallback = callable(mixed $value): mixed
@@ -69,7 +70,7 @@ final class Promise
      *
      * The returned promise will reject if it becomes impossible for `$count`
      * items to resolve (that is, when `(count($promises) - $count) + 1` items
-     * reject). The rejection value will be an array of
+     * reject). The rejection value will be an iterable-exception of
      * `(count($promises) - $howMany) + 1` rejection reasons.
      *
      * The returned promise will also reject with a {@see LengthException} if
@@ -81,7 +82,70 @@ final class Promise
      */
     public static function some(iterable $promises, int $count): PromiseInterface
     {
-        return some([...$promises], $count);
+        $cancellationQueue = new CancellationQueue();
+        $cancellationQueue->enqueue($promises);
+
+        return new \React\Promise\Promise(
+            static function (callable $resolve, callable $reject) use ($promises, $count, $cancellationQueue): void {
+                resolve($promises)->then(
+                    static function (iterable $array) use ($count, $cancellationQueue, $resolve, $reject): void {
+                        if (!\is_array($array) || $count < 1) {
+                            $resolve([]);
+                            return;
+                        }
+
+                        $len = \count($array);
+
+                        if ($len < $count) {
+                            $reject(new LengthException(
+                                \sprintf(
+                                    'Input array must contain at least %d item%s but contains only %s item%s.',
+                                    $count,
+                                    1 === $count ? '' : 's',
+                                    $len,
+                                    1 === $len ? '' : 's'
+                                )
+                            ));
+                            return;
+                        }
+
+                        $toResolve = $count;
+                        $toReject = ($len - $toResolve) + 1;
+                        $values = [];
+                        $reasons = [];
+
+                        foreach ($array as $i => $promiseOrValue) {
+                            $fulfiller = static function (mixed $val) use ($i, &$values, &$toResolve, $toReject, $resolve): void {
+                                if ($toResolve < 1 || $toReject < 1) {
+                                    return;
+                                }
+
+                                $values[$i] = $val;
+
+                                if (0 === --$toResolve) {
+                                    $resolve($values);
+                                }
+                            };
+
+                            $rejecter = static function (\Throwable $reason) use ($i, &$reasons, &$toReject, $toResolve, $reject): void {
+                                if ($toResolve < 1 || $toReject < 1) {
+                                    return;
+                                }
+
+                                $reasons[$i] = $reason;
+
+                                if (0 === --$toReject) {
+                                    $reject(new Reasons($reasons));
+                                }
+                            };
+
+                            $cancellationQueue->enqueue($promiseOrValue);
+
+                            resolve($promiseOrValue)->then($fulfiller, $rejecter);
+                        }
+                    }, $reject);
+            }, $cancellationQueue
+        );
     }
 
     /**
@@ -99,7 +163,41 @@ final class Promise
      */
     public static function map(iterable $promises, callable $map): PromiseInterface
     {
-        return map([...$promises], $map);
+        $cancellationQueue = new CancellationQueue();
+        $cancellationQueue->enqueue($promises);
+
+        return new \React\Promise\Promise(
+            function (callable $resolve, callable $reject) use ($promises, $map, $cancellationQueue): void {
+                resolve($promises)
+                    ->then(static function (iterable $array) use ($map, $cancellationQueue, $resolve, $reject): void {
+                        if (!\is_array($array) || !$array) {
+                            $resolve([]);
+                            return;
+                        }
+
+                        $toResolve = \count($array);
+                        $values = [];
+
+                        foreach ($array as $i => $promiseOrValue) {
+                            $cancellationQueue->enqueue($promiseOrValue);
+                            $values[$i] = null;
+
+                            resolve($promiseOrValue)
+                                ->then($map)
+                                ->then(
+                                    static function (mixed $mapped) use ($i, &$values, &$toResolve, $resolve): void {
+                                        $values[$i] = $mapped;
+
+                                        if (0 === --$toResolve) {
+                                            $resolve($values);
+                                        }
+                                    },
+                                    $reject,
+                                );
+                        }
+                    }, $reject);
+            }, $cancellationQueue
+        );
     }
 
     /**
@@ -116,7 +214,55 @@ final class Promise
      */
     public static function reduce(iterable $promises, callable $reduce, $initial = null): PromiseInterface
     {
-        return reduce([...$promises], $reduce, $initial);
+        $cancellationQueue = new CancellationQueue();
+        $cancellationQueue->enqueue($promises);
+
+        return new \React\Promise\Promise(
+            function (callable $resolve, callable $reject) use ($promises, $reduce, $initial, $cancellationQueue): void {
+                resolve($promises)
+                    ->then(
+                        static function (iterable $array) use (
+                            $reduce,
+                            $initial,
+                            $cancellationQueue,
+                            $resolve,
+                            $reject,
+                        ): void {
+                            if (!\is_array($array)) {
+                                $array = [];
+                            }
+
+                            $total = \count($array);
+                            $i = 0;
+
+                            // Wrap the supplied $reduce with one that handles promises and then
+                            // delegates to the supplied.
+                            $wrappedReduceFunc = static function (PromiseInterface $current, mixed $val) use (
+                                $reduce,
+                                $cancellationQueue,
+                                $total,
+                                &$i
+                            ): PromiseInterface {
+                                $cancellationQueue->enqueue($val);
+
+                                return $current
+                                    ->then(static function (mixed $c) use ($reduce, $total, &$i, $val): PromiseInterface {
+                                        return resolve($val)
+                                            ->then(static function (mixed $value) use ($reduce, $total, &$i, $c): mixed {
+                                                return $reduce($c, $value, $i++, $total);
+                                            });
+                                    });
+                            };
+
+                            $cancellationQueue->enqueue($initial);
+
+                            \array_reduce($array, $wrappedReduceFunc, resolve($initial))
+                                ->then($resolve, $reject);
+                        },
+                        $reject,
+                    );
+            }, $cancellationQueue
+        );
     }
 
     /**

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Temporal;
 
 use React\Promise\Exception\LengthException;
+use React\Promise\Internal\RejectedPromise;
 use React\Promise\PromiseInterface;
 use Temporal\Internal\Promise\CancellationQueue;
 
@@ -207,7 +208,7 @@ final class Promise
      *
      * @psalm-param PromiseReduceCallback $reduce
      * @param iterable<int, PromiseInterface|mixed> $promises
-     * @param callable $reduce
+     * @param callable(mixed $current, mixed $carry, int $current, positive-int $items): mixed $reduce
      * @param mixed $initial
      * @return PromiseInterface
      */
@@ -297,7 +298,7 @@ final class Promise
      * the value of another promise.
      *
      * @param $promiseOrValue
-     * @return PromiseInterface
+     * @return PromiseInterface<never>
      */
     public static function reject($promiseOrValue = null): PromiseInterface
     {
@@ -311,8 +312,9 @@ final class Promise
      * The returned promise will become **infinitely pending** if  `$promisesOrValues`
      * contains 0 items.
      *
-     * @param iterable $promisesOrValues
-     * @return PromiseInterface
+     * @template T
+     * @param iterable<PromiseInterface<T>|T> $promisesOrValues
+     * @return PromiseInterface<T>
      */
     public static function race(iterable $promisesOrValues): PromiseInterface
     {

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -17,8 +17,6 @@ use Temporal\Internal\Promise\CancellationQueue;
 
 use Temporal\Internal\Promise\Reasons;
 
-use function React\Promise\all;
-use function React\Promise\any;
 use function React\Promise\race;
 use function React\Promise\reject;
 use function React\Promise\resolve;
@@ -40,7 +38,7 @@ final class Promise
      */
     public static function all(iterable $promises): PromiseInterface
     {
-        return all([...$promises]);
+        return self::map($promises, static fn($val): mixed => $val);
     }
 
     /**
@@ -59,7 +57,8 @@ final class Promise
      */
     public static function any(iterable $promises): PromiseInterface
     {
-        return any([...$promises]);
+        return self::some([...$promises], 1)
+            ->then(static fn(array $values): mixed => \array_shift($values));
     }
 
     /**

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -27,7 +27,6 @@ use Temporal\Workflow\ChildWorkflowOptions;
 use Temporal\Workflow\ChildWorkflowStubInterface;
 use Temporal\Workflow\ContinueAsNewOptions;
 use Temporal\Workflow\ExternalWorkflowStubInterface;
-use Temporal\Workflow\ParentClosePolicy;
 use Temporal\Workflow\ScopedContextInterface;
 use Temporal\Internal\Workflow\WorkflowContext;
 use Temporal\Workflow\WorkflowExecution;
@@ -318,7 +317,7 @@ final class Workflow extends Facade
      *
      * @param DateIntervalValue $interval
      * @param callable|PromiseInterface ...$conditions
-     * @return PromiseInterface
+     * @return PromiseInterface<bool>
      */
     public static function awaitWithTimeout($interval, ...$conditions): PromiseInterface
     {
@@ -424,7 +423,7 @@ final class Workflow extends Facade
      * @param string $changeId
      * @param int $minSupported
      * @param int $maxSupported
-     * @return PromiseInterface
+     * @return PromiseInterface<int>
      * @throws OutOfContextException in the absence of the workflow execution context.
      */
     public static function getVersion(string $changeId, int $minSupported, int $maxSupported): PromiseInterface
@@ -453,8 +452,9 @@ final class Workflow extends Facade
      *  }
      * </code>
      *
-     * @param callable $value
-     * @return PromiseInterface
+     * @template TReturn
+     * @param callable(): TReturn $value
+     * @return PromiseInterface<TReturn>
      * @throws OutOfContextException in the absence of the workflow execution context.
      */
     public static function sideEffect(callable $value): PromiseInterface
@@ -489,7 +489,7 @@ final class Workflow extends Facade
      * </code>
      *
      * @param DateIntervalValue $interval
-     * @return PromiseInterface
+     * @return PromiseInterface<null>
      * @throws OutOfContextException in the absence of the workflow execution context.
      */
     public static function timer($interval): PromiseInterface
@@ -830,7 +830,7 @@ final class Workflow extends Facade
      * @param array $args
      * @param ActivityOptions|null $options
      * @param Type|string|null|\ReflectionClass|\ReflectionType $returnType
-     * @return PromiseInterface
+     * @return PromiseInterface<mixed>
      * @throws OutOfContextException in the absence of the workflow execution context.
      */
     public static function executeActivity(
@@ -946,7 +946,7 @@ final class Workflow extends Facade
     /**
      * Generate a UUID.
      *
-     * @return PromiseInterface
+     * @return PromiseInterface<UuidInterface>
      */
     public static function uuid(): PromiseInterface
     {
@@ -959,7 +959,7 @@ final class Workflow extends Facade
     /**
      * Generate a UUID version 4 (random).
      *
-     * @return PromiseInterface
+     * @return PromiseInterface<UuidInterface>
      */
     public static function uuid4(): PromiseInterface
     {
@@ -976,7 +976,7 @@ final class Workflow extends Facade
      *     to create the version 7 UUID. If not provided, the UUID is generated
      *     using the current date/time.
      *
-     * @return PromiseInterface
+     * @return PromiseInterface<UuidInterface>
      */
     public static function uuid7(?DateTimeInterface $dateTime = null): PromiseInterface
     {

--- a/src/Workflow/CancellationScopeInterface.php
+++ b/src/Workflow/CancellationScopeInterface.php
@@ -11,10 +11,9 @@ declare(strict_types=1);
 
 namespace Temporal\Workflow;
 
-use React\Promise\CancellablePromiseInterface;
 use React\Promise\PromiseInterface;
 
-interface CancellationScopeInterface extends PromiseInterface, CancellablePromiseInterface
+interface CancellationScopeInterface extends PromiseInterface
 {
     /**
      * Detached scopes can continue working even if parent scope was cancelled.
@@ -37,4 +36,15 @@ interface CancellationScopeInterface extends PromiseInterface, CancellablePromis
      * @return $this
      */
     public function onCancel(callable $then): self;
+
+    /**
+     * The `cancel()` method notifies the creator of the promise that there is no
+     * further interest in the results of the operation.
+     *
+     * Once a promise is settled (either fulfilled or rejected), calling `cancel()` on
+     * a promise has no effect.
+     *
+     * @return void
+     */
+    public function cancel();
 }

--- a/src/Workflow/CancellationScopeInterface.php
+++ b/src/Workflow/CancellationScopeInterface.php
@@ -13,6 +13,10 @@ namespace Temporal\Workflow;
 
 use React\Promise\PromiseInterface;
 
+/**
+ * @template T
+ * @extends PromiseInterface<T>
+ */
 interface CancellationScopeInterface extends PromiseInterface
 {
     /**

--- a/src/Workflow/CancellationScopeInterface.php
+++ b/src/Workflow/CancellationScopeInterface.php
@@ -46,5 +46,5 @@ interface CancellationScopeInterface extends PromiseInterface
      *
      * @return void
      */
-    public function cancel();
+    public function cancel(): void;
 }

--- a/src/Workflow/ProcessInterface.php
+++ b/src/Workflow/ProcessInterface.php
@@ -13,6 +13,10 @@ namespace Temporal\Workflow;
 
 use Temporal\Internal\Repository\Identifiable;
 
+/**
+ * @template T
+ * @extends CancellationScopeInterface<T>
+ */
 interface ProcessInterface extends CancellationScopeInterface, Identifiable
 {
     /**

--- a/src/Workflow/WorkflowContextInterface.php
+++ b/src/Workflow/WorkflowContextInterface.php
@@ -94,11 +94,9 @@ interface WorkflowContextInterface extends EnvironmentInterface
     /**
      * @see Workflow::sideEffect()
      *
-     * @psalm-type SideEffectCallback = callable(): mixed
-     * @psalm-param SideEffectCallback $context
-     *
-     * @param callable $context
-     * @return PromiseInterface
+     * @template TReturn
+     * @param callable(): TReturn $context
+     * @return PromiseInterface<TReturn>
      */
     public function sideEffect(callable $context): PromiseInterface;
 
@@ -223,7 +221,7 @@ interface WorkflowContextInterface extends EnvironmentInterface
      * @param array $args
      * @param ActivityOptions|null $options
      * @param Type|string|null|\ReflectionClass|\ReflectionType $returnType
-     * @return PromiseInterface
+     * @return PromiseInterface<mixed>
      */
     public function executeActivity(
         string $type,
@@ -266,7 +264,7 @@ interface WorkflowContextInterface extends EnvironmentInterface
      *
      * @param DateIntervalValue $interval
      * @param callable|PromiseInterface ...$conditions
-     * @return PromiseInterface
+     * @return PromiseInterface<bool>
      */
     public function awaitWithTimeout($interval, ...$conditions): PromiseInterface;
 
@@ -287,7 +285,7 @@ interface WorkflowContextInterface extends EnvironmentInterface
      *
      * Generate a UUID.
      *
-     * @return PromiseInterface
+     * @return PromiseInterface<UuidInterface>
      */
     public function uuid(): PromiseInterface;
 
@@ -296,7 +294,7 @@ interface WorkflowContextInterface extends EnvironmentInterface
      *
      * Generate a UUID version 4 (random).
      *
-     * @return PromiseInterface
+     * @return PromiseInterface<UuidInterface>
      */
     public function uuid4(): PromiseInterface;
 
@@ -309,7 +307,7 @@ interface WorkflowContextInterface extends EnvironmentInterface
      *     to create the version 7 UUID. If not provided, the UUID is generated
      *     using the current date/time.
      *
-     * @return PromiseInterface
+     * @return PromiseInterface<UuidInterface>
      */
     public function uuid7(?DateTimeInterface $dateTime = null): PromiseInterface;
 }

--- a/tests/Fixtures/src/Workflow/CancelSignalledChildWorkflow.php
+++ b/tests/Fixtures/src/Workflow/CancelSignalledChildWorkflow.php
@@ -44,7 +44,7 @@ class CancelSignalledChildWorkflow
 
                 yield $simple->add(8);
                 $this->status[] = 'child signalled';
-                $waitSignalled->resolve();
+                $waitSignalled->resolve(null);
 
                 return yield $call;
             }

--- a/tests/Unit/Promise/BaseFunction.php
+++ b/tests/Unit/Promise/BaseFunction.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\Promise;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use React\Promise\CancellablePromiseInterface;
+use React\Promise\PromiseInterface;
+
+/**
+ * Got from reactphp/promise and modified
+ * @link https://github.com/reactphp/promise/blob/f913fb8cceba1e6644b7b90c4bfb678ed8a3ef38/tests/TestCase.php
+ * @license MIT
+ */
+abstract class BaseFunction extends TestCase
+{
+    protected function expectCallableExactly($amount)
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->exactly($amount))
+            ->method('__invoke');
+
+        return $mock;
+    }
+
+    protected function expectCallableOnce()
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke');
+
+        return $mock;
+    }
+
+    protected function expectCallableNever(): callable
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->never())
+            ->method('__invoke');
+
+        return $mock;
+    }
+
+    protected function createCallableMock()
+    {
+        return $this->getMockBuilder('stdClass')->addMethods(array('__invoke'))->getMock();
+    }
+
+    protected function setExpectedException($exception, $exceptionMessage = '', $exceptionCode = null)
+    {
+        $this->expectException($exception);
+        if ($exceptionMessage !== '') {
+            $this->expectExceptionMessage($exceptionMessage);
+        }
+        if ($exceptionCode !== null) {
+            $this->expectExceptionCode($exceptionCode);
+        }
+    }
+
+    protected function creteCancellableMock(): MockObject
+    {
+        return \interface_exists(CancellablePromiseInterface::class)
+            ? $this
+                ->getMockBuilder(CancellablePromiseInterface::class)
+                ->getMock()
+            : $this
+                ->getMockBuilder(PromiseInterface::class)
+                ->getMock();
+    }
+}

--- a/tests/Unit/Promise/FunctionAllTestCase.php
+++ b/tests/Unit/Promise/FunctionAllTestCase.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Promise;
+
+use React\Promise\Deferred;
+use Temporal\Promise;
+use Temporal\Tests\Unit\Promise\BaseFunction;
+
+/**
+ * Got from reactphp/promise and modified
+ * @license MIT
+ * @link https://github.com/reactphp/promise/blob/f913fb8cceba1e6644b7b90c4bfb678ed8a3ef38/tests/FunctionAllTest.php
+ */
+final class FunctionAllTestCase extends BaseFunction
+{
+    public function testResolveEmptyInput(): void
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo([]));
+
+        Promise::all([])
+            ->then($mock);
+    }
+
+    public function testResolveValuesArray(): void
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo([1, 2, 3]));
+
+        Promise::all([1, 2, 3])
+            ->then($mock);
+    }
+
+    public function testResolvePromisesArray(): void
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo([1, 2, 3]));
+
+        Promise::all([Promise::resolve(1), Promise::resolve(2), Promise::resolve(3)])
+            ->then($mock);
+    }
+
+    public function testResolveSparseArrayInput(): void
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo([null, 1, null, 1, 1]));
+
+        Promise::all([null, 1, null, 1, 1])
+            ->then($mock);
+    }
+
+    public function testRejectIfAnyInputPromiseRejects(): void
+    {
+        $e = new \Exception();
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo($e));
+
+        Promise::all([Promise::resolve(1), Promise::reject($e), Promise::resolve(3)])
+            ->then($this->expectCallableNever(), $mock);
+    }
+
+    public function testAcceptAPromiseForAnArray(): void
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo([1, 2, 3]));
+
+        Promise::all([Promise::resolve(1), Promise::resolve(2), Promise::resolve(3)])
+            ->then($mock);
+    }
+
+    public function testPreserveTheOrderOfArrayWhenResolvingAsyncPromises(): void
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo([1, 2, 3]));
+
+        $deferred = new Deferred();
+
+        Promise::all([Promise::resolve(1), $deferred->promise(), Promise::resolve(3)])
+            ->then($mock);
+
+        $deferred->resolve(2);
+    }
+}

--- a/tests/Unit/Promise/FunctionAnyTestCase.php
+++ b/tests/Unit/Promise/FunctionAnyTestCase.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Promise;
+
+use React\Promise\Deferred;
+use React\Promise\Exception\LengthException;
+use Temporal\Internal\Promise\Reasons;
+use Temporal\Promise;
+use Temporal\Tests\Unit\Promise\BaseFunction;
+
+/**
+ * Got from reactphp/promise and modified
+ * @license MIT
+ * @link https://github.com/reactphp/promise/blob/f913fb8cceba1e6644b7b90c4bfb678ed8a3ef38/tests/FunctionAnyTest.php
+ */
+final class FunctionAnyTestCase extends BaseFunction
+{
+    public function testRejectWithLengthExceptionWithEmptyInputArray(): void
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with(
+                $this->callback(function ($exception) {
+                    return $exception instanceof LengthException &&
+                        'Input array must contain at least 1 item but contains only 0 items.' === $exception->getMessage();
+                })
+            );
+
+        Promise::any([])
+            ->then($this->expectCallableNever(), $mock);
+    }
+
+    public function testResolveWithAnInputValue(): void
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo(1));
+
+        Promise::any([1, 2, 3])
+            ->then($mock);
+    }
+
+    public function testResolveWithAPromisedInputValue(): void
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo(1));
+
+        Promise::any([Promise::resolve(1), Promise::resolve(2), Promise::resolve(3)])
+            ->then($mock);
+    }
+
+    public function testRejectWithAllRejectedInputValuesIfAllInputsAreRejected(): void
+    {
+        $e1 = new \Exception();
+        $e2 = new \Exception();
+        $e3 = new \Exception();
+
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->callback(fn (Reasons $e): bool => \iterator_to_array($e) === [0 => $e1, 1 => $e2, 2 => $e3]));
+
+        Promise::any([Promise::reject($e1), Promise::reject($e2), Promise::reject($e3)])
+            ->then($this->expectCallableNever(), $mock);
+    }
+
+    public function testResolveWhenFirstInputPromiseResolves(): void
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo(1));
+
+        Promise::any([Promise::resolve(1), Promise::reject(new \Exception()), Promise::reject(new \Exception())])
+            ->then($mock);
+    }
+
+    public function testNotRelyOnArryIndexesWhenUnwrappingToASingleResolutionValue(): void
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo(2));
+
+        $d1 = new Deferred();
+        $d2 = new Deferred();
+
+        Promise::any(['abc' => $d1->promise(), 1 => $d2->promise()])
+            ->then($mock);
+
+        $d2->resolve(2);
+        $d1->resolve(1);
+    }
+
+    public function testRejectWhenInputPromiseRejects(): void
+    {
+        $e = new \Exception();
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            // ->with($this->identicalTo(null));
+            ->with($this->callback(fn (Reasons $reason): bool => \iterator_to_array($reason) === [$e]));
+
+        Promise::any([Promise::reject($e)])
+            ->then($this->expectCallableNever(), $mock)
+            ->then(null, fn(\Throwable $e) => null);
+    }
+
+    public function testCancelInputPromise(): void
+    {
+        $mock = $this->creteCancellableMock();
+        $mock
+            ->expects($this->once())
+            ->method('cancel');
+
+        Promise::any([$mock])->cancel();
+    }
+
+    public function testCancelInputArrayPromises(): void
+    {
+        $mock1 = $this->creteCancellableMock();
+        $mock1
+            ->expects($this->once())
+            ->method('cancel');
+
+        $mock2 = $this->creteCancellableMock();
+        $mock2
+            ->expects($this->once())
+            ->method('cancel');
+
+        Promise::any([$mock1, $mock2])->cancel();
+    }
+
+    public function testNotCancelOtherPendingInputArrayPromisesIfOnePromiseFulfills(): void
+    {
+        $e = new \Exception();
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->never())
+            ->method('__invoke');
+
+
+        $deferred = new Deferred($mock);
+        $deferred->resolve($e);
+
+        $mock2 = $this->creteCancellableMock();
+        $mock2
+            ->expects($this->never())
+            ->method('cancel');
+
+        Promise::some([$deferred->promise(), $mock2], 1)->cancel();
+    }
+}

--- a/tests/Unit/Promise/FunctionMapTestCase.php
+++ b/tests/Unit/Promise/FunctionMapTestCase.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\Promise;
+
+use Exception;
+use React\Promise\Deferred;
+use Temporal\Promise;
+
+/**
+ * Got from reactphp/promise and modified
+ * @license MIT
+ * @link https://github.com/reactphp/promise/blob/f913fb8cceba1e6644b7b90c4bfb678ed8a3ef38/tests/FunctionMapTest.php
+ */
+final class FunctionMapTestCase extends BaseFunction
+{
+    public function testMapInputValuesArray(): void
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo([2, 4, 6]));
+
+        Promise::map(
+            [1, 2, 3],
+            $this->mapper()
+        )->then($mock);
+    }
+
+    public function testMapInputPromisesArray(): void
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo([2, 4, 6]));
+
+        Promise::map(
+            [Promise::resolve(1), Promise::resolve(2), Promise::resolve(3)],
+            $this->mapper()
+        )->then($mock);
+    }
+
+    public function testMapMixedInputArray(): void
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo([2, 4, 6]));
+
+        Promise::map(
+            [1, Promise::resolve(2), 3],
+            $this->mapper()
+        )->then($mock);
+    }
+
+    public function testMapInputWhenMapperReturnsAPromise(): void
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo([2, 4, 6]));
+
+        Promise::map(
+            [1, 2, 3],
+            $this->promiseMapper()
+        )->then($mock);
+    }
+
+    public function testPreserveTheOrderOfArrayWhenResolvingAsyncPromises(): void
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo([2, 4, 6]));
+
+        $deferred = new Deferred();
+
+        Promise::map(
+            [Promise::resolve(1), $deferred->promise(), Promise::resolve(3)],
+            $this->mapper()
+        )->then($mock);
+
+        $deferred->resolve(2);
+    }
+
+    public function testRejectWhenInputContainsRejection(): void
+    {
+        $e = new Exception();
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo($e));
+
+        Promise::map(
+            [Promise::resolve(1), Promise::reject($e), Promise::resolve(3)],
+            $this->mapper()
+        )->then($this->expectCallableNever(), $mock);
+    }
+
+    public function testRejectWhenInputPromiseRejects(): void
+    {
+        $e = new Exception();
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo($e));
+
+        Promise::map(
+            [Promise::reject($e)],
+            $this->mapper()
+        )->then($this->expectCallableNever(), $mock);
+    }
+
+    public function testCancelInputPromise(): void
+    {
+        $mock = $this->creteCancellableMock();
+        $mock
+            ->expects($this->once())
+            ->method('cancel');
+
+        Promise::map(
+            [$mock],
+            $this->mapper()
+        )->cancel();
+    }
+
+    public function testCancelInputArrayPromises(): void
+    {
+        $mock1 = $this
+            ->creteCancellableMock();
+        $mock1
+            ->expects($this->once())
+            ->method('cancel');
+
+        $mock2 = $this
+            ->creteCancellableMock();
+        $mock2
+            ->expects($this->once())
+            ->method('cancel');
+
+        Promise::map(
+            [$mock1, $mock2],
+            $this->mapper()
+        )->cancel();
+    }
+
+    protected function mapper(): callable
+    {
+        return static fn($val) => $val * 2;
+    }
+
+    protected function promiseMapper(): callable
+    {
+        return static fn($val) => Promise::resolve($val * 2);
+    }
+}

--- a/tests/Unit/Promise/FunctionReduceTestCase.php
+++ b/tests/Unit/Promise/FunctionReduceTestCase.php
@@ -13,7 +13,7 @@ use Temporal\Promise;
  * @license MIT
  * @link https://github.com/reactphp/promise/blob/f913fb8cceba1e6644b7b90c4bfb678ed8a3ef38/tests/FunctionReduceTest.php
  */
-class FunctionReduceTestCase extends BaseFunction
+final class FunctionReduceTestCase extends BaseFunction
 {
     public function testReduceValuesWithoutInitialValue(): void
     {

--- a/tests/Unit/Promise/FunctionReduceTestCase.php
+++ b/tests/Unit/Promise/FunctionReduceTestCase.php
@@ -1,0 +1,301 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\Promise;
+
+use Exception;
+use React\Promise\Deferred;
+use Temporal\Promise;
+
+/**
+ * Got from reactphp/promise and modified
+ * @license MIT
+ * @link https://github.com/reactphp/promise/blob/f913fb8cceba1e6644b7b90c4bfb678ed8a3ef38/tests/FunctionReduceTest.php
+ */
+class FunctionReduceTestCase extends BaseFunction
+{
+    public function testReduceValuesWithoutInitialValue(): void
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo(6));
+
+        Promise::reduce(
+            [1, 2, 3],
+            $this->plus()
+        )->then($mock);
+    }
+
+    public function testReduceValuesWithInitialValue(): void
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo(7));
+
+        Promise::reduce(
+            [1, 2, 3],
+            $this->plus(),
+            1
+        )->then($mock);
+    }
+
+    public function testReduceValuesWithInitialPromise(): void
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo(7));
+
+        Promise::reduce(
+            [1, 2, 3],
+            $this->plus(),
+            Promise::resolve(1)
+        )->then($mock);
+    }
+
+    public function testReducePromisedValuesWithoutInitialValue(): void
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo(6));
+
+        Promise::reduce(
+            [Promise::resolve(1), Promise::resolve(2), Promise::resolve(3)],
+            $this->plus()
+        )->then($mock);
+    }
+
+    public function testReducePromisedValuesWithInitialValue(): void
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo(7));
+
+        Promise::reduce(
+            [Promise::resolve(1), Promise::resolve(2), Promise::resolve(3)],
+            $this->plus(),
+            1
+        )->then($mock);
+    }
+
+    public function testReducePromisedValuesWithInitialPromise(): void
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo(7));
+
+        Promise::reduce(
+            [Promise::resolve(1), Promise::resolve(2), Promise::resolve(3)],
+            $this->plus(),
+            Promise::resolve(1)
+        )->then($mock);
+    }
+
+    public function testReduceEmptyInputWithInitialValue(): void
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo(1));
+
+        Promise::reduce(
+            [],
+            $this->plus(),
+            1
+        )->then($mock);
+    }
+
+    public function testReduceEmptyInputWithInitialPromise(): void
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo(1));
+
+        Promise::reduce(
+            [],
+            $this->plus(),
+            Promise::resolve(1)
+        )->then($mock);
+    }
+
+    public function testRejectWhenInputContainsRejection(): void
+    {
+        $e = new Exception();
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo($e));
+
+        Promise::reduce(
+            [Promise::resolve(1), Promise::reject($e), Promise::resolve(3)],
+            $this->plus(),
+            Promise::resolve(1)
+        )->then($this->expectCallableNever(), $mock);
+    }
+
+    public function testResolveWithNullWhenInputIsEmptyAndNoInitialValueOrPromiseProvided(): void
+    {
+        // Note: this is different from when.js's behavior!
+        // In when.Promise::reduce(), this rejects with a TypeError exception (following
+        // JavaScript's [].reduce behavior.
+        // We're following PHP's array_reduce behavior and resolve with NULL.
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo(null));
+
+        Promise::reduce(
+            [],
+            $this->plus()
+        )->then($mock);
+    }
+
+    public function testAllowSparseArrayInputWithoutInitialValue(): void
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo(3));
+
+        Promise::reduce(
+            [null, null, 1, null, 1, 1],
+            $this->plus()
+        )->then($mock);
+    }
+
+    public function testAllowSparseArrayInputWithInitialValue(): void
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo(4));
+
+        Promise::reduce(
+            [null, null, 1, null, 1, 1],
+            $this->plus(),
+            1
+        )->then($mock);
+    }
+
+    public function testReduceInInputOrder(): void
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo('123'));
+
+        Promise::reduce(
+            [1, 2, 3],
+            $this->append(),
+            ''
+        )->then($mock);
+    }
+
+    public function testProvideCorrectBasisValue(): void
+    {
+        $insertIntoArray = function ($arr, $val, $i) {
+            $arr[$i] = $val;
+
+            return $arr;
+        };
+
+        $d1 = new Deferred();
+        $d2 = new Deferred();
+        $d3 = new Deferred();
+
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo([1, 2, 3]));
+
+        Promise::reduce(
+            [$d1->promise(), $d2->promise(), $d3->promise()],
+            $insertIntoArray,
+            []
+        )->then($mock);
+
+        $d3->resolve(3);
+        $d1->resolve(1);
+        $d2->resolve(2);
+    }
+
+    public function testRejectWhenInputPromiseRejects(): void
+    {
+        $e = new Exception();
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo($e));
+
+        Promise::reduce(
+            [Promise::reject($e)],
+            $this->plus(),
+            1
+        )->then($this->expectCallableNever(), $mock);
+    }
+
+    public function testCancelInputPromise(): void
+    {
+        $mock = $this->creteCancellableMock();
+        $mock
+            ->expects($this->once())
+            ->method('cancel');
+
+        Promise::reduce(
+            [$mock],
+            $this->plus(),
+            1
+        )->cancel();
+    }
+
+    public function testCancelInputArrayPromises(): void
+    {
+        $mock1 = $this->creteCancellableMock();
+        $mock1
+            ->expects($this->once())
+            ->method('cancel');
+
+        $mock2 = $this->creteCancellableMock();
+        $mock2
+            ->expects($this->once())
+            ->method('cancel');
+
+        Promise::reduce(
+            [$mock1, $mock2],
+            $this->plus(),
+            1
+        )->cancel();
+    }
+
+    protected function plus(): callable
+    {
+        return static fn($sum, $val) => $sum + $val;
+    }
+
+    protected function append(): callable
+    {
+        return static fn($sum, $val) => $sum . $val;
+    }
+}

--- a/tests/Unit/Promise/FunctionSomeTestCase.php
+++ b/tests/Unit/Promise/FunctionSomeTestCase.php
@@ -16,7 +16,7 @@ use Temporal\Tests\Unit\Promise\BaseFunction;
  * @license MIT
  * @link https://github.com/reactphp/promise/blob/f913fb8cceba1e6644b7b90c4bfb678ed8a3ef38/tests/FunctionSomeTest.php
  */
-class FunctionSomeTestCase extends BaseFunction
+final class FunctionSomeTestCase extends BaseFunction
 {
     public function testRejectWithLengthExceptionWithEmptyInputArray(): void
     {

--- a/tests/Unit/Promise/FunctionSomeTestCase.php
+++ b/tests/Unit/Promise/FunctionSomeTestCase.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Promise;
+
+use Exception;
+use React\Promise\Deferred;
+use React\Promise\Exception\LengthException;
+use Temporal\Internal\Promise\Reasons;
+use Temporal\Promise;
+use Temporal\Tests\Unit\Promise\BaseFunction;
+
+/**
+ * Got from reactphp/promise and modified
+ * @license MIT
+ * @link https://github.com/reactphp/promise/blob/f913fb8cceba1e6644b7b90c4bfb678ed8a3ef38/tests/FunctionSomeTest.php
+ */
+class FunctionSomeTestCase extends BaseFunction
+{
+    public function testRejectWithLengthExceptionWithEmptyInputArray(): void
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with(
+                $this->callback(static function ($exception): bool {
+                    return $exception instanceof LengthException &&
+                        'Input array must contain at least 1 item but contains only 0 items.' === $exception->getMessage();
+                })
+            );
+
+        Promise::some([], 1)
+            ->then($this->expectCallableNever(), $mock);
+    }
+
+    public function testRejectWithLengthExceptionWithInputArrayContainingNotEnoughItems(): void
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with(
+                $this->callback(function ($exception) {
+                    return $exception instanceof LengthException &&
+                        'Input array must contain at least 4 items but contains only 3 items.' === $exception->getMessage();
+                })
+            );
+
+        Promise::some(
+            [1, 2, 3],
+            4
+        )->then($this->expectCallableNever(), $mock);
+    }
+
+    public function testResolveValuesArray(): void
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo([1, 2]));
+
+        Promise::some(
+            [1, 2, 3],
+            2
+        )->then($mock);
+    }
+
+    public function testResolvePromisesArray(): void
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo([1, 2]));
+
+        Promise::some(
+            [Promise::resolve(1), Promise::resolve(2), Promise::resolve(3)],
+            2
+        )->then($mock);
+    }
+
+    public function testResolveSparseArrayInput(): void
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo([null, 1]));
+
+        Promise::some(
+            [null, 1, null, 2, 3],
+            2
+        )->then($mock);
+    }
+
+    public function testRejectIfAnyInputPromiseRejectsBeforeDesiredNumberOfInputsAreResolved(): void
+    {
+        $e = new Exception();
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->callback(function (mixed $exception) use ($e) {
+                return $exception instanceof Reasons &&
+                    \in_array($e, \iterator_to_array($exception));
+            }));
+
+        Promise::some(
+            [Promise::resolve(1), Promise::reject($e), Promise::reject($e)],
+            2
+        )->then($this->expectCallableNever(), $mock);
+    }
+
+    public function testResolveWithEmptyArrayIfHowManyIsLessThanOne(): void
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo([]));
+
+        Promise::some(
+            [1],
+            0
+        )->then($mock);
+    }
+
+    public function testCancelInputArrayPromises(): void
+    {
+        $mock1 = $this
+            ->creteCancellableMock();
+        $mock1
+            ->expects($this->once())
+            ->method('cancel');
+
+        $mock2 = $this
+            ->creteCancellableMock();
+        $mock2
+            ->expects($this->once())
+            ->method('cancel');
+
+        Promise::some([$mock1, $mock2], 1)->cancel();
+    }
+
+    public function testNotCancelOtherPendingInputArrayPromisesIfEnoughPromisesFulfill(): void
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->never())
+            ->method('__invoke');
+
+        $deferred = new Deferred($mock);
+        $deferred->resolve(null);
+
+        $mock2 = $this
+            ->creteCancellableMock();
+        $mock2
+            ->expects($this->never())
+            ->method('cancel');
+
+        Promise::some([$deferred->promise(), $mock2], 1);
+    }
+
+    public function testNotCancelOtherPendingInputArrayPromisesIfEnoughPromisesReject(): void
+    {
+        $e = new Exception();
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->never())
+            ->method('__invoke');
+
+        $deferred = new Deferred($mock);
+        $deferred->reject($e);
+
+        $mock2 = $this
+            ->creteCancellableMock();
+        $mock2
+            ->expects($this->never())
+            ->method('cancel');
+
+        Promise::some([$deferred->promise(), $mock2], 2);
+    }
+}


### PR DESCRIPTION
## What was changed

Added supporting for `react/promise` v3 package.
I'm not sure that all 3rd packages was migrated to promises v3, that's why I paid attention to maintaining compatibility with the old promises version.
## Why?

It adds new features of extended promises like methods `catch()`, `finally()` and `cancel()`.
Also there were added `@template` annotations and better type coverage.

## Checklist
1. Closes #348
2. All old tests passed
- [x] Implement Temporal\Promise functions that were deleted from react/promise v3

## Release note

The ReactPHP Promise dependency has been updated from version 2 to version 3.

> **Note**: there are no BC breaks in the Temporal SDK, but there are BC breaks in the ReactPHP Promise library.
> If you rely on the functions of the ReactPHP Promise library and use them directly, please familiarize yourself with the list of changes [there](https://github.com/reactphp/promise/releases/tag/v3.0.0).
> We have not completely abandoned compatibility with Promise v2, and it will be available for some time — just add `"react/promise": "^2.9"` in your `composer.json`, if you are tied to Promise v2.


Despite the fact that some functions (`some()`, `map()`, `reduce()`) have been removed from React, they have remained in our `Temporal\Promise` helper with the same behavior.

Otherwise, meet:
 - the new convenient methods of `PromiseInterface`: `catch()` and `finally()`;
 - `@template` annotation for the `PromiseInterface`, which allows you to specify the type of the promise result.  
   So start specifying types in Activity and Workflow, and when [this initiative](https://github.com/orgs/reactphp/discussions/536) is implemented, the Workflow code will become fully typed and understandable for IDE and static analysis.

```php
#[\Temporal\Activity]
class MyActivityClass {
    /**
     * @return PromiseInterface<non-empty-string>
     */
    #[\Temporal\ActivityMethod]
    public function myActivityMethod(): string {
        return 'some string';
    }
}

#[\Temporal\Workflow]
class MyWorkflowClass {
    #[\Temporal\WorkflowMethod]
    public function handle() {
        $activity = Workflow::newActivityStub(MyActivityClass::class);
        // IDE will know that the result is a string
        $result = yield $activity->myActivityMethod();
    }
}
```