### PR TITLE
Add Workflow::uuid() | uuid4() | uuid7() methods

### DIFF
--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -13,7 +13,7 @@ on:
       test-timeout:
         required: false
         type: number
-        default: 10
+        default: 15
       run-temporal-test-server:
         required: false
         type: boolean

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.13.1@086b94371304750d1c673315321a55d15fc59015">
+<files psalm-version="5.15.0@5c774aca4746caf3d239d9c8cadb9f882ca29352">
   <file src="src/Activity.php">
     <ImplicitToStringCast>
       <code>$type</code>
@@ -53,15 +53,10 @@
       <code>$timeout</code>
     </PossiblyInvalidArgument>
   </file>
-  <file src="src/Client/Paginator.php">
-    <InvalidDocblock>
-      <code><![CDATA[$this->nextPage->counter = &$this->nextPage;]]></code>
-    </InvalidDocblock>
-    <UnsupportedPropertyReferenceUsage>
-      <code><![CDATA[$this->nextPage->counter = &$this->nextPage]]></code>
-    </UnsupportedPropertyReferenceUsage>
-  </file>
   <file src="src/Client/WorkflowClient.php">
+    <ArgumentTypeCoercion>
+      <code>$counter</code>
+    </ArgumentTypeCoercion>
     <InvalidReturnStatement>
       <code><![CDATA[new WorkflowProxy(
             $this,
@@ -88,10 +83,10 @@
       <code><![CDATA[$workflowStub->getWorkflowType()]]></code>
       <code><![CDATA[$workflowStub->getWorkflowType()]]></code>
     </PossiblyNullArgument>
-    <TooFewArguments>
+    <RedundantFunctionCall>
       <code>\sprintf</code>
       <code>\sprintf</code>
-    </TooFewArguments>
+    </RedundantFunctionCall>
   </file>
   <file src="src/Client/WorkflowOptions.php">
     <PossiblyNullReference>
@@ -763,6 +758,11 @@
       <code>new static()</code>
     </UnsafeInstantiation>
   </file>
+  <file src="src/Internal/Support/StackRenderer.php">
+    <PossiblyInvalidArgument>
+      <code>$path</code>
+    </PossiblyInvalidArgument>
+  </file>
   <file src="src/Internal/Transport/Client.php">
     <InternalClass>
       <code>self::ERROR_REQUEST_ID_DUPLICATION</code>
@@ -770,15 +770,18 @@
     </InternalClass>
     <InternalMethod>
       <code>fetch</code>
-      <code>fetch</code>
-      <code>fetch</code>
       <code>get</code>
+      <code>reject</code>
       <code>request</code>
     </InternalMethod>
     <InternalProperty>
-      <code><![CDATA[$this->queue]]></code>
       <code><![CDATA[$this->requests]]></code>
     </InternalProperty>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$command->getID()]]></code>
+      <code><![CDATA[$command->getID()]]></code>
+      <code><![CDATA[$command->getID()]]></code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="src/Internal/Transport/Request/NewTimer.php">
     <PossiblyNullPropertyFetch>
@@ -819,26 +822,36 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="src/Internal/Transport/Router/InvokeQuery.php">
+    <InternalMethod>
+      <code>getContext</code>
+    </InternalMethod>
     <PossiblyNullFunctionCall>
       <code><![CDATA[$handler($request->getPayloads())]]></code>
     </PossiblyNullFunctionCall>
+    <PossiblyUndefinedStringArrayOffset>
+      <code><![CDATA[$request->getOptions()['name']]]></code>
+    </PossiblyUndefinedStringArrayOffset>
     <UndefinedInterfaceMethod>
       <code>getQueryHandlerNames</code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="src/Internal/Transport/Router/InvokeSignal.php">
+    <PossiblyNullPropertyAssignment>
+      <code><![CDATA[$instance->getContext()]]></code>
+    </PossiblyNullPropertyAssignment>
     <PossiblyUndefinedStringArrayOffset>
-      <code><![CDATA[$payload['name']]]></code>
-      <code><![CDATA[$payload['runId']]]></code>
+      <code><![CDATA[$request->getOptions()['name']]]></code>
     </PossiblyUndefinedStringArrayOffset>
   </file>
   <file src="src/Internal/Transport/Router/StackTrace.php">
     <InternalMethod>
       <code>getContext</code>
     </InternalMethod>
-    <PossiblyNullArgument>
-      <code><![CDATA[$payload['runId'] ?? null]]></code>
-    </PossiblyNullArgument>
+  </file>
+  <file src="src/Internal/Transport/Router/StartWorkflow.php">
+    <UnnecessaryVarAnnotation>
+      <code>Input</code>
+    </UnnecessaryVarAnnotation>
   </file>
   <file src="src/Internal/Transport/Router/WorkflowProcessAwareRoute.php">
     <LessSpecificReturnStatement>
@@ -849,6 +862,13 @@
     </MoreSpecificReturnType>
   </file>
   <file src="src/Internal/Transport/Server.php">
+    <InvalidArgument>
+      <code>$request</code>
+    </InvalidArgument>
+    <MismatchingDocblockParamType>
+      <code>RequestInterface</code>
+      <code>RequestInterface</code>
+    </MismatchingDocblockParamType>
     <MissingClosureParamType>
       <code>$result</code>
       <code>$result</code>
@@ -908,6 +928,9 @@
     </PossiblyNullArgument>
   </file>
   <file src="src/Internal/Workflow/ExternalWorkflowStub.php">
+    <ArgumentTypeCoercion>
+      <code>$request</code>
+    </ArgumentTypeCoercion>
     <LessSpecificReturnStatement>
       <code><![CDATA[$this->request($request)]]></code>
     </LessSpecificReturnStatement>
@@ -929,11 +952,8 @@
       <code>parent::__construct($services, $ctx)</code>
       <code>parent::start($handler, $values)</code>
       <code>promise</code>
-      <code>start</code>
+      <code>startSignal</code>
     </InternalMethod>
-    <LessSpecificImplementedReturnType>
-      <code>mixed|string</code>
-    </LessSpecificImplementedReturnType>
     <MissingClosureParamType>
       <code>$result</code>
     </MissingClosureParamType>
@@ -944,7 +964,6 @@
       <code>Process</code>
     </PropertyNotSetInConstructor>
     <UndefinedInterfaceMethod>
-      <code>getRunId</code>
       <code>getSignalQueue</code>
       <code>getWorkflowInstance</code>
       <code>isContinuedAsNew</code>
@@ -960,12 +979,14 @@
     <InternalMethod>
       <code>attach</code>
       <code>call</code>
+      <code>callSignalHandler</code>
       <code>createScope</code>
       <code>createScope</code>
       <code>defer</code>
       <code>defer</code>
       <code>handleError</code>
       <code>handleError</code>
+      <code>makeCurrent</code>
       <code>makeCurrent</code>
       <code>makeCurrent</code>
       <code>makeCurrent</code>
@@ -978,11 +999,14 @@
       <code>next</code>
       <code>next</code>
       <code>next</code>
+      <code>next</code>
       <code>nextPromise</code>
       <code>nextPromise</code>
       <code>nextPromise</code>
       <code>nextPromise</code>
       <code>onClose</code>
+      <code>onException</code>
+      <code>onException</code>
       <code>onException</code>
       <code>onException</code>
       <code>onException</code>
@@ -998,6 +1022,7 @@
       <code><![CDATA[$this->cancelID]]></code>
       <code><![CDATA[$this->cancelled]]></code>
       <code><![CDATA[$this->context]]></code>
+      <code><![CDATA[$this->coroutine]]></code>
       <code><![CDATA[$this->coroutine]]></code>
       <code><![CDATA[$this->coroutine]]></code>
       <code><![CDATA[$this->deferred]]></code>
@@ -1032,6 +1057,8 @@
       <code>getClient</code>
       <code>getClient</code>
       <code>getClient</code>
+      <code>resolveConditions</code>
+      <code>resolveConditions</code>
       <code>resolveConditions</code>
       <code>resolveConditions</code>
       <code>resolveConditions</code>
@@ -1190,10 +1217,21 @@
     </PossiblyInvalidArgument>
   </file>
   <file src="src/Worker/Transport/Codec/JsonCodec/Decoder.php">
+    <InvalidReturnStatement>
+      <code><![CDATA[match (true) {
+            isset($command['command']) => $this->parseRequest($command),
+            isset($command['failure']) => $this->parseFailureResponse($command),
+            default => $this->parseResponse($command),
+        }]]></code>
+    </InvalidReturnStatement>
+    <InvalidReturnType>
+      <code>ServerRequestInterface|ResponseInterface</code>
+    </InvalidReturnType>
+    <MismatchingDocblockReturnType>
+      <code>RequestInterface</code>
+    </MismatchingDocblockReturnType>
     <PossiblyUndefinedStringArrayOffset>
-      <code><![CDATA[$data['command']]]></code>
       <code><![CDATA[$data['failure']]]></code>
-      <code><![CDATA[$data['id']]]></code>
       <code><![CDATA[$data['id']]]></code>
       <code><![CDATA[$data['id']]]></code>
     </PossiblyUndefinedStringArrayOffset>
@@ -1210,13 +1248,25 @@
     </PossiblyInvalidArgument>
   </file>
   <file src="src/Worker/Transport/Codec/ProtoCodec/Decoder.php">
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$msg->getId()]]></code>
-      <code><![CDATA[$msg->getId()]]></code>
-    </PossiblyInvalidArgument>
+    <ArgumentTypeCoercion>
+      <code><![CDATA[(int)$msg->getHistoryLength()]]></code>
+      <code><![CDATA[(int)$msg->getHistoryLength()]]></code>
+    </ArgumentTypeCoercion>
+    <InvalidReturnStatement>
+      <code><![CDATA[match (true) {
+            $msg->getCommand() !== '' => $this->parseRequest($msg),
+            $msg->hasFailure() => $this->parseFailureResponse($msg),
+            default => $this->parseResponse($msg),
+        }]]></code>
+    </InvalidReturnStatement>
+    <InvalidReturnType>
+      <code>ServerRequestInterface|ResponseInterface</code>
+    </InvalidReturnType>
+    <MismatchingDocblockReturnType>
+      <code>RequestInterface</code>
+    </MismatchingDocblockReturnType>
     <PossiblyNullArgument>
       <code><![CDATA[$msg->getFailure()]]></code>
-      <code><![CDATA[$msg->getPayloads()]]></code>
       <code><![CDATA[$msg->getPayloads()]]></code>
     </PossiblyNullArgument>
   </file>
@@ -1224,6 +1274,25 @@
     <PossiblyNullArgument>
       <code><![CDATA[$cmd->getFailure()]]></code>
     </PossiblyNullArgument>
+  </file>
+  <file src="src/Worker/Transport/Command/RequestTrait.php">
+    <InvalidNullableReturnType>
+      <code>object</code>
+    </InvalidNullableReturnType>
+    <LessSpecificImplementedReturnType>
+      <code>array</code>
+      <code>array</code>
+      <code>string</code>
+      <code>string</code>
+    </LessSpecificImplementedReturnType>
+    <UndefinedThisPropertyFetch>
+      <code><![CDATA[$this->header]]></code>
+    </UndefinedThisPropertyFetch>
+  </file>
+  <file src="src/Worker/Transport/Command/ServerRequest.php">
+    <ImpureMethodCall>
+      <code><![CDATA[$options['info']]]></code>
+    </ImpureMethodCall>
   </file>
   <file src="src/Worker/Transport/Goridge.php">
     <ArgumentTypeCoercion>
@@ -1296,12 +1365,13 @@
   </file>
   <file src="src/WorkerFactory.php">
     <InternalClass>
-      <code><![CDATA[new Client($this->responses, $this)]]></code>
+      <code><![CDATA[new Client($this->responses)]]></code>
     </InternalClass>
     <InternalMethod>
-      <code><![CDATA[new Client($this->responses, $this)]]></code>
+      <code><![CDATA[new Client($this->responses)]]></code>
     </InternalMethod>
     <InvalidArgument>
+      <code><![CDATA[$this->onRequest(...)]]></code>
       <code><![CDATA[$this->queues]]></code>
     </InvalidArgument>
     <InvalidReturnStatement>
@@ -1326,9 +1396,6 @@
     <PropertyNotSetInConstructor>
       <code>$codec</code>
     </PropertyNotSetInConstructor>
-    <TooManyArguments>
-      <code><![CDATA[new Client($this->responses, $this)]]></code>
-    </TooManyArguments>
     <UndefinedInterfaceMethod>
       <code>dispatch</code>
       <code>dispatch</code>

--- a/src/Internal/Transport/Router/Route.php
+++ b/src/Internal/Transport/Router/Route.php
@@ -14,7 +14,7 @@ namespace Temporal\Internal\Transport\Router;
 abstract class Route implements RouteInterface
 {
     /**
-     * @return string
+     * @return non-empty-string
      */
     public function getName(): string
     {
@@ -26,6 +26,7 @@ abstract class Route implements RouteInterface
      */
     private function getShortClassName(): string
     {
+        /** @var non-empty-list<non-empty-string> $chunks */
         $chunks = \explode('\\', static::class);
 
         return \array_pop($chunks);

--- a/src/Internal/Workflow/WorkflowContext.php
+++ b/src/Internal/Workflow/WorkflowContext.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Temporal\Internal\Workflow;
 
+use DateTimeInterface;
 use React\Promise\Deferred;
 use React\Promise\PromiseInterface;
 use RuntimeException;
@@ -546,5 +547,29 @@ class WorkflowContext implements WorkflowContextInterface
     public function rejectConditionGroup(string $conditionGroupId): void
     {
         unset($this->awaits[$conditionGroupId]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function uuid(): PromiseInterface
+    {
+        return $this->sideEffect(static fn(): UuidInterface => \Ramsey\Uuid\Uuid::uuid4());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function uuid4(): PromiseInterface
+    {
+        return $this->sideEffect(static fn(): UuidInterface => \Ramsey\Uuid\Uuid::uuid4());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function uuid7(?DateTimeInterface $dateTime = null): PromiseInterface
+    {
+        return $this->sideEffect(static fn(): UuidInterface => \Ramsey\Uuid\Uuid::uuid7($dateTime));
     }
 }

--- a/src/Internal/Workflow/WorkflowContext.php
+++ b/src/Internal/Workflow/WorkflowContext.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Temporal\Internal\Workflow;
 
 use DateTimeInterface;
+use Ramsey\Uuid\UuidInterface;
 use React\Promise\Deferred;
 use React\Promise\PromiseInterface;
 use RuntimeException;

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -946,7 +946,7 @@ final class Workflow extends Facade
     /**
      * Generate a UUID.
      *
-     * @return PromiseInterface<UuidInterface>
+     * @return PromiseInterface
      */
     public static function uuid(): PromiseInterface
     {
@@ -959,7 +959,7 @@ final class Workflow extends Facade
     /**
      * Generate a UUID version 4 (random).
      *
-     * @return PromiseInterface<UuidInterface>
+     * @return PromiseInterface
      */
     public static function uuid4(): PromiseInterface
     {
@@ -976,7 +976,7 @@ final class Workflow extends Facade
      *     to create the version 7 UUID. If not provided, the UUID is generated
      *     using the current date/time.
      *
-     * @return PromiseInterface<UuidInterface>
+     * @return PromiseInterface
      */
     public static function uuid7(?DateTimeInterface $dateTime = null): PromiseInterface
     {

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace Temporal;
 
+use DateTimeInterface;
+use Ramsey\Uuid\UuidInterface;
 use React\Promise\PromiseInterface;
 use Temporal\Activity\ActivityOptions;
 use Temporal\Activity\ActivityOptionsInterface;
@@ -939,5 +941,48 @@ final class Workflow extends Facade
         /** @var ScopedContextInterface $context */
         $context = self::getCurrentContext();
         $context->upsertSearchAttributes($searchAttributes);
+    }
+
+    /**
+     * Generate a UUID.
+     *
+     * @return PromiseInterface<UuidInterface>
+     */
+    public static function uuid(): PromiseInterface
+    {
+        /** @var ScopedContextInterface $context */
+        $context = self::getCurrentContext();
+
+        return $context->uuid();
+    }
+
+    /**
+     * Generate a UUID version 4 (random).
+     *
+     * @return PromiseInterface<UuidInterface>
+     */
+    public static function uuid4(): PromiseInterface
+    {
+        /** @var ScopedContextInterface $context */
+        $context = self::getCurrentContext();
+
+        return $context->uuid4();
+    }
+
+    /**
+     * Generate a UUID version 7 (Unix Epoch time).
+     *
+     * @param DateTimeInterface|null $dateTime An optional date/time from which
+     *     to create the version 7 UUID. If not provided, the UUID is generated
+     *     using the current date/time.
+     *
+     * @return PromiseInterface<UuidInterface>
+     */
+    public static function uuid7(?DateTimeInterface $dateTime = null): PromiseInterface
+    {
+        /** @var ScopedContextInterface $context */
+        $context = self::getCurrentContext();
+
+        return $context->uuid7($dateTime);
     }
 }

--- a/src/Workflow/WorkflowContextInterface.php
+++ b/src/Workflow/WorkflowContextInterface.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace Temporal\Workflow;
 
+use DateTimeInterface;
+use Ramsey\Uuid\UuidInterface;
 use React\Promise\PromiseInterface;
 use Temporal\Activity\ActivityOptions;
 use Temporal\Activity\ActivityOptionsInterface;
@@ -279,4 +281,35 @@ interface WorkflowContextInterface extends EnvironmentInterface
      * @param array<string, mixed> $searchAttributes
      */
     public function upsertSearchAttributes(array $searchAttributes): void;
+
+    /**
+     * @see Workflow::uuid()
+     *
+     * Generate a UUID.
+     *
+     * @return PromiseInterface<UuidInterface>
+     */
+    public function uuid(): PromiseInterface;
+
+    /**
+     * @see Workflow::uuid4()
+     *
+     * Generate a UUID version 4 (random).
+     *
+     * @return PromiseInterface<UuidInterface>
+     */
+    public function uuid4(): PromiseInterface;
+
+    /**
+     * @see Workflow::uuid7()
+     *
+     * Generate a UUID version 7 (Unix Epoch time).
+     *
+     * @param DateTimeInterface|null $dateTime An optional date/time from which
+     *     to create the version 7 UUID. If not provided, the UUID is generated
+     *     using the current date/time.
+     *
+     * @return PromiseInterface<UuidInterface>
+     */
+    public function uuid7(?DateTimeInterface $dateTime = null): PromiseInterface;
 }

--- a/src/Workflow/WorkflowContextInterface.php
+++ b/src/Workflow/WorkflowContextInterface.php
@@ -287,7 +287,7 @@ interface WorkflowContextInterface extends EnvironmentInterface
      *
      * Generate a UUID.
      *
-     * @return PromiseInterface<UuidInterface>
+     * @return PromiseInterface
      */
     public function uuid(): PromiseInterface;
 
@@ -296,7 +296,7 @@ interface WorkflowContextInterface extends EnvironmentInterface
      *
      * Generate a UUID version 4 (random).
      *
-     * @return PromiseInterface<UuidInterface>
+     * @return PromiseInterface
      */
     public function uuid4(): PromiseInterface;
 
@@ -309,7 +309,7 @@ interface WorkflowContextInterface extends EnvironmentInterface
      *     to create the version 7 UUID. If not provided, the UUID is generated
      *     using the current date/time.
      *
-     * @return PromiseInterface<UuidInterface>
+     * @return PromiseInterface
      */
     public function uuid7(?DateTimeInterface $dateTime = null): PromiseInterface;
 }

--- a/tests/Fixtures/src/Workflow/SimpleUuidWorkflow.php
+++ b/tests/Fixtures/src/Workflow/SimpleUuidWorkflow.php
@@ -23,10 +23,25 @@ class SimpleUuidWorkflow
     #[Workflow\ReturnType(UuidInterface::class)]
     public function handler(UuidInterface $uuid)
     {
-        $newUuid = yield Workflow::sideEffect(static fn(): UuidInterface => Uuid::uuid4());
-
-        if (!$newUuid instanceof UuidInterface) {
+        // Side effect
+        $seUuid = yield Workflow::sideEffect(static fn(): UuidInterface => Uuid::uuid4());
+        if (!$seUuid instanceof UuidInterface) {
             throw new \RuntimeException('Invalid type');
+        }
+        // UUID
+        $newUuid = yield Workflow::uuid();
+        if (!$newUuid instanceof UuidInterface) {
+            throw new \RuntimeException('Invalid UUID type');
+        }
+        // UUID4
+        $uuid4 = yield Workflow::uuid4();
+        if (!$uuid4 instanceof UuidInterface) {
+            throw new \RuntimeException('Invalid UUID4 type');
+        }
+        // UUID7
+        $uuid7 = yield Workflow::uuid7(Workflow::now());
+        if (!$uuid7 instanceof UuidInterface) {
+            throw new \RuntimeException('Invalid UUID7 type');
         }
 
         return $uuid;


### PR DESCRIPTION
## What was changed

Added new functions:

```php
$uuid  = yield Workflow::uuid();  // Generate a UUID (user doesn't care about the UUID version)
$uuid4 = yield Workflow::uuid4(); // Generate a UUID v4
$uuid7 = yield Workflow::uuid7(); // Generate a UUID v7
```

## Why?

Just a good sugar.
Java SDK has some similar method `Workflow.randomUUID()` that uses `UUID.randomUUID()` with the SideEffect function.
We do the same.

## Checklist

1. Closes #350
2. How was this tested: added autotests
3. It might be added in the documentation