### PR TITLE
Add test case where workflow fails with react/promise v3

### DIFF
--- a/tests/Fixtures/src/Workflow/CancelSignaledChildWorkflow.php
+++ b/tests/Fixtures/src/Workflow/CancelSignaledChildWorkflow.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Workflow;
+
+use React\Promise\Deferred;
+use Temporal\Workflow;
+use Temporal\Workflow\WorkflowMethod;
+
+#[Workflow\WorkflowInterface]
+class CancelSignaledChildWorkflow
+{
+    private array $status = [];
+
+    #[Workflow\QueryMethod(name: 'getStatus')]
+    public function getStatus(): array
+    {
+        return $this->status;
+    }
+
+    #[WorkflowMethod(name: 'CancelSignaledChildWorkflow')]
+    public function handler()
+    {
+        // typed stub
+        $simple = Workflow::newChildWorkflowStub(SimpleSignaledWorkflow::class);
+
+        $waitSignaled = new Deferred();
+
+        $this->status[] = 'start';
+
+        // start execution
+        $scope = Workflow::async(
+            function () use ($simple, $waitSignaled) {
+                $call = $simple->handler();
+                $this->status[] = 'child started';
+
+                yield $simple->add(8);
+                $this->status[] = 'child signaled';
+                $waitSignaled->resolve();
+
+                return yield $call;
+            }
+        );
+
+        // only cancel scope when signal dispatched
+        yield $waitSignaled;
+        $scope->cancel();
+        $this->status[] = 'scope canceled';
+
+        try {
+            return yield $scope;
+        } catch (\Throwable $e) {
+            $this->status[] = 'process done';
+
+            return 'canceled ok';
+        }
+    }
+}

--- a/tests/Fixtures/src/Workflow/SimpleSignaledWorkflow.php
+++ b/tests/Fixtures/src/Workflow/SimpleSignaledWorkflow.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Workflow;
+
+use Temporal\Workflow;
+use Temporal\Workflow\WorkflowMethod;
+
+#[Workflow\WorkflowInterface]
+class SimpleSignaledWorkflow
+{
+    private $counter = 0;
+
+    #[Workflow\SignalMethod(name: "add")]
+    public function add(
+        int $value
+    ) {
+        $this->counter += $value;
+    }
+
+    #[WorkflowMethod(name: 'SimpleSignaledWorkflow')]
+    public function handler(): iterable
+    {
+        // collect signals during one second
+        yield Workflow::timer(1);
+
+        return $this->counter;
+    }
+}

--- a/tests/Functional/SimpleWorkflowTestCase.php
+++ b/tests/Functional/SimpleWorkflowTestCase.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Functional;
 
+use Temporal\Api\Enums\V1\EventType;
 use Temporal\Client\GRPC\ServiceClient;
 use Temporal\Client\WorkflowClient;
 use Temporal\Client\WorkflowOptions;
 use Temporal\Testing\ActivityMocker;
 use Temporal\Tests\TestCase;
 use Temporal\Tests\Workflow\SimpleWorkflow;
+use Temporal\Workflow\WorkflowExecution;
 
 final class SimpleWorkflowTestCase extends TestCase
 {
@@ -46,5 +48,42 @@ final class SimpleWorkflowTestCase extends TestCase
             ->newWorkflowStub(SimpleWorkflow::class, WorkflowOptions::new()->withEagerStart());
         $run = $this->workflowClient->start($workflow, 'hello');
         $this->assertSame('HELLO', $run->getResult('string'));
+    }
+
+    public function testCancelSignaledChildWorkflow(): void
+    {
+        $workflow = $this->workflowClient
+            ->newWorkflowStub(\Temporal\Tests\Workflow\CancelSignaledChildWorkflow::class);
+        $run = $this->workflowClient->start($workflow);
+
+        $this->assertSame('canceled ok', $run->getResult('string', 10));
+
+        $status = $workflow->getStatus();
+        $this->assertSame([
+			"start",
+			"child started",
+			"child signaled",
+			"scope canceled",
+			"process done",
+        ], $status);
+
+        $this->assertContainsEvent(
+            $run->getExecution(),
+            EventType::EVENT_TYPE_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED,
+        );
+    }
+
+    private function assertContainsEvent(WorkflowExecution $execution, int $event): void
+    {
+        $history = $this->workflowClient->getWorkflowHistory(
+            $execution,
+        );
+        foreach ($history as $item) {
+            if ($item->getEventType() === $event) {
+                return;
+            }
+        }
+
+        throw new \Exception(\sprintf('Event %s not found', EventType::value($event)));
     }
 }


### PR DESCRIPTION
## What was changed

A test has been added that demonstrates different SDK work results on different versions of react/promise.

Related issue: https://github.com/temporalio/sdk-php/issues/357