### PR TITLE
Rename `WorkflowInboundInterceptor` to `WorkflowInboundCallsInterceptor`

### DIFF
--- a/src/Interceptor/Trait/WorkflowInboundCallsInterceptorTrait.php
+++ b/src/Interceptor/Trait/WorkflowInboundCallsInterceptorTrait.php
@@ -14,15 +14,15 @@ namespace Temporal\Interceptor\Trait;
 use Temporal\Interceptor\WorkflowInbound\QueryInput;
 use Temporal\Interceptor\WorkflowInbound\SignalInput;
 use Temporal\Interceptor\WorkflowInbound\WorkflowInput;
-use Temporal\Interceptor\WorkflowInboundInterceptor;
+use Temporal\Interceptor\WorkflowInboundCallsInterceptor;
 
 /**
- * Implements {@see WorkflowInboundInterceptor}
+ * Implements {@see WorkflowInboundCallsInterceptor}
  */
-trait WorkflowInboundInterceptorTrait
+trait WorkflowInboundCallsInterceptorTrait
 {
     /**
-     * @see WorkflowInboundInterceptor::execute()
+     * @see WorkflowInboundCallsInterceptor::execute()
      */
     public function execute(WorkflowInput $input, callable $next): void
     {
@@ -30,7 +30,7 @@ trait WorkflowInboundInterceptorTrait
     }
 
     /**
-     * @see WorkflowInboundInterceptor::handleSignal()
+     * @see WorkflowInboundCallsInterceptor::handleSignal()
      */
     public function handleSignal(SignalInput $input, callable $next): void
     {
@@ -38,7 +38,7 @@ trait WorkflowInboundInterceptorTrait
     }
 
     /**
-     * @see WorkflowInboundInterceptor::handleQuery()
+     * @see WorkflowInboundCallsInterceptor::handleQuery()
      */
     public function handleQuery(QueryInput $input, callable $next): mixed
     {

--- a/src/Interceptor/WorkflowInboundCallsInterceptor.php
+++ b/src/Interceptor/WorkflowInboundCallsInterceptor.php
@@ -11,19 +11,19 @@ declare(strict_types=1);
 
 namespace Temporal\Interceptor;
 
-use Temporal\Interceptor\Trait\WorkflowInboundInterceptorTrait;
+use Temporal\Interceptor\Trait\WorkflowInboundCallsInterceptorTrait;
 use Temporal\Interceptor\WorkflowInbound\QueryInput;
 use Temporal\Interceptor\WorkflowInbound\SignalInput;
 use Temporal\Interceptor\WorkflowInbound\WorkflowInput;
 use Temporal\Internal\Interceptor\Interceptor;
 
 /**
- * It's recommended to use {@see WorkflowInboundInterceptorTrait} when implementing this interface because
+ * It's recommended to use {@see WorkflowInboundCallsInterceptorTrait} when implementing this interface because
  * the interface might be extended in the future. The trait will provide forward compatibility.
  *
  * @psalm-immutable
  */
-interface WorkflowInboundInterceptor extends Interceptor
+interface WorkflowInboundCallsInterceptor extends Interceptor
 {
     /**
      * @param WorkflowInput $input

--- a/src/Internal/Declaration/Instantiator/WorkflowInstantiator.php
+++ b/src/Internal/Declaration/Instantiator/WorkflowInstantiator.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace Temporal\Internal\Declaration\Instantiator;
 
 use Temporal\Exception\InstantiationException;
-use Temporal\Interceptor\WorkflowInboundInterceptor;
+use Temporal\Interceptor\WorkflowInboundCallsInterceptor;
 use Temporal\Internal\Declaration\Prototype\PrototypeInterface;
 use Temporal\Internal\Declaration\Prototype\WorkflowPrototype;
 use Temporal\Internal\Declaration\WorkflowInstance;
@@ -37,7 +37,7 @@ final class WorkflowInstantiator extends Instantiator
         return new WorkflowInstance(
             $prototype,
             $this->getInstance($prototype),
-            $this->interceptorProvider->getPipeline(WorkflowInboundInterceptor::class),
+            $this->interceptorProvider->getPipeline(WorkflowInboundCallsInterceptor::class),
         );
     }
 

--- a/src/Internal/Declaration/WorkflowInstance.php
+++ b/src/Internal/Declaration/WorkflowInstance.php
@@ -13,7 +13,7 @@ namespace Temporal\Internal\Declaration;
 
 use Temporal\DataConverter\ValuesInterface;
 use Temporal\Interceptor\WorkflowInbound\QueryInput;
-use Temporal\Interceptor\WorkflowInboundInterceptor;
+use Temporal\Interceptor\WorkflowInboundCallsInterceptor;
 use Temporal\Internal\Declaration\Prototype\WorkflowPrototype;
 use Temporal\Internal\Declaration\WorkflowInstance\SignalQueue;
 use Temporal\Internal\Interceptor;
@@ -46,7 +46,7 @@ final class WorkflowInstance extends Instance implements WorkflowInstanceInterfa
     /**
      * @param WorkflowPrototype $prototype
      * @param object $context
-     * @param Interceptor\Pipeline<WorkflowInboundInterceptor, mixed> $pipeline
+     * @param Interceptor\Pipeline<WorkflowInboundCallsInterceptor, mixed> $pipeline
      */
     public function __construct(
         WorkflowPrototype $prototype,
@@ -68,7 +68,7 @@ final class WorkflowInstance extends Instance implements WorkflowInstanceInterfa
                 function (QueryInput $input) use ($fn) {
                     return ($this->queryExecutor)($input, $fn);
                 },
-                /** @see WorkflowInboundInterceptor::handleQuery() */
+                /** @see WorkflowInboundCallsInterceptor::handleQuery() */
                 'handleQuery',
             ));
         }
@@ -127,7 +127,7 @@ final class WorkflowInstance extends Instance implements WorkflowInstanceInterfa
             function (QueryInput $input) use ($fn) {
                 return ($this->queryExecutor)($input, $fn);
             },
-            /** @see WorkflowInboundInterceptor::handleQuery() */
+            /** @see WorkflowInboundCallsInterceptor::handleQuery() */
             'handleQuery',
         ));
     }

--- a/src/Internal/Transport/Router/StartWorkflow.php
+++ b/src/Internal/Transport/Router/StartWorkflow.php
@@ -14,7 +14,7 @@ namespace Temporal\Internal\Transport\Router;
 use React\Promise\Deferred;
 use Temporal\DataConverter\EncodedValues;
 use Temporal\Interceptor\WorkflowInbound\WorkflowInput;
-use Temporal\Interceptor\WorkflowInboundInterceptor;
+use Temporal\Interceptor\WorkflowInboundCallsInterceptor;
 use Temporal\Internal\Declaration\Instantiator\WorkflowInstantiator;
 use Temporal\Internal\Declaration\Prototype\WorkflowPrototype;
 use Temporal\Internal\ServiceContainer;
@@ -96,10 +96,10 @@ final class StartWorkflow extends Route
 
         // Run workflow handler in an interceptor pipeline
         $this->services->interceptorProvider
-            ->getPipeline(WorkflowInboundInterceptor::class)
+            ->getPipeline(WorkflowInboundCallsInterceptor::class)
             ->with(
                 $starter,
-                /** @see WorkflowInboundInterceptor::execute() */
+                /** @see WorkflowInboundCallsInterceptor::execute() */
                 'execute',
             )(
                 new WorkflowInput($context->getInfo(), $context->getInput(), $context->getHeader()),

--- a/src/Internal/Workflow/Process/Process.php
+++ b/src/Internal/Workflow/Process/Process.php
@@ -16,7 +16,7 @@ use Temporal\DataConverter\ValuesInterface;
 use Temporal\Exception\DestructMemorizedInstanceException;
 use Temporal\Interceptor\WorkflowInbound\QueryInput;
 use Temporal\Interceptor\WorkflowInbound\SignalInput;
-use Temporal\Interceptor\WorkflowInboundInterceptor;
+use Temporal\Interceptor\WorkflowInboundCallsInterceptor;
 use Temporal\Internal\Declaration\WorkflowInstance;
 use Temporal\Internal\Declaration\WorkflowInstanceInterface;
 use Temporal\Internal\ServiceContainer;
@@ -45,7 +45,7 @@ class Process extends Scope implements ProcessInterface
     ) {
         parent::__construct($services, $ctx);
 
-        $inboundPipeline = $services->interceptorProvider->getPipeline(WorkflowInboundInterceptor::class);
+        $inboundPipeline = $services->interceptorProvider->getPipeline(WorkflowInboundCallsInterceptor::class);
         $wfInstance = $this->getWorkflowInstance();
         \assert($wfInstance instanceof WorkflowInstance);
 
@@ -92,7 +92,7 @@ class Process extends Scope implements ProcessInterface
                             $input->arguments
                         );
                     },
-                    /** @see WorkflowInboundInterceptor::handleSignal() */
+                    /** @see WorkflowInboundCallsInterceptor::handleSignal() */
                     'handleSignal',
                 )(new SignalInput(
                     $name,

--- a/src/Internal/Workflow/WorkflowContext.php
+++ b/src/Internal/Workflow/WorkflowContext.php
@@ -359,7 +359,7 @@ class WorkflowContext implements WorkflowContextInterface, HeaderCarrier
         string $type,
         array $args = [],
         ChildWorkflowOptions $options = null,
-        $returnType = null,
+        mixed $returnType = null,
     ): PromiseInterface {
         return $this->callsInterceptor->with(
             fn(ExecuteChildWorkflowInput $input): PromiseInterface => $this
@@ -467,7 +467,7 @@ class WorkflowContext implements WorkflowContextInterface, HeaderCarrier
     public function newActivityStub(
         string $class,
         ActivityOptionsInterface $options = null,
-    ): object {
+    ): ActivityProxy {
         $activities = $this->services->activitiesReader->fromClass($class);
 
         if (isset($activities[0]) && $activities[0]->isLocalActivity() && !$options instanceof LocalActivityOptions) {

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -580,7 +580,7 @@ final class Workflow extends Facade
         string $type,
         array $args = [],
         ChildWorkflowOptions $options = null,
-        $returnType = null,
+        mixed $returnType = null,
     ): PromiseInterface {
         return self::getCurrentContext()->executeChildWorkflow($type, $args, $options, $returnType);
     }

--- a/tests/Fixtures/PipelineProvider.php
+++ b/tests/Fixtures/PipelineProvider.php
@@ -13,7 +13,7 @@ namespace Temporal\Tests\Fixtures;
 
 use Temporal\Interceptor\ActivityInboundInterceptor;
 use Temporal\Interceptor\WorkflowClientCallsInterceptor;
-use Temporal\Interceptor\WorkflowInboundInterceptor;
+use Temporal\Interceptor\WorkflowInboundCallsInterceptor;
 use Temporal\Interceptor\WorkflowOutboundRequestInterceptor;
 use Temporal\Internal\Interceptor\Interceptor;
 use Temporal\Internal\Interceptor\Pipeline;
@@ -26,7 +26,7 @@ final class PipelineProvider implements \Temporal\Interceptor\PipelineProvider
      * @param array<class-string<Type>, array<class-string<Type>>> $classes
      */
     private array $classes = [
-        WorkflowInboundInterceptor::class => [],
+        WorkflowInboundCallsInterceptor::class => [],
         WorkflowOutboundRequestInterceptor::class => [],
         ActivityInboundInterceptor::class => [],
         WorkflowClientCallsInterceptor::class => [],

--- a/tests/Fixtures/src/Interceptor/HeaderChanger.php
+++ b/tests/Fixtures/src/Interceptor/HeaderChanger.php
@@ -15,11 +15,11 @@ use React\Promise\PromiseInterface;
 use RuntimeException;
 use Temporal\Interceptor\Header;
 use Temporal\Interceptor\Trait\WorkflowClientCallsInterceptorTrait;
-use Temporal\Interceptor\Trait\WorkflowInboundInterceptorTrait;
+use Temporal\Interceptor\Trait\WorkflowInboundCallsInterceptorTrait;
 use Temporal\Interceptor\WorkflowClient\StartInput;
 use Temporal\Interceptor\WorkflowClientCallsInterceptor;
 use Temporal\Interceptor\WorkflowInbound\WorkflowInput;
-use Temporal\Interceptor\WorkflowInboundInterceptor;
+use Temporal\Interceptor\WorkflowInboundCallsInterceptor;
 use Temporal\Interceptor\WorkflowOutboundRequestInterceptor;
 use Temporal\Internal\Transport\Request\ExecuteActivity;
 use Temporal\Tests\Workflow\Header\ChildedHeaderWorkflow;
@@ -35,10 +35,10 @@ use Temporal\Workflow;
  */
 final class HeaderChanger implements
     WorkflowOutboundRequestInterceptor,
-    WorkflowInboundInterceptor,
+    WorkflowInboundCallsInterceptor,
     WorkflowClientCallsInterceptor
 {
-    use WorkflowInboundInterceptorTrait;
+    use WorkflowInboundCallsInterceptorTrait;
     use WorkflowClientCallsInterceptorTrait;
 
     private function processInput(StartInput $input): StartInput

--- a/tests/Fixtures/src/Interceptor/InterceptorCallsCounter.php
+++ b/tests/Fixtures/src/Interceptor/InterceptorCallsCounter.php
@@ -25,7 +25,7 @@ use Temporal\Interceptor\WorkflowClientCallsInterceptor;
 use Temporal\Interceptor\WorkflowInbound\QueryInput;
 use Temporal\Interceptor\WorkflowInbound\SignalInput;
 use Temporal\Interceptor\WorkflowInbound\WorkflowInput;
-use Temporal\Interceptor\WorkflowInboundInterceptor;
+use Temporal\Interceptor\WorkflowInboundCallsInterceptor;
 use Temporal\Interceptor\WorkflowOutboundRequestInterceptor;
 use Temporal\Worker\Transport\Command\RequestInterface;
 use Temporal\Workflow;
@@ -41,7 +41,7 @@ use Temporal\Workflow\WorkflowExecution;
 final class InterceptorCallsCounter implements
     WorkflowOutboundRequestInterceptor,
     ActivityInboundInterceptor,
-    WorkflowInboundInterceptor,
+    WorkflowInboundCallsInterceptor,
     WorkflowClientCallsInterceptor
 {
     private function increment(HeaderInterface $header, string $key): HeaderInterface


### PR DESCRIPTION
## What was changed

`WorkflowInboundInterceptor` has been renamed to `WorkflowInboundCallsInterceptor`

## Why?

To have the same name of the interceptor like in other SDKs