### PR TITLE
Fix marshalling with PHP protobuf extension

### DIFF
--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -40,20 +40,25 @@ on:
 
 jobs:
   test:
-    name: (PHP ${{ matrix.php }}, ${{ matrix.os }}, ${{ matrix.dependencies }} deps
+    name: (PHP${{ matrix.php }}${{ matrix.extensions-suffix }} ${{ matrix.os }} ${{ matrix.dependencies }} deps
     runs-on: ${{ matrix.os }}
     timeout-minutes: ${{ matrix.timeout-minutes }}
     env: {GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'}
     strategy:
       fail-fast: ${{ inputs.fail-fast }}
       matrix:
-        php: [ 8.1, 8.2 ]
+        php: [ 8.1, 8.2, 8.3 ]
         os: [ ubuntu-latest, windows-latest ]
+        extensions-suffix: [ '', ', protobuf' ]
         dependencies: [ lowest , highest ]
         timeout-minutes: [ '${{ inputs.test-timeout }}' ]
         exclude:
           - os: windows-latest
             php: 8.2
+          - os: windows-latest
+            extensions-suffix: ', protobuf'
+          - os: windows-latest
+            php: 8.3
         include:
           - os: ubuntu-latest
             php: 8.3
@@ -70,7 +75,8 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           tools: composer:v2
-          extensions: dom, sockets, grpc, curl
+          extensions: dom, sockets, grpc, curl ${{ matrix.extensions-suffix }}
+#          extensions: dom, sockets, grpc, curl
 
       - name: Check Out Code
         uses: actions/checkout@v4

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -59,11 +59,6 @@ jobs:
             extensions-suffix: ', protobuf'
           - os: windows-latest
             php: 8.3
-        include:
-          - os: ubuntu-latest
-            php: 8.3
-            dependencies: highest
-            timeout-minutes: 40
     steps:
       - name: Set Git To Use LF
         run: |

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -40,7 +40,7 @@ on:
 
 jobs:
   test:
-    name: (PHP${{ matrix.php }}${{ matrix.extensions-suffix }} ${{ matrix.os }} ${{ matrix.dependencies }} deps
+    name: PHP${{ matrix.php }}${{ matrix.extensions-suffix }}, ${{ matrix.os }}, ${{ matrix.dependencies }} deps
     runs-on: ${{ matrix.os }}
     timeout-minutes: ${{ matrix.timeout-minutes }}
     env: {GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'}

--- a/src/Client/Interceptor/SystemInfoInterceptor.php
+++ b/src/Client/Interceptor/SystemInfoInterceptor.php
@@ -48,7 +48,7 @@ final class SystemInfoInterceptor implements GrpcClientInterceptor
             if ($capabilities !== null && $this->serviceClient->getServerCapabilities() === null) {
                 $this->serviceClient->setServerCapabilities(new ServerCapabilities(
                     signalAndQueryHeader: $capabilities->getSignalAndQueryHeader(),
-                    internalErrorDifferentiation: $capabilities->getInternalErrorDifferentiation()
+                    internalErrorDifferentiation: $capabilities->getInternalErrorDifferentiation(),
                 ));
             }
         } catch (ServiceClientException $e) {

--- a/src/Internal/Mapper/ScheduleMapper.php
+++ b/src/Internal/Mapper/ScheduleMapper.php
@@ -47,7 +47,7 @@ final class ScheduleMapper
         $array['state'] = new ScheduleState($array['state'] ?? []);
         isset($array['action']) and $array['action'] = $this->prepareAction($dto->action, $array['action']);
 
-        return new \Temporal\Api\Schedule\V1\Schedule($array);
+        return new \Temporal\Api\Schedule\V1\Schedule(self::cleanArray($array));
     }
 
     /**
@@ -103,7 +103,7 @@ final class ScheduleMapper
             $result['exclude_structured_calendar'] ?? [],
         );
 
-        return new ScheduleSpec($result);
+        return new ScheduleSpec(self::cleanArray($result));
     }
 
     private function prepareStructuredCalendar(array $array): array

--- a/src/Internal/Mapper/ScheduleMapper.php
+++ b/src/Internal/Mapper/ScheduleMapper.php
@@ -70,7 +70,7 @@ final class ScheduleMapper
                 $values['retry_policy'] = $action->retryPolicy?->toWorkflowRetryPolicy();
 
                 $result->setStartWorkflow(
-                    new \Temporal\Api\Workflow\V1\NewWorkflowExecutionInfo($values),
+                    new \Temporal\Api\Workflow\V1\NewWorkflowExecutionInfo(self::cleanArray($values)),
                 );
                 break;
             default:
@@ -117,9 +117,14 @@ final class ScheduleMapper
                 );
             }
 
-            $calendar = new StructuredCalendarSpec($calendar);
+            $calendar = new StructuredCalendarSpec(self::cleanArray($calendar));
         }
 
         return $array;
+    }
+
+    private static function cleanArray(array $array): array
+    {
+        return \array_filter($array, static fn ($item): bool => $item !== null);
     }
 }

--- a/tests/Unit/Client/Interceptor/SystemInfoInterceptorTestCase.php
+++ b/tests/Unit/Client/Interceptor/SystemInfoInterceptorTestCase.php
@@ -32,7 +32,7 @@ final class SystemInfoInterceptorTestCase extends TestCase
         $this->serviceClient
             ->expects($this->once())
             ->method('getSystemInfo')
-            ->willReturn(new GetSystemInfoResponse(['capabilities' => null]));
+            ->willReturn(new GetSystemInfoResponse());
 
         $this->serviceClient
             ->expects($this->never())
@@ -91,7 +91,7 @@ final class SystemInfoInterceptorTestCase extends TestCase
             // it is important for this test
             ->expects($this->once())
             ->method('getSystemInfo')
-            ->willReturn(new GetSystemInfoResponse(['capabilities' => null]));
+            ->willReturn(new GetSystemInfoResponse());
 
         $this->interceptor->interceptCall(
             'foo',

--- a/tests/Unit/Client/Mapper/WorkflowExecutionInfoMapperTestCase.php
+++ b/tests/Unit/Client/Mapper/WorkflowExecutionInfoMapperTestCase.php
@@ -83,7 +83,7 @@ final class WorkflowExecutionInfoMapperTestCase extends TestCase
         $this->assertSame('2021-01-01T00:00:00.000000Z', $info->executionTime->format('Y-m-d\TH:i:s.u\Z'));
         $this->assertSame(2, $info->memo->count());
         $this->assertSame(['mem1' => 'value1', 'mem2' => 'value2'], $info->memo->getValues());
-        $this->assertSame(['attr1' => 'value1', 'attr2' => 'value2'], $info->searchAttributes->getValues());
+        $this->assertEquals(['attr1' => 'value1', 'attr2' => 'value2'], $info->searchAttributes->getValues());
         $this->assertSame('taskQueue', $info->taskQueue);
         $this->assertSame(1, $info->stateTransitionCount);
         $this->assertCount(1, $info->autoResetPoints);

--- a/tests/Unit/Client/Mapper/WorkflowExecutionInfoMapperTestCase.php
+++ b/tests/Unit/Client/Mapper/WorkflowExecutionInfoMapperTestCase.php
@@ -18,7 +18,7 @@ use Temporal\Internal\Mapper\WorkflowExecutionInfoMapper;
 use Temporal\Workflow\ResetPointInfo;
 use Temporal\Workflow\WorkflowExecutionStatus;
 
-final class WorkflowExecutionInfoMapperTest extends TestCase
+final class WorkflowExecutionInfoMapperTestCase extends TestCase
 {
     public function testFromPayload(): void
     {

--- a/tests/Unit/Common/PaginatorTestCase.php
+++ b/tests/Unit/Common/PaginatorTestCase.php
@@ -8,7 +8,7 @@ use Generator;
 use PHPUnit\Framework\TestCase;
 use Temporal\Client\Paginator;
 
-final class PaginatorTest extends TestCase
+final class PaginatorTestCase extends TestCase
 {
     public function testNextPage(): void
     {

--- a/tests/Unit/Common/SdkVersionTestCase.php
+++ b/tests/Unit/Common/SdkVersionTestCase.php
@@ -5,7 +5,7 @@ namespace Temporal\Tests\Unit\Common;
 use PHPUnit\Framework\TestCase;
 use Temporal\Common\SdkVersion;
 
-class SdkVersionTest extends TestCase
+class SdkVersionTestCase extends TestCase
 {
     /**
      * @dataProvider versionProvider

--- a/tests/Unit/Schedule/Action/StartWorkflowActionTestCase.php
+++ b/tests/Unit/Schedule/Action/StartWorkflowActionTestCase.php
@@ -15,7 +15,7 @@ use Temporal\Workflow\WorkflowType;
 /**
  * @covers \Temporal\Client\Schedule\Action\StartWorkflowAction
  */
-class StartWorkflowActionTest extends TestCase
+class StartWorkflowActionTestCase extends TestCase
 {
     public function testWithWorkflowTypeString(): void
     {

--- a/tests/Unit/Schedule/BackfillPeriodTestCase.php
+++ b/tests/Unit/Schedule/BackfillPeriodTestCase.php
@@ -11,7 +11,7 @@ use Temporal\Client\Schedule\Policy\ScheduleOverlapPolicy;
 /**
  * @covers \Temporal\Client\Schedule\BackfillPeriod
  */
-class BackfillPeriodTest extends TestCase
+class BackfillPeriodTestCase extends TestCase
 {
     public function testCreateFromDatetimeImmutable(): void
     {

--- a/tests/Unit/Schedule/Mapper/WorkflowExecutionInfoMapperTestCase.php
+++ b/tests/Unit/Schedule/Mapper/WorkflowExecutionInfoMapperTestCase.php
@@ -119,7 +119,7 @@ final class WorkflowExecutionInfoMapperTestCase extends TestCase
                 $this->dataConverter,
             )->getValues(),
         );
-        $this->assertSame(
+        $this->assertEquals(
             ['sAttr1' => 's-value1', 'sAttr2' => 's-value2'],
             EncodedCollection::fromPayloadCollection(
                 $startWorkflow->getSearchAttributes()->getIndexedFields(),

--- a/tests/Unit/Schedule/Mapper/WorkflowExecutionInfoMapperTestCase.php
+++ b/tests/Unit/Schedule/Mapper/WorkflowExecutionInfoMapperTestCase.php
@@ -22,7 +22,7 @@ use Temporal\Internal\Marshaller\Marshaller;
 /**
  * @covers \Temporal\Internal\Mapper\ScheduleMapper
  */
-final class WorkflowExecutionInfoMapperTest extends TestCase
+final class WorkflowExecutionInfoMapperTestCase extends TestCase
 {
     private DataConverterInterface $dataConverter;
 

--- a/tests/Unit/Schedule/ScheduleClientTestCase.php
+++ b/tests/Unit/Schedule/ScheduleClientTestCase.php
@@ -34,7 +34,7 @@ use Temporal\Internal\Marshaller\ProtoToArrayConverter;
 /**
  * @covers \Temporal\Client\ScheduleClient
  */
-class ScheduleClientTest extends TestCase
+class ScheduleClientTestCase extends TestCase
 {
     public function testCreateSchedule(): void
     {

--- a/tests/Unit/Schedule/ScheduleHandleTestCase.php
+++ b/tests/Unit/Schedule/ScheduleHandleTestCase.php
@@ -34,7 +34,7 @@ use Temporal\Internal\Marshaller\ProtoToArrayConverter;
 /**
  * @covers \Temporal\Client\Schedule\ScheduleHandle
  */
-class ScheduleHandleTest extends TestCase
+class ScheduleHandleTestCase extends TestCase
 {
     public function testGetId(): void
     {

--- a/tests/Unit/Schedule/ScheduleOptionsTestCase.php
+++ b/tests/Unit/Schedule/ScheduleOptionsTestCase.php
@@ -13,7 +13,7 @@ use Temporal\DataConverter\EncodedCollection;
 /**
  * @covers \Temporal\Client\Schedule\ScheduleOptions
  */
-class ScheduleOptionsTest extends TestCase
+class ScheduleOptionsTestCase extends TestCase
 {
     public function testWithNamespace(): void
     {

--- a/tests/Unit/Schedule/ScheduleTestCase.php
+++ b/tests/Unit/Schedule/ScheduleTestCase.php
@@ -14,7 +14,7 @@ use Temporal\Client\Schedule\Spec\ScheduleState;
 /**
  * @covers \Temporal\Client\Schedule\Schedule
  */
-class ScheduleTest extends TestCase
+class ScheduleTestCase extends TestCase
 {
     public function testWithAction(): void
     {

--- a/tests/Unit/Schedule/Spec/CalendarSpecTestCase.php
+++ b/tests/Unit/Schedule/Spec/CalendarSpecTestCase.php
@@ -10,7 +10,7 @@ use Temporal\Client\Schedule\Spec\CalendarSpec;
 /**
  * @covers \Temporal\Client\Schedule\Spec\CalendarSpec
  */
-class CalendarSpecTest extends TestCase
+class CalendarSpecTestCase extends TestCase
 {
     public function testWithSecondString(): void
     {

--- a/tests/Unit/Schedule/Spec/IntervalSpecTestCase.php
+++ b/tests/Unit/Schedule/Spec/IntervalSpecTestCase.php
@@ -10,7 +10,7 @@ use Temporal\Client\Schedule\Spec\IntervalSpec;
 /**
  * @covers \Temporal\Client\Schedule\Spec\IntervalSpec
  */
-class IntervalSpecTest extends TestCase
+class IntervalSpecTestCase extends TestCase
 {
     public function testWithIntervalInt(): void
     {

--- a/tests/Unit/Schedule/Spec/RangeTestCase.php
+++ b/tests/Unit/Schedule/Spec/RangeTestCase.php
@@ -10,7 +10,7 @@ use Temporal\Client\Schedule\Spec\Range;
 /**
  * @covers \Temporal\Client\Schedule\Spec\Range
  */
-class RangeTest extends TestCase
+class RangeTestCase extends TestCase
 {
     public function testWithStart(): void
     {

--- a/tests/Unit/Schedule/Spec/ScheduleSpecTestCase.php
+++ b/tests/Unit/Schedule/Spec/ScheduleSpecTestCase.php
@@ -14,7 +14,7 @@ use Temporal\Client\Schedule\Spec\StructuredCalendarSpec;
 /**
  * @covers \Temporal\Client\Schedule\Spec\ScheduleSpec
  */
-class ScheduleSpecTest extends TestCase
+class ScheduleSpecTestCase extends TestCase
 {
     public function testWithTimezoneName(): void
     {

--- a/tests/Unit/Schedule/Spec/ScheduleStateTestCase.php
+++ b/tests/Unit/Schedule/Spec/ScheduleStateTestCase.php
@@ -10,7 +10,7 @@ use Temporal\Client\Schedule\Spec\ScheduleState;
 /**
  * @covers \Temporal\Client\Schedule\Spec\ScheduleState
  */
-class ScheduleStateTest extends TestCase
+class ScheduleStateTestCase extends TestCase
 {
     public function testWithNotes(): void
     {

--- a/tests/Unit/Schedule/Spec/StructuredCalendarSpecTestCase.php
+++ b/tests/Unit/Schedule/Spec/StructuredCalendarSpecTestCase.php
@@ -11,7 +11,7 @@ use Temporal\Client\Schedule\Spec\StructuredCalendarSpec;
 /**
  * @covers \Temporal\Client\Schedule\Spec\StructuredCalendarSpec
  */
-class StructuredCalendarSpecTest extends TestCase
+class StructuredCalendarSpecTestCase extends TestCase
 {
     public function testWithSeconds(): void
     {


### PR DESCRIPTION
## What was changed

### Protobuf extension

Testing in the SDK was done without using the PHP `protobuf` extension. The presence of the extension changes the behavior around protobuf messages. Therefore, cases with broken hydration of protobuf messages were not caught in CI.
I added variants with the protobuf extension to the testing matrix (Linux only).

### Test cases

A problem was discovered with the naming of test cases. Usually, such test cases have the `Test` postfix. However, in the SDK, it is set to `TestCase`. All tests with the `Test` postfix were ignored in CI. I found and renamed all tests to TestCase:

Before renaming: "Tests: 332, Assertions: 442"
After renaming: "Tests: 511, Assertions: 1122"

## Why?

Users are observing different SDK behavior depending on the presence of the PHP protobuf extension.

## Checklist

1. Closes  #383 
