### PR TITLE
Don't set Workflow Start Delay if it wasn't specified

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.2]
+        php: [8.3]
         os: [ubuntu-latest]
     steps:
       - name: Set up PHP ${{ matrix.php }}

--- a/src/Internal/Client/WorkflowStarter.php
+++ b/src/Internal/Client/WorkflowStarter.php
@@ -191,7 +191,6 @@ final class WorkflowStarter
             ->setTaskQueue(new TaskQueue(['name' => $options->taskQueue]))
             ->setWorkflowType(new WorkflowType(['name' => $input->workflowType]))
             ->setWorkflowId($input->workflowId)
-            ->setWorkflowStartDelay(DateInterval::toDuration($options->workflowStartDelay))
             ->setCronSchedule($options->cronSchedule ?? '')
             ->setRetryPolicy($options->retryOptions ? $options->retryOptions->toWorkflowRetryPolicy() : null)
             ->setWorkflowIdReusePolicy($options->workflowIdReusePolicy)
@@ -201,6 +200,11 @@ final class WorkflowStarter
             ->setMemo($options->toMemo($this->converter))
             ->setSearchAttributes($options->toSearchAttributes($this->converter))
             ->setHeader($header->toHeader());
+
+        $delay = DateInterval::toDuration($options->workflowStartDelay);
+        if ($delay !== null && ($delay->getSeconds() > 0 || $delay->getNanos() > 0)) {
+            $req->setWorkflowStartDelay($delay);
+        }
 
         if ($req instanceof StartWorkflowExecutionRequest) {
             $req->setRequestEagerExecution($options->eagerStart);

--- a/tests/Unit/Internal/Client/WorkflowStarterTestCase.php
+++ b/tests/Unit/Internal/Client/WorkflowStarterTestCase.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\Internal\Client;
+
+use PHPUnit\Framework\TestCase;
+use Temporal\Api\Workflowservice\V1\StartWorkflowExecutionRequest;
+use Temporal\Api\Workflowservice\V1\StartWorkflowExecutionResponse;
+use Temporal\Client\GRPC\ServiceClientInterface;
+use Temporal\Client\WorkflowOptions;
+use Temporal\DataConverter\DataConverter;
+use Temporal\Internal\Client\WorkflowStarter;
+use Temporal\Internal\Interceptor\Pipeline;
+use Temporal\Internal\Support\DateInterval;
+
+/**
+ * @internal
+ *
+ * @covers \Temporal\Internal\Client\WorkflowStub
+ */
+final class WorkflowStarterTestCase extends TestCase
+{
+    private const NAMESPACE = 'test-namespace';
+    private const IDENTITY = 'test-identity';
+    private const WORKFLOW_RUN_ID = 'test-run-id';
+
+    /**
+     * @link https://github.com/temporalio/sdk-php/issues/387
+     */
+    public function testDelayIsNullIfNotSpecified(): void
+    {
+        $options = new WorkflowOptions();
+
+        $request = $this->startRequest('test-workflow', $options);
+
+        self::assertNull($request->getWorkflowStartDelay());
+    }
+
+    public function testDelayIsNullIfEmpty(): void
+    {
+        $options = (new WorkflowOptions())->withWorkflowStartDelay(0);
+
+        $request = $this->startRequest('test-workflow', $options);
+
+        self::assertNull($request->getWorkflowStartDelay());
+    }
+
+    public function testDelayIfSpecifiedSeconds(): void
+    {
+        $options = (new WorkflowOptions())->withWorkflowStartDelay(10);
+
+        $request = $this->startRequest('test-workflow', $options);
+
+        self::assertNotNull($request->getWorkflowStartDelay());
+        self::assertSame(10, $request->getWorkflowStartDelay()->getSeconds());
+        self::assertSame(0, $request->getWorkflowStartDelay()->getNanos());
+    }
+
+    public function testDelayIfSpecifiedNanos(): void
+    {
+        $options = (new WorkflowOptions())
+            ->withWorkflowStartDelay(DateInterval::parse(42, DateInterval::FORMAT_MICROSECONDS));
+
+        $request = $this->startRequest('test-workflow', $options);
+
+        self::assertNotNull($request->getWorkflowStartDelay());
+        self::assertSame(0, $request->getWorkflowStartDelay()->getSeconds());
+        self::assertSame(42000, $request->getWorkflowStartDelay()->getNanos());
+    }
+
+    private function startRequest(
+        string $workflowType,
+        WorkflowOptions $options,
+        array $args = [],
+    ): StartWorkflowExecutionRequest {
+        $clientOptions = (new \Temporal\Client\ClientOptions())
+            ->withNamespace(self::NAMESPACE)
+            ->withIdentity(self::IDENTITY);
+
+        $result = null;
+        $clientMock = $this->createMock(ServiceClientInterface::class);
+        $clientMock
+            ->expects($this->once())
+            ->method('StartWorkflowExecution')
+            ->with(
+                $this->callback(static function (StartWorkflowExecutionRequest $request) use (&$result) {
+                    $result = $request;
+                    return true;
+                })
+            )->willReturn(
+                (new StartWorkflowExecutionResponse())
+                    ->setRunId(self::WORKFLOW_RUN_ID)
+            );
+
+        $starter = new WorkflowStarter(
+            serviceClient: $clientMock,
+            converter: DataConverter::createDefault(),
+            clientOptions: $clientOptions,
+            interceptors: Pipeline::prepare([]),
+        );
+
+        $execution = $starter->start($workflowType, $options, $args);
+
+        if (self::WORKFLOW_RUN_ID !== $execution->getRunID()) {
+            $this->fail('Unexpected workflow run ID.');
+        }
+
+        return $result;
+    }
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Workflow Start Delay is not set in Start Workflow request if it wasn't specified

## Why?

Temporal doesn't check the interval (Duration) equals to zero.

## Checklist

1. Closes #387 
2. How was this tested: added unit tests
