### PR TITLE
Optimize garbage collecting

### DIFF
--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -116,7 +116,7 @@ jobs:
       - name: Run tests with Temporal test server
         if: inputs.run-temporal-test-server == true
         run: ${{ format(
-            'vendor/bin/phpunit --testsuite={0} --testdox --verbose --exclude {1}',
+            'vendor/bin/phpunit --testsuite={0} --testdox --colors=always --exclude-group {1}',
             inputs.test-suite,
             contains(matrix.extensions-suffix, 'protobuf') && 'skip-on-test-server,skip-ext-protobuf' || 'skip-on-test-server'
           ) }}
@@ -125,4 +125,4 @@ jobs:
 
       - name: Run tests without Temporal test server
         if: inputs.run-temporal-test-server == false
-        run: vendor/bin/phpunit --testsuite=${{ inputs.test-suite }} --testdox --verbose
+        run: vendor/bin/phpunit --testsuite=${{ inputs.test-suite }} --testdox --colors=always

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         "illuminate/support": "^9.0",
         "jetbrains/phpstorm-attributes": "dev-master@dev",
         "laminas/laminas-code": "^4.0",
-        "phpunit/phpunit": "^9.5.21",
+        "phpunit/phpunit": "^10.5",
         "symfony/var-dumper": "^6.0 || ^7.0",
         "vimeo/psalm": "^4.30 || ^5.4"
     },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,36 +3,31 @@
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="tests/bootstrap.php"
          backupGlobals="false"
-         backupStaticAttributes="false"
          colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
          stopOnError="false"
          stderr="true"
 >
-    <coverage>
-        <include>
-            <directory>src</directory>
-        </include>
-    </coverage>
-    <testsuites>
-        <testsuite name="Unit">
-            <directory suffix="TestCase.php">tests/Unit</directory>
-        </testsuite>
-        <testsuite name="Feature">
-            <directory suffix="TestCase.php">tests/Feature</directory>
-        </testsuite>
-        <testsuite name="Functional">
-            <directory suffix="TestCase.php">tests/Functional</directory>
-        </testsuite>
-    </testsuites>
-    <php>
-        <ini name="error_reporting" value="-1"/>
-        <ini name="memory_limit" value="-1"/>
-        <env name="TEMPORAL_ADDRESS" value="127.0.0.1:7233" />
-    </php>
+<testsuites>
+    <testsuite name="Unit">
+      <directory suffix="TestCase.php">tests/Unit</directory>
+    </testsuite>
+    <testsuite name="Feature">
+      <directory suffix="TestCase.php">tests/Feature</directory>
+    </testsuite>
+    <testsuite name="Functional">
+      <directory suffix="TestCase.php">tests/Functional</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <ini name="error_reporting" value="-1"/>
+    <ini name="memory_limit" value="-1"/>
+    <env name="TEMPORAL_ADDRESS" value="127.0.0.1:7233"/>
+  </php>
+  <source>
+    <include>
+      <directory>src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1330,11 +1330,6 @@
       <code>$e</code>
     </UnusedClosureParam>
   </file>
-  <file src="src/Internal/Workflow/ProcessCollection.php">
-    <DocblockTypeContradiction>
-      <code>$process === null</code>
-    </DocblockTypeContradiction>
-  </file>
   <file src="src/Internal/Workflow/Proxy.php">
     <MissingReturnType>
       <code>__call</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -921,7 +921,7 @@
     <MissingTemplateParam>
       <code>\IteratorAggregate</code>
     </MissingTemplateParam>
-  </file>
+  </file>c
   <file src="src/Internal/Repository/ArrayRepository.php">
     <InvalidReturnStatement>
       <code><![CDATA[$this->entries[$id] ?? null]]></code>
@@ -1159,9 +1159,6 @@
     </DocblockTypeContradiction>
   </file>
   <file src="src/Internal/Transport/Router/DestroyWorkflow.php">
-    <DocblockTypeContradiction>
-      <code>$process === null</code>
-    </DocblockTypeContradiction>
     <UndefinedInterfaceMethod>
       <code>pull</code>
     </UndefinedInterfaceMethod>

--- a/src/DataConverter/EncodedCollection.php
+++ b/src/DataConverter/EncodedCollection.php
@@ -24,7 +24,7 @@ use Traversable;
  *
  * @implements IteratorAggregate<TKey, TValue>
  */
-class EncodedCollection implements IteratorAggregate
+class EncodedCollection implements IteratorAggregate, Countable
 {
     /**
      * @var DataConverterInterface|null

--- a/src/Internal/Declaration/Destroyable.php
+++ b/src/Internal/Declaration/Destroyable.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Internal\Declaration;
+
+/**
+ * Means that instance can be destroyed. It's preferred to destroy instance to guarantee
+ * that all resources related to it will be released.
+ */
+interface Destroyable
+{
+    public function destroy(): void;
+}

--- a/src/Internal/Declaration/WorkflowInstance.php
+++ b/src/Internal/Declaration/WorkflowInstance.php
@@ -23,7 +23,7 @@ use Temporal\Internal\Interceptor;
  * @psalm-type QueryHandler = \Closure(QueryInput): mixed
  * @psalm-type QueryExecutor = \Closure(QueryInput, callable(ValuesInterface): mixed): mixed
  */
-final class WorkflowInstance extends Instance implements WorkflowInstanceInterface
+final class WorkflowInstance extends Instance implements WorkflowInstanceInterface, Destroyable
 {
     /**
      * @var array<non-empty-string, QueryHandler>
@@ -163,6 +163,14 @@ final class WorkflowInstance extends Instance implements WorkflowInstanceInterfa
     public function clearSignalQueue(): void
     {
         $this->signalQueue->clear();
+    }
+
+    public function destroy(): void
+    {
+        $this->signalQueue->clear();
+        $this->signalHandlers = [];
+        $this->queryHandlers = [];
+        unset($this->queryExecutor);
     }
 
     /**

--- a/src/Internal/Support/GarbageCollector.php
+++ b/src/Internal/Support/GarbageCollector.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Internal\Support;
+
+/**
+ * Garbage collector that might be called after some number of calls or after certain timeout.
+ * @internal
+ */
+final class GarbageCollector
+{
+    /** @var positive-int Last time when GC was called. */
+    private int $lastTime;
+
+    /** @var int<0, max> Number of calls since last GC. */
+    private int $counter = 0;
+
+    /**
+     * @param positive-int $threshold Number of calls before GC will be called.
+     * @param int<0, max> $timeout Timeout in seconds.
+     */
+    public function __construct(
+        private readonly int $threshold,
+        private readonly int $timeout,
+    ) {
+        $this->lastTime = \time();
+    }
+
+    /**
+     * Check if GC should be called.
+     */
+    public function check(): bool
+    {
+        $this->counter++;
+        if ($this->counter >= $this->threshold) {
+            return true;
+        }
+
+        if (($this->lastTime + $this->timeout) < \time()) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Call GC.
+     */
+    public function collect(): void
+    {
+        $this->lastTime = \time();
+        $this->counter = 0;
+
+        \gc_collect_cycles();
+    }
+}

--- a/src/Internal/Support/GarbageCollector.php
+++ b/src/Internal/Support/GarbageCollector.php
@@ -26,6 +26,7 @@ final class GarbageCollector
     /**
      * @param positive-int $threshold Number of ticks before GC will be called.
      * @param int<0, max> $timeout Timeout in seconds.
+     * @param positive-int|null $lastTime Start point for timeout.
      */
     public function __construct(
         private readonly int $threshold,
@@ -44,9 +45,7 @@ final class GarbageCollector
             return true;
         }
 
-        echo "($this->lastTime + $this->timeout) <" . \time();
-        if (($this->lastTime + $this->timeout) < \time()) {
-        // if (\time() - $this->lastTime > $this->timeout) {
+        if (\time() - $this->lastTime > $this->timeout) {
             return true;
         }
 

--- a/src/Internal/Transport/Router/DestroyWorkflow.php
+++ b/src/Internal/Transport/Router/DestroyWorkflow.php
@@ -27,7 +27,9 @@ class DestroyWorkflow extends WorkflowProcessAwareRoute
      */
     private const ERROR_PROCESS_NOT_DEFINED = 'Unable to kill workflow because workflow process #%s was not found';
 
+    /** Maximum number of ticks before GC call. */
     private const GC_THRESHOLD = 1000;
+    /** Interval between GC calls in seconds. */
     private const GC_TIMEOUT_SECONDS = 30;
 
     private GarbageCollector $gc;
@@ -64,6 +66,8 @@ class DestroyWorkflow extends WorkflowProcessAwareRoute
             'finally',
             function () use ($process) {
                 $process->destroy();
+
+                // Collect garbage if needed
                 if ($this->gc->check()) {
                     $this->gc->collect();
                 }

--- a/src/Internal/Transport/Router/WorkflowProcessAwareRoute.php
+++ b/src/Internal/Transport/Router/WorkflowProcessAwareRoute.php
@@ -23,16 +23,11 @@ abstract class WorkflowProcessAwareRoute extends Route
     private const ERROR_PROCESS_NOT_FOUND = 'Workflow with the specified run identifier "%s" not found';
 
     /**
-     * @var RepositoryInterface
-     */
-    protected RepositoryInterface $running;
-
-    /**
      * @param RepositoryInterface $running
      */
-    public function __construct(RepositoryInterface $running)
-    {
-        $this->running = $running;
+    public function __construct(
+        protected RepositoryInterface $running
+    ) {
     }
 
     /**

--- a/src/Internal/Workflow/Process/Scope.php
+++ b/src/Internal/Workflow/Process/Scope.php
@@ -19,6 +19,7 @@ use Temporal\Exception\DestructMemorizedInstanceException;
 use Temporal\Exception\Failure\CanceledFailure;
 use Temporal\Exception\Failure\TemporalFailure;
 use Temporal\Exception\InvalidArgumentException;
+use Temporal\Internal\Declaration\Destroyable;
 use Temporal\Internal\ServiceContainer;
 use Temporal\Internal\Transport\Request\Cancel;
 use Temporal\Internal\Workflow\ScopeContext;
@@ -36,7 +37,7 @@ use Temporal\Workflow\WorkflowContextInterface;
  * @psalm-internal Temporal\Internal
  * @implements CancellationScopeInterface<mixed>
  */
-class Scope implements CancellationScopeInterface
+class Scope implements CancellationScopeInterface, Destroyable
 {
     /**
      * @var ServiceContainer

--- a/src/Internal/Workflow/Process/Scope.php
+++ b/src/Internal/Workflow/Process/Scope.php
@@ -245,8 +245,8 @@ class Scope implements CancellationScopeInterface
 
         foreach ($this->onCancel as $i => $handler) {
             $this->makeCurrent();
-            $handler($reason);
             unset($this->onCancel[$i]);
+            $handler($reason);
         }
     }
 
@@ -595,5 +595,12 @@ class Scope implements CancellationScopeInterface
         }
 
         return $listener;
+    }
+
+    public function destroy(): void
+    {
+        $this->scopeContext->destroy();
+        $this->context->destroy();
+        unset($this->coroutine);
     }
 }

--- a/src/Internal/Workflow/ProcessCollection.php
+++ b/src/Internal/Workflow/ProcessCollection.php
@@ -20,10 +20,7 @@ use Temporal\Internal\Workflow\Process\Process;
  */
 class ProcessCollection extends ArrayRepository
 {
-    /**
-     * @var string
-     */
-    private const ERROR_PROCESS_NOT_DEFINED = 'Unable to kill workflow because workflow process #%s was not found';
+    private const ERROR_PROCESS_NOT_FOUND = 'Process #%s not found.';
 
     public function __construct()
     {
@@ -32,16 +29,14 @@ class ProcessCollection extends ArrayRepository
 
     /**
      * @param string $runId
+     * @param non-empty-string|null $error Error message if the process was not found.
      * @return Process
      */
-    public function pull(string $runId): Process
+    public function pull(string $runId, ?string $error = null): Process
     {
-        /** @var Process $process */
-        $process = $this->find($runId);
-
-        if ($process === null) {
-            throw new \InvalidArgumentException(\sprintf(self::ERROR_PROCESS_NOT_DEFINED, $runId));
-        }
+        $process = $this->find($runId) ?? throw new \InvalidArgumentException(
+            $error ?? \sprintf(self::ERROR_PROCESS_NOT_FOUND, $runId),
+        );
 
         $this->remove($runId);
 

--- a/src/Internal/Workflow/ScopeContext.php
+++ b/src/Internal/Workflow/ScopeContext.php
@@ -14,6 +14,7 @@ namespace Temporal\Internal\Workflow;
 use React\Promise\Deferred;
 use React\Promise\PromiseInterface;
 use Temporal\Exception\Failure\CanceledFailure;
+use Temporal\Internal\Declaration\Destroyable;
 use Temporal\Internal\Transport\CompletableResult;
 use Temporal\Internal\Workflow\Process\Scope;
 use Temporal\Worker\Transport\Command\RequestInterface;
@@ -21,7 +22,7 @@ use Temporal\Workflow\CancellationScopeInterface;
 use Temporal\Workflow\ScopedContextInterface;
 use Temporal\Internal\Transport\Request\UpsertSearchAttributes;
 
-class ScopeContext extends WorkflowContext implements ScopedContextInterface
+class ScopeContext extends WorkflowContext implements ScopedContextInterface, Destroyable
 {
     private WorkflowContext $parent;
     private Scope $scope;

--- a/src/Internal/Workflow/ScopeContext.php
+++ b/src/Internal/Workflow/ScopeContext.php
@@ -145,4 +145,10 @@ class ScopeContext extends WorkflowContext implements ScopedContextInterface
             new UpsertSearchAttributes($searchAttributes)
         );
     }
+
+    public function destroy(): void
+    {
+        parent::destroy();
+        unset($this->scope, $this->parent, $this->onRequest);
+    }
 }

--- a/src/Internal/Workflow/WorkflowContext.php
+++ b/src/Internal/Workflow/WorkflowContext.php
@@ -38,6 +38,7 @@ use Temporal\Interceptor\WorkflowOutboundCalls\TimerInput;
 use Temporal\Interceptor\WorkflowOutboundCalls\UpsertSearchAttributesInput;
 use Temporal\Interceptor\WorkflowOutboundCallsInterceptor;
 use Temporal\Interceptor\WorkflowOutboundRequestInterceptor;
+use Temporal\Internal\Declaration\Destroyable;
 use Temporal\Internal\Declaration\WorkflowInstanceInterface;
 use Temporal\Internal\Interceptor\HeaderCarrier;
 use Temporal\Internal\Interceptor\Pipeline;
@@ -68,7 +69,7 @@ use Temporal\Workflow\WorkflowInfo;
 use function React\Promise\reject;
 use function React\Promise\resolve;
 
-class WorkflowContext implements WorkflowContextInterface, HeaderCarrier
+class WorkflowContext implements WorkflowContextInterface, HeaderCarrier, Destroyable
 {
     /**
      * Contains conditional groups that contains tuple of a condition callable and its promise
@@ -85,18 +86,10 @@ class WorkflowContext implements WorkflowContextInterface, HeaderCarrier
     /** @var Pipeline<WorkflowOutboundCallsInterceptor, PromiseInterface> */
     private Pipeline $callsInterceptor;
 
-    /**
-     * WorkflowContext constructor.
-     * @param ServiceContainer          $services
-     * @param ClientInterface           $client
-     * @param WorkflowInstanceInterface $workflowInstance
-     * @param Input                     $input
-     * @param ValuesInterface|null      $lastCompletionResult
-     */
     public function __construct(
         protected ServiceContainer $services,
         protected ClientInterface $client,
-        protected WorkflowInstanceInterface $workflowInstance,
+        protected WorkflowInstanceInterface&Destroyable $workflowInstance,
         protected Input $input,
         protected ?ValuesInterface $lastCompletionResult = null
     ) {
@@ -703,6 +696,7 @@ class WorkflowContext implements WorkflowContextInterface, HeaderCarrier
     public function destroy(): void
     {
         $this->awaits = [];
+        $this->workflowInstance->destroy();
         unset($this->workflowInstance);
     }
 }

--- a/src/Internal/Workflow/WorkflowContext.php
+++ b/src/Internal/Workflow/WorkflowContext.php
@@ -585,8 +585,8 @@ class WorkflowContext implements WorkflowContextInterface, HeaderCarrier
         foreach ($this->awaits as $awaitsGroupId => $awaitsGroup) {
             foreach ($awaitsGroup as $i => [$condition, $deferred]) {
                 if ($condition()) {
-                    $deferred->resolve();
                     unset($this->awaits[$awaitsGroupId][$i]);
+                    $deferred->resolve();
                     $this->resolveConditionGroup($awaitsGroupId);
                 }
             }
@@ -698,5 +698,11 @@ class WorkflowContext implements WorkflowContextInterface, HeaderCarrier
     protected function recordTrace(): void
     {
         $this->trace = \debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS);
+    }
+
+    public function destroy(): void
+    {
+        $this->awaits = [];
+        unset($this->workflowInstance);
     }
 }

--- a/src/Worker/LoopInterface.php
+++ b/src/Worker/LoopInterface.php
@@ -54,6 +54,12 @@ interface LoopInterface extends EventListenerInterface
      */
     public const ON_CALLBACK = 'callback';
 
+    /** Must be emitted at the end of each loop iteration after all other events.
+     *
+     * @var string
+     */
+    public const ON_FINALLY = 'finally';
+
     /**
      * @return void
      */

--- a/src/Worker/Transport/Codec/ProtoCodec/Decoder.php
+++ b/src/Worker/Transport/Codec/ProtoCodec/Decoder.php
@@ -18,16 +18,12 @@ use Temporal\Interceptor\Header;
 use RoadRunner\Temporal\DTO\V1\Message;
 use Temporal\Worker\Transport\Command\FailureResponse;
 use Temporal\Worker\Transport\Command\FailureResponseInterface;
-use Temporal\Worker\Transport\Command\RequestInterface;
 use Temporal\Worker\Transport\Command\ResponseInterface;
 use Temporal\Worker\Transport\Command\ServerRequest;
 use Temporal\Worker\Transport\Command\ServerRequestInterface;
 use Temporal\Worker\Transport\Command\SuccessResponse;
 use Temporal\Worker\Transport\Command\SuccessResponseInterface;
 
-/**
- * @codeCoverageIgnore tested via roadrunner-temporal repository.
- */
 class Decoder
 {
     /**

--- a/src/Worker/Worker.php
+++ b/src/Worker/Worker.php
@@ -177,7 +177,7 @@ class Worker implements WorkerInterface, Identifiable, EventListenerInterface, D
         $router->add(new Router\InvokeQuery($this->services->running, $this->services->loop));
         $router->add(new Router\InvokeSignal($this->services->running));
         $router->add(new Router\CancelWorkflow($this->services->running));
-        $router->add(new Router\DestroyWorkflow($this->services->running));
+        $router->add(new Router\DestroyWorkflow($this->services->running, $this->services->loop));
         $router->add(new Router\StackTrace($this->services->running));
 
         return $router;

--- a/src/WorkerFactory.php
+++ b/src/WorkerFactory.php
@@ -285,6 +285,7 @@ class WorkerFactory implements WorkerFactoryInterface, LoopInterface
         $this->emit(LoopInterface::ON_CALLBACK);
         $this->emit(LoopInterface::ON_QUERY);
         $this->emit(LoopInterface::ON_TICK);
+        $this->emit('finally');
     }
 
     /**

--- a/src/WorkerFactory.php
+++ b/src/WorkerFactory.php
@@ -285,7 +285,7 @@ class WorkerFactory implements WorkerFactoryInterface, LoopInterface
         $this->emit(LoopInterface::ON_CALLBACK);
         $this->emit(LoopInterface::ON_QUERY);
         $this->emit(LoopInterface::ON_TICK);
-        $this->emit('finally');
+        $this->emit(LoopInterface::ON_FINALLY);
     }
 
     /**

--- a/tests/Feature/AbstractFeature.php
+++ b/tests/Feature/AbstractFeature.php
@@ -9,14 +9,13 @@
 
 declare(strict_types=1);
 
-namespace Temporal\Tests\Unit\Worker;
+namespace Temporal\Tests\Feature;
 
-use Temporal\Tests\Unit\UnitTestCase;
+use Temporal\Tests\TestCase;
 
 /**
- * @group worker
- * @group unit
+ * @group feature
  */
-abstract class WorkerTestCase extends UnitTestCase
+abstract class AbstractFeature extends TestCase
 {
 }

--- a/tests/Functional/AbstractFunctional.php
+++ b/tests/Functional/AbstractFunctional.php
@@ -9,14 +9,13 @@
 
 declare(strict_types=1);
 
-namespace Temporal\Tests\Unit\WorkerFactory;
+namespace Temporal\Tests\Functional;
 
-use Temporal\Tests\Unit\UnitTestCase;
+use Temporal\Tests\TestCase;
 
 /**
- * @group worker
- * @group unit
+ * @group functional
  */
-abstract class WorkerFactoryTestCase extends UnitTestCase
+abstract class AbstractFunctional extends TestCase
 {
 }

--- a/tests/Functional/ActivityInvocationCacheTestCase.php
+++ b/tests/Functional/ActivityInvocationCacheTestCase.php
@@ -12,7 +12,7 @@ use Temporal\Worker\ActivityInvocationCache\RoadRunnerActivityInvocationCache;
 use Temporal\Worker\Transport\Command\ServerRequest;
 use Temporal\Worker\Transport\Command\ServerRequestInterface;
 
-class ActivityInvocationCacheTestCase extends FunctionalTestCase
+class ActivityInvocationCacheTestCase extends AbstractFunctional
 {
     private RoadRunnerActivityInvocationCache $cache;
 

--- a/tests/Functional/Client/AbstractClient.php
+++ b/tests/Functional/Client/AbstractClient.php
@@ -16,14 +16,13 @@ use Temporal\Api\History\V1\HistoryEvent;
 use Temporal\Api\Workflowservice\V1\GetWorkflowExecutionHistoryRequest;
 use Temporal\Client\GRPC\ServiceClient;
 use Temporal\Client\WorkflowClient;
-use Temporal\Testing\WithoutTimeSkipping;
-use Temporal\Tests\Functional\FunctionalTestCase;
+use Temporal\Tests\Functional\AbstractFunctional;
 use Temporal\Workflow\WorkflowExecution;
 
 /**
  * @group client
  */
-abstract class ClientTestCase extends FunctionalTestCase
+abstract class AbstractClient extends AbstractFunctional
 {
     /**
      * @param string $connection

--- a/tests/Functional/Client/ActivityCompletionClientTestCase.php
+++ b/tests/Functional/Client/ActivityCompletionClientTestCase.php
@@ -23,7 +23,7 @@ use Temporal\Exception\Failure\ApplicationFailure;
  * @group client
  * @group functional
  */
-class ActivityCompletionClientTestCase extends ClientTestCase
+class ActivityCompletionClientTestCase extends AbstractClient
 {
     public function testCompleteAsyncActivityById()
     {

--- a/tests/Functional/Client/AsyncClosureTestCase.php
+++ b/tests/Functional/Client/AsyncClosureTestCase.php
@@ -19,7 +19,7 @@ use Temporal\Tests\Workflow\AsyncClosureWorkflow;
  * @group client
  * @group functional
  */
-class AsyncClosureTestCase extends ClientTestCase
+class AsyncClosureTestCase extends AbstractClient
 {
     use WithoutTimeSkipping;
 

--- a/tests/Functional/Client/AwaitTestCase.php
+++ b/tests/Functional/Client/AwaitTestCase.php
@@ -28,7 +28,7 @@ use Temporal\Workflow\WorkflowStub;
  * @group client
  * @group functional
  */
-class AwaitTestCase extends ClientTestCase
+class AwaitTestCase extends AbstractClient
 {
     use WithoutTimeSkipping;
 

--- a/tests/Functional/Client/DynamicObjectReturnWorkflowTestCase.php
+++ b/tests/Functional/Client/DynamicObjectReturnWorkflowTestCase.php
@@ -10,7 +10,7 @@ use Temporal\Tests\Workflow\DynamicObjectReturnWorkflow;
  * @group client
  * @group functional
  */
-final class DynamicObjectReturnWorkflowTestCase extends ClientTestCase
+final class DynamicObjectReturnWorkflowTestCase extends AbstractClient
 {
     public function testWorkflow(): void
     {

--- a/tests/Functional/Client/EnumTestCase.php
+++ b/tests/Functional/Client/EnumTestCase.php
@@ -22,7 +22,7 @@ use Temporal\Tests\Workflow\SimpleEnumWorkflow;
  * @group client
  * @group functional
  */
-class EnumTestCase extends ClientTestCase
+class EnumTestCase extends AbstractClient
 {
     public function testSimpleEnum(): void
     {

--- a/tests/Functional/Client/ExternalWorkflowTestCase.php
+++ b/tests/Functional/Client/ExternalWorkflowTestCase.php
@@ -18,7 +18,7 @@ use Temporal\Tests\Workflow\LoopKillerWorkflow;
 use Temporal\Tests\Workflow\LoopSignallingWorkflow;
 use Temporal\Tests\Workflow\LoopWorkflow;
 
-class ExternalWorkflowTestCase extends ClientTestCase
+class ExternalWorkflowTestCase extends AbstractClient
 {
     use WithoutTimeSkipping;
 

--- a/tests/Functional/Client/FailureTestCase.php
+++ b/tests/Functional/Client/FailureTestCase.php
@@ -23,7 +23,7 @@ use Temporal\Tests\Workflow\SignalExceptionsWorkflow;
  * @group client
  * @group functional
  */
-class FailureTestCase extends ClientTestCase
+class FailureTestCase extends AbstractClient
 {
     public function testSimpleFailurePropagation()
     {

--- a/tests/Functional/Client/SagaTestCase.php
+++ b/tests/Functional/Client/SagaTestCase.php
@@ -19,7 +19,7 @@ use Temporal\Tests\Workflow\SagaWorkflow;
  * @group client
  * @group functional
  */
-class SagaTestCase extends ClientTestCase
+class SagaTestCase extends AbstractClient
 {
     public function testGetResult()
     {

--- a/tests/Functional/Client/ServiceClientTestCase.php
+++ b/tests/Functional/Client/ServiceClientTestCase.php
@@ -20,7 +20,7 @@ use Temporal\Exception\Client\TimeoutException;
  * @group client
  * @group functional
  */
-class ServiceClientTestCase extends ClientTestCase
+class ServiceClientTestCase extends AbstractClient
 {
     public function testTimeoutException()
     {

--- a/tests/Functional/Client/TypeArrayOfObjectsTestCase.php
+++ b/tests/Functional/Client/TypeArrayOfObjectsTestCase.php
@@ -19,7 +19,7 @@ use Temporal\Tests\Workflow\ArrayOfObjectsWorkflow;
  * @group client
  * @group functional
  */
-class TypeArrayOfObjectsTestCase extends ClientTestCase
+class TypeArrayOfObjectsTestCase extends AbstractClient
 {
     public function testArrayOfMessagesReceived(): void
     {

--- a/tests/Functional/Client/TypedStubTestCase.php
+++ b/tests/Functional/Client/TypedStubTestCase.php
@@ -30,7 +30,7 @@ use Temporal\Tests\Workflow\SimpleWorkflow;
  * @group client
  * @group functional
  */
-class TypedStubTestCase extends ClientTestCase
+class TypedStubTestCase extends AbstractClient
 {
     public function testGetResult()
     {

--- a/tests/Functional/Client/UntypedWorkflowStubTestCase.php
+++ b/tests/Functional/Client/UntypedWorkflowStubTestCase.php
@@ -24,7 +24,7 @@ use Temporal\Tests\Unit\Declaration\Fixture\WorkflowWithoutHandler;
  * @group client
  * @group functional
  */
-class UntypedWorkflowStubTestCase extends ClientTestCase
+class UntypedWorkflowStubTestCase extends AbstractClient
 {
     public function testUntypedStartAndWaitResult()
     {

--- a/tests/Functional/Client/UpsertSearchAttributesWorkflowTestCase.php
+++ b/tests/Functional/Client/UpsertSearchAttributesWorkflowTestCase.php
@@ -8,19 +8,18 @@ namespace Temporal\Tests\Functional\Client;
  * @group client
  * @group functional
  */
-class UpsertSearchAttributesWorkflowTestCase extends ClientTestCase
+class UpsertSearchAttributesWorkflowTestCase extends AbstractClient
 {
-    // TODO: doesn't work on the new test server ¯\_(ツ)_/¯
-    // public function testUpsertSearchAttributes()
-    // {
-    //     $client = $this->createClient();
-    //     $workflow = $client->newUntypedWorkflowStub('UpsertSearchAttributesWorkflow');
-    //
-    //     $e = $client->start($workflow);
-    //
-    //     $this->assertNotEmpty($e->getExecution()->getID());
-    //     $this->assertNotEmpty($e->getExecution()->getRunID());
-    //
-    //     $this->assertSame('done', $workflow->getResult());
-    // }
+    public function testUpsertSearchAttributes()
+    {
+        $client = $this->createClient();
+        $workflow = $client->newUntypedWorkflowStub('UpsertSearchAttributesWorkflow');
+
+        $e = $client->start($workflow);
+
+        $this->assertNotEmpty($e->getExecution()->getID());
+        $this->assertNotEmpty($e->getExecution()->getRunID());
+
+        $this->assertSame('done', $workflow->getResult());
+    }
 }

--- a/tests/Functional/Client/UuidTestCase.php
+++ b/tests/Functional/Client/UuidTestCase.php
@@ -20,7 +20,7 @@ use Temporal\Tests\Workflow\SimpleUuidWorkflow;
  * @group client
  * @group functional
  */
-class UuidTestCase extends ClientTestCase
+class UuidTestCase extends AbstractClient
 {
     public function testUuidPassedAndReturned(): void
     {

--- a/tests/Functional/Interceptor/AbstractClient.php
+++ b/tests/Functional/Interceptor/AbstractClient.php
@@ -14,13 +14,13 @@ namespace Temporal\Tests\Functional\Interceptor;
 use Temporal\Client\GRPC\ServiceClient;
 use Temporal\Client\WorkflowClient;
 use Temporal\Tests\Fixtures\PipelineProvider;
-use Temporal\Tests\Functional\FunctionalTestCase;
+use Temporal\Tests\Functional\AbstractFunctional;
 use Temporal\Tests\Interceptor\InterceptorCallsCounter;
 
 /**
  * @group client
  */
-abstract class AbstractClient extends FunctionalTestCase
+abstract class AbstractClient extends AbstractFunctional
 {
     /**
      * @param string $connection

--- a/tests/Functional/Interceptor/HeaderTestCase.php
+++ b/tests/Functional/Interceptor/HeaderTestCase.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace Temporal\Tests\Functional\Interceptor;
 
 use Temporal\Client\WorkflowOptions;
-use Temporal\Tests\Functional\Client\ClientTestCase;
+use Temporal\Tests\Functional\Client\AbstractClient;
 use Temporal\Tests\Workflow\Header\ChildedHeaderWorkflow;
 use Temporal\Tests\Workflow\Header\EmptyHeaderWorkflow;
 
@@ -25,7 +25,7 @@ use Temporal\Tests\Workflow\Header\EmptyHeaderWorkflow;
  * @group workflow
  * @group functional
  */
-class HeaderTestCase extends ClientTestCase
+class HeaderTestCase extends AbstractClient
 {
     public function testWorkflowEmptyHeader(): void
     {

--- a/tests/Functional/WorkflowTestCase.php
+++ b/tests/Functional/WorkflowTestCase.php
@@ -19,7 +19,7 @@ use Temporal\Tests\Fixtures\WorkerMock;
  * @group workflow
  * @group functional
  */
-class WorkflowTestCase extends FunctionalTestCase
+class WorkflowTestCase extends AbstractFunctional
 {
     public function setUp(): void
     {

--- a/tests/Functional/WorkflowTestCase.php
+++ b/tests/Functional/WorkflowTestCase.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace Temporal\Tests\Functional;
 
 use Temporal\Common\Uuid;
-use Temporal\Tests\Fixtures\CommandResetter;
 use Temporal\Tests\Fixtures\Splitter;
 use Temporal\Tests\Fixtures\WorkerMock;
 

--- a/tests/Unit/AbstractUnit.php
+++ b/tests/Unit/AbstractUnit.php
@@ -9,13 +9,13 @@
 
 declare(strict_types=1);
 
-namespace Temporal\Tests\Functional;
+namespace Temporal\Tests\Unit;
 
 use Temporal\Tests\TestCase;
 
 /**
- * @group functional
+ * @group unit
  */
-abstract class FunctionalTestCase extends TestCase
+abstract class AbstractUnit extends TestCase
 {
 }

--- a/tests/Unit/Activity/ActivityPrototypeTestCase.php
+++ b/tests/Unit/Activity/ActivityPrototypeTestCase.php
@@ -8,10 +8,10 @@ use Spiral\Attributes\AnnotationReader;
 use Spiral\Attributes\AttributeReader;
 use Spiral\Attributes\Composite\SelectiveReader;
 use Temporal\Internal\Declaration\Reader\ActivityReader;
-use Temporal\Tests\Unit\UnitTestCase;
+use Temporal\Tests\Unit\AbstractUnit;
 use WeakReference;
 
-final class ActivityPrototypeTestCase extends UnitTestCase
+final class ActivityPrototypeTestCase extends AbstractUnit
 {
     private ActivityReader $activityReader;
 

--- a/tests/Unit/Common/SdkVersionTestCase.php
+++ b/tests/Unit/Common/SdkVersionTestCase.php
@@ -2,14 +2,13 @@
 
 namespace Temporal\Tests\Unit\Common;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Temporal\Common\SdkVersion;
 
 class SdkVersionTestCase extends TestCase
 {
-    /**
-     * @dataProvider versionProvider
-     */
+    #[DataProvider('versionProvider')]
     public function testVersionRegx(string $version, string $matched): void
     {
         $result = preg_match(SdkVersion::VERSION_REGX, $version, $matches);
@@ -20,7 +19,7 @@ class SdkVersionTestCase extends TestCase
         }
     }
 
-    public function versionProvider(): iterable
+    public static function versionProvider(): iterable
     {
         return [
             ['1.2.3.0', '1.2.3'],

--- a/tests/Unit/DTO/AbstractDTOMarshalling.php
+++ b/tests/Unit/DTO/AbstractDTOMarshalling.php
@@ -17,7 +17,7 @@ use Temporal\Internal\Marshaller\Marshaller;
 use Temporal\Internal\Marshaller\MarshallerInterface;
 use Temporal\Internal\Marshaller\Type\DetectableTypeInterface;
 use Temporal\Internal\Marshaller\TypeFactory;
-use Temporal\Tests\Unit\UnitTestCase;
+use Temporal\Tests\Unit\AbstractUnit;
 
 /**
  * @group unit
@@ -25,7 +25,7 @@ use Temporal\Tests\Unit\UnitTestCase;
  *
  * @psalm-import-type CallableTypeMatcher from TypeFactory
  */
-abstract class DTOMarshallingTestCase extends UnitTestCase
+abstract class AbstractDTOMarshalling extends AbstractUnit
 {
     /**
      * @var MarshallerInterface

--- a/tests/Unit/DTO/ActivityInfoTestCase.php
+++ b/tests/Unit/DTO/ActivityInfoTestCase.php
@@ -13,7 +13,7 @@ namespace Temporal\Tests\Unit\DTO;
 
 use Temporal\Activity\ActivityInfo;
 
-class ActivityInfoTestCase extends DTOMarshallingTestCase
+class ActivityInfoTestCase extends AbstractDTOMarshalling
 {
     /**
      * @throws \ReflectionException

--- a/tests/Unit/DTO/ActivityOptionsTestCase.php
+++ b/tests/Unit/DTO/ActivityOptionsTestCase.php
@@ -17,7 +17,7 @@ use Temporal\Activity\ActivityOptions;
 use Temporal\Common\RetryOptions;
 use Temporal\Common\Uuid;
 
-class ActivityOptionsTestCase extends DTOMarshallingTestCase
+class ActivityOptionsTestCase extends AbstractDTOMarshalling
 {
     /**
      * @throws \ReflectionException

--- a/tests/Unit/DTO/ActivityTypeTestCase.php
+++ b/tests/Unit/DTO/ActivityTypeTestCase.php
@@ -13,7 +13,7 @@ namespace Temporal\Tests\Unit\DTO;
 
 use Temporal\Activity\ActivityType;
 
-class ActivityTypeTestCase extends DTOMarshallingTestCase
+class ActivityTypeTestCase extends AbstractDTOMarshalling
 {
     /**
      * @throws \ReflectionException

--- a/tests/Unit/DTO/ChildWorkflowOptionsTestCase.php
+++ b/tests/Unit/DTO/ChildWorkflowOptionsTestCase.php
@@ -14,7 +14,7 @@ namespace Temporal\Tests\Unit\DTO;
 use Temporal\Common\IdReusePolicy;
 use Temporal\Workflow\ChildWorkflowOptions;
 
-class ChildWorkflowOptionsTestCase extends DTOMarshallingTestCase
+class ChildWorkflowOptionsTestCase extends AbstractDTOMarshalling
 {
     /**
      * @throws \ReflectionException

--- a/tests/Unit/DTO/ClientOptionsTestCase.php
+++ b/tests/Unit/DTO/ClientOptionsTestCase.php
@@ -15,7 +15,7 @@ use Temporal\Api\Enums\V1\QueryRejectCondition;
 use Temporal\Client\ClientOptions;
 use Temporal\Common\Uuid;
 
-class ClientOptionsTestCase extends DTOMarshallingTestCase
+class ClientOptionsTestCase extends AbstractDTOMarshalling
 {
     public function testNamespaceChangesNotMutateState(): void
     {

--- a/tests/Unit/DTO/ContinueAsNewOptionsTestCase.php
+++ b/tests/Unit/DTO/ContinueAsNewOptionsTestCase.php
@@ -13,7 +13,7 @@ namespace Temporal\Tests\Unit\DTO;
 
 use Temporal\Workflow\ContinueAsNewOptions;
 
-class ContinueAsNewOptionsTestCase extends DTOMarshallingTestCase
+class ContinueAsNewOptionsTestCase extends AbstractDTOMarshalling
 {
     /**
      * @throws \ReflectionException

--- a/tests/Unit/DTO/Readonly/ReadonlyPropertiesTestCase.php
+++ b/tests/Unit/DTO/Readonly/ReadonlyPropertiesTestCase.php
@@ -12,9 +12,9 @@ declare(strict_types=1);
 namespace Temporal\Tests\Unit\DTO\Readonly;
 
 use Temporal\DataConverter\DataConverter;
-use Temporal\Tests\Unit\DTO\DTOMarshallingTestCase;
+use Temporal\Tests\Unit\DTO\AbstractDTOMarshalling;
 
-class ReadonlyPropertiesTestCase extends DTOMarshallingTestCase
+class ReadonlyPropertiesTestCase extends AbstractDTOMarshalling
 {
     public function testMarshalling(): void
     {

--- a/tests/Unit/DTO/RetryOptionsTestCase.php
+++ b/tests/Unit/DTO/RetryOptionsTestCase.php
@@ -13,7 +13,7 @@ namespace Temporal\Tests\Unit\DTO;
 
 use Temporal\Common\RetryOptions;
 
-class RetryOptionsTestCase extends DTOMarshallingTestCase
+class RetryOptionsTestCase extends AbstractDTOMarshalling
 {
     /**
      * @throws \ReflectionException

--- a/tests/Unit/DTO/Type/ArrayType/ArrayTestCase.php
+++ b/tests/Unit/DTO/Type/ArrayType/ArrayTestCase.php
@@ -12,9 +12,9 @@ declare(strict_types=1);
 namespace Temporal\Tests\Unit\DTO\Type\ArrayType;
 
 use Temporal\Internal\Marshaller\Type\ArrayType;
-use Temporal\Tests\Unit\DTO\DTOMarshallingTestCase;
+use Temporal\Tests\Unit\DTO\AbstractDTOMarshalling;
 
-class ArrayTestCase extends DTOMarshallingTestCase
+class ArrayTestCase extends AbstractDTOMarshalling
 {
     public function testMarshalling(): void
     {

--- a/tests/Unit/DTO/Type/DateIntervalType/DateIntervalTestCase.php
+++ b/tests/Unit/DTO/Type/DateIntervalType/DateIntervalTestCase.php
@@ -13,10 +13,10 @@ namespace Temporal\Tests\Unit\DTO\Type\DateIntervalType;
 
 use DateInterval;
 use Temporal\Internal\Marshaller\Type\DateIntervalType;
-use Temporal\Tests\Unit\DTO\DTOMarshallingTestCase;
+use Temporal\Tests\Unit\DTO\AbstractDTOMarshalling;
 use Temporal\Tests\Unit\DTO\Type\DateIntervalType\Stub\DateIntervalDto;
 
-class DateIntervalTestCase extends DTOMarshallingTestCase
+class DateIntervalTestCase extends AbstractDTOMarshalling
 {
     public function testMarshalAndUnmarshalWithoutAttribute(): void
     {

--- a/tests/Unit/DTO/Type/DateTimeType/DateTimeTestCase.php
+++ b/tests/Unit/DTO/Type/DateTimeType/DateTimeTestCase.php
@@ -16,10 +16,10 @@ use Carbon\CarbonImmutable;
 use DateTime;
 use DateTimeImmutable;
 use Temporal\Internal\Marshaller\Type\DateTimeType;
-use Temporal\Tests\Unit\DTO\DTOMarshallingTestCase;
+use Temporal\Tests\Unit\DTO\AbstractDTOMarshalling;
 use Temporal\Tests\Unit\DTO\Type\DateTimeType\Stub\DateTimeDto;
 
-class DateTimeTestCase extends DTOMarshallingTestCase
+class DateTimeTestCase extends AbstractDTOMarshalling
 {
     public function testMarshal(): void
     {

--- a/tests/Unit/DTO/Type/EnumType/EnumTestCase.php
+++ b/tests/Unit/DTO/Type/EnumType/EnumTestCase.php
@@ -13,12 +13,12 @@ namespace Temporal\Tests\Unit\DTO\Type\EnumType;
 
 use Error;
 use Temporal\Internal\Marshaller\Type\EnumType;
-use Temporal\Tests\Unit\DTO\DTOMarshallingTestCase;
+use Temporal\Tests\Unit\DTO\AbstractDTOMarshalling;
 use Temporal\Tests\Unit\DTO\Type\EnumType\Stub\EnumDto;
 use Temporal\Tests\Unit\DTO\Type\EnumType\Stub\ScalarEnum;
 use Temporal\Tests\Unit\DTO\Type\EnumType\Stub\SimpleEnum;
 
-class EnumTestCase extends DTOMarshallingTestCase
+class EnumTestCase extends AbstractDTOMarshalling
 {
     public function testMarshal(): void
     {

--- a/tests/Unit/DTO/Type/ObjectType/ObjectTypeTestCase.php
+++ b/tests/Unit/DTO/Type/ObjectType/ObjectTypeTestCase.php
@@ -21,11 +21,11 @@ use Temporal\Tests\Unit\DTO\Type\ObjectType\Stub\Nested3;
 use Temporal\Tests\Unit\DTO\Type\ObjectType\Stub\NestedParent;
 use Temporal\Tests\Unit\DTO\Type\ObjectType\Stub\NullableProperty;
 use Temporal\Tests\Unit\DTO\Type\ObjectType\Stub\ParentDto;
-use Temporal\Tests\Unit\DTO\DTOMarshallingTestCase;
+use Temporal\Tests\Unit\DTO\AbstractDTOMarshalling;
 use Temporal\Tests\Unit\DTO\Type\ObjectType\Stub\ReadonlyProperty;
 use Temporal\Tests\Unit\DTO\Type\ObjectType\Stub\StdClassObjectProp;
 
-final class ObjectTypeTestCase extends DTOMarshallingTestCase
+final class ObjectTypeTestCase extends AbstractDTOMarshalling
 {
     public function testReflectionTypeMarshal(): void
     {

--- a/tests/Unit/DTO/Type/UuidType/UuidTypeTestCase.php
+++ b/tests/Unit/DTO/Type/UuidType/UuidTypeTestCase.php
@@ -11,11 +11,11 @@ use ReflectionClass;
 use Temporal\Internal\Marshaller\MarshallingRule;
 use Temporal\Internal\Marshaller\Type\NullableType;
 use Temporal\Internal\Marshaller\Type\UuidType;
-use Temporal\Tests\Unit\DTO\DTOMarshallingTestCase;
+use Temporal\Tests\Unit\DTO\AbstractDTOMarshalling;
 use Temporal\Tests\Unit\DTO\Type\UuidType\Stub\UuidObjectProp;
 use Temporal\Tests\Unit\Internal\Marshaller\Fixture\PropertyType;
 
-final class UuidTypeTestCase extends DTOMarshallingTestCase
+final class UuidTypeTestCase extends AbstractDTOMarshalling
 {
     #[DataProvider('matchDataProvider')]
     public function testMatch(string $property, bool $expected): void

--- a/tests/Unit/DTO/Type/UuidType/UuidTypeTestCase.php
+++ b/tests/Unit/DTO/Type/UuidType/UuidTypeTestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Unit\DTO\Type\UuidType;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
 use ReflectionClass;
@@ -16,9 +17,7 @@ use Temporal\Tests\Unit\Internal\Marshaller\Fixture\PropertyType;
 
 final class UuidTypeTestCase extends DTOMarshallingTestCase
 {
-    /**
-     * @dataProvider matchDataProvider
-     */
+    #[DataProvider('matchDataProvider')]
     public function testMatch(string $property, bool $expected): void
     {
         $this->assertSame(
@@ -27,9 +26,7 @@ final class UuidTypeTestCase extends DTOMarshallingTestCase
         );
     }
 
-    /**
-     * @dataProvider makeRuleDataProvider
-     */
+    #[DataProvider('makeRuleDataProvider')]
     public function testMakeRule(string $property, mixed $expected): void
     {
         $this->assertEquals(

--- a/tests/Unit/DTO/WorkerOptionsTestCase.php
+++ b/tests/Unit/DTO/WorkerOptionsTestCase.php
@@ -13,7 +13,7 @@ namespace Temporal\Tests\Unit\DTO;
 
 use Temporal\Worker\WorkerOptions;
 
-class WorkerOptionsTestCase extends DTOMarshallingTestCase
+class WorkerOptionsTestCase extends AbstractDTOMarshalling
 {
     /**
      * @throws \ReflectionException

--- a/tests/Unit/DTO/WorkflowExecutionTestCase.php
+++ b/tests/Unit/DTO/WorkflowExecutionTestCase.php
@@ -15,7 +15,7 @@ use Temporal\DataConverter\DataConverter;
 use Temporal\Internal\Marshaller\ProtoToArrayConverter;
 use Temporal\Workflow\WorkflowExecution;
 
-class WorkflowExecutionTestCase extends DTOMarshallingTestCase
+class WorkflowExecutionTestCase extends AbstractDTOMarshalling
 {
     /**
      * @throws \ReflectionException

--- a/tests/Unit/DTO/WorkflowInfoTestCase.php
+++ b/tests/Unit/DTO/WorkflowInfoTestCase.php
@@ -13,7 +13,7 @@ namespace Temporal\Tests\Unit\DTO;
 
 use Temporal\Workflow\WorkflowInfo;
 
-class WorkflowInfoTestCase extends DTOMarshallingTestCase
+class WorkflowInfoTestCase extends AbstractDTOMarshalling
 {
     /**
      * @throws \ReflectionException

--- a/tests/Unit/DTO/WorkflowOptionsTestCase.php
+++ b/tests/Unit/DTO/WorkflowOptionsTestCase.php
@@ -20,7 +20,7 @@ use Temporal\Common\RetryOptions;
 use Temporal\Common\Uuid;
 use Temporal\DataConverter\DataConverter;
 
-class WorkflowOptionsTestCase extends DTOMarshallingTestCase
+class WorkflowOptionsTestCase extends AbstractDTOMarshalling
 {
     /**
      * @throws \ReflectionException

--- a/tests/Unit/DTO/WorkflowTypeTestCase.php
+++ b/tests/Unit/DTO/WorkflowTypeTestCase.php
@@ -13,7 +13,7 @@ namespace Temporal\Tests\Unit\DTO;
 
 use Temporal\Workflow\WorkflowType;
 
-class WorkflowTypeTestCase extends DTOMarshallingTestCase
+class WorkflowTypeTestCase extends AbstractDTOMarshalling
 {
     /**
      * @throws \ReflectionException

--- a/tests/Unit/DataConverter/DataConverterTestCase.php
+++ b/tests/Unit/DataConverter/DataConverterTestCase.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Unit\DataConverter;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Temporal\DataConverter\DataConverter;
 use Temporal\DataConverter\DataConverterInterface;
 use Temporal\DataConverter\Type;
@@ -26,7 +27,7 @@ class DataConverterTestCase extends UnitTestCase
     /**
      * @return array[]
      */
-    public function typesDataProvider(): array
+    public static function typesDataProvider(): array
     {
         return [
             // Any
@@ -59,7 +60,7 @@ class DataConverterTestCase extends UnitTestCase
     /**
      * @return array
      */
-    public function negativeTypesDataProvider(): array
+    public static function negativeTypesDataProvider(): array
     {
         return [
             Type::TYPE_OBJECT . ' => ' . Type::TYPE_STRING => [Type::TYPE_STRING, (object)['field' => 'value']],
@@ -115,7 +116,7 @@ class DataConverterTestCase extends UnitTestCase
      * @return array[]
      * @throws \Exception
      */
-    public function nullableTypesDataProvider(): array
+    public static function nullableTypesDataProvider(): array
     {
         return [
             Type::TYPE_ARRAY . ' => ' . Type::TYPE_VOID  => [Type::TYPE_VOID, [1, 2, 3]],
@@ -137,11 +138,10 @@ class DataConverterTestCase extends UnitTestCase
     }
 
     /**
-     * @dataProvider typesDataProvider
-     *
      * @param string $type
      * @param mixed $value
      */
+    #[DataProvider('typesDataProvider')]
     public function testPositiveConvert(string $type, $value): void
     {
         $converter = $this->create();
@@ -152,11 +152,10 @@ class DataConverterTestCase extends UnitTestCase
     }
 
     /**
-     * @dataProvider negativeTypesDataProvider
-     *
      * @param string $type
      * @param mixed $value
      */
+    #[DataProvider('negativeTypesDataProvider')]
     public function testConvertErrors(string $type, $value): void
     {
         $this->expectException(DataConverterException::class);
@@ -166,11 +165,10 @@ class DataConverterTestCase extends UnitTestCase
     }
 
     /**
-     * @dataProvider nullableTypesDataProvider
-     *
      * @param string $type
      * @param mixed $value
      */
+    #[DataProvider('nullableTypesDataProvider')]
     public function testNullableTypeCoercion(string $type, $value): void
     {
         $converter = $this->create();

--- a/tests/Unit/DataConverter/DataConverterTestCase.php
+++ b/tests/Unit/DataConverter/DataConverterTestCase.php
@@ -16,13 +16,13 @@ use Temporal\DataConverter\DataConverter;
 use Temporal\DataConverter\DataConverterInterface;
 use Temporal\DataConverter\Type;
 use Temporal\Exception\DataConverterException;
-use Temporal\Tests\Unit\UnitTestCase;
+use Temporal\Tests\Unit\AbstractUnit;
 
 /**
  * @group unit
  * @group data-converter
  */
-class DataConverterTestCase extends UnitTestCase
+class DataConverterTestCase extends AbstractUnit
 {
     /**
      * @return array[]

--- a/tests/Unit/DataConverter/JsonConverterTestCase.php
+++ b/tests/Unit/DataConverter/JsonConverterTestCase.php
@@ -15,13 +15,13 @@ use Ramsey\Uuid\Uuid;
 use Temporal\DataConverter\JsonConverter;
 use Temporal\DataConverter\PayloadConverterInterface;
 use Temporal\DataConverter\Type;
-use Temporal\Tests\Unit\UnitTestCase;
+use Temporal\Tests\Unit\AbstractUnit;
 
 /**
  * @group unit
  * @group data-converter
  */
-class JsonConverterTestCase extends UnitTestCase
+class JsonConverterTestCase extends AbstractUnit
 {
     protected function create(): PayloadConverterInterface
     {

--- a/tests/Unit/DataConverter/ProtoConverterTestCase.php
+++ b/tests/Unit/DataConverter/ProtoConverterTestCase.php
@@ -14,13 +14,13 @@ namespace Temporal\Tests\Unit\DataConverter;
 use Temporal\DataConverter\EncodingKeys;
 use Temporal\DataConverter\PayloadConverterInterface;
 use Temporal\DataConverter\ProtoConverter;
-use Temporal\Tests\Unit\UnitTestCase;
+use Temporal\Tests\Unit\AbstractUnit;
 
 /**
  * @group unit
  * @group data-converter
  */
-class ProtoConverterTestCase extends UnitTestCase
+class ProtoConverterTestCase extends AbstractUnit
 {
     protected function create(): PayloadConverterInterface
     {

--- a/tests/Unit/DataConverter/ProtoJsonConverterTestCase.php
+++ b/tests/Unit/DataConverter/ProtoJsonConverterTestCase.php
@@ -14,13 +14,13 @@ namespace Temporal\Tests\Unit\DataConverter;
 use Temporal\DataConverter\EncodingKeys;
 use Temporal\DataConverter\PayloadConverterInterface;
 use Temporal\DataConverter\ProtoJsonConverter;
-use Temporal\Tests\Unit\UnitTestCase;
+use Temporal\Tests\Unit\AbstractUnit;
 
 /**
  * @group unit
  * @group data-converter
  */
-class ProtoJsonConverterTestCase extends UnitTestCase
+class ProtoJsonConverterTestCase extends AbstractUnit
 {
     protected function create(): PayloadConverterInterface
     {

--- a/tests/Unit/Declaration/AbstractDeclaration.php
+++ b/tests/Unit/Declaration/AbstractDeclaration.php
@@ -15,13 +15,13 @@ use Spiral\Attributes\AnnotationReader;
 use Spiral\Attributes\AttributeReader;
 use Temporal\Internal\Declaration\Reader\ActivityReader;
 use Temporal\Internal\Declaration\Reader\WorkflowReader;
-use Temporal\Tests\Unit\UnitTestCase;
+use Temporal\Tests\Unit\AbstractUnit;
 
 /**
  * @group unit
  * @group declaration
  */
-abstract class DeclarationTestCase extends UnitTestCase
+abstract class AbstractDeclaration extends AbstractUnit
 {
     /**
      * @return WorkflowReader[][]

--- a/tests/Unit/Declaration/ActivitiesNegativeDeclarationTestCase.php
+++ b/tests/Unit/Declaration/ActivitiesNegativeDeclarationTestCase.php
@@ -23,7 +23,7 @@ use Temporal\Tests\Unit\Declaration\Fixture\ActivityWithPublicStaticMethod;
  * @group unit
  * @group declaration
  */
-class ActivitiesNegativeDeclarationTestCase extends DeclarationTestCase
+class ActivitiesNegativeDeclarationTestCase extends AbstractDeclaration
 {
     /**
      * @param ActivityReader $reader

--- a/tests/Unit/Declaration/ActivitiesNegativeDeclarationTestCase.php
+++ b/tests/Unit/Declaration/ActivitiesNegativeDeclarationTestCase.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Unit\Declaration;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
 use Temporal\Internal\Declaration\Reader\ActivityReader;
 use Temporal\Tests\Unit\Declaration\Fixture\ActivityNamesDuplication;
 use Temporal\Tests\Unit\Declaration\Fixture\ActivityWithPrivateMethod;
@@ -24,12 +26,11 @@ use Temporal\Tests\Unit\Declaration\Fixture\ActivityWithPublicStaticMethod;
 class ActivitiesNegativeDeclarationTestCase extends DeclarationTestCase
 {
     /**
-     * @testdox Checks for errors when reading activity class methods with the same name
-     * @dataProvider activityReaderDataProvider
-     *
      * @param ActivityReader $reader
      * @throws \ReflectionException
      */
+    #[TestDox("Checks for errors when reading activity class methods with the same name")]
+    #[DataProvider('activityReaderDataProvider')]
     public function testNameConflict(ActivityReader $reader): void
     {
         $reflection = new \ReflectionMethod(ActivityNamesDuplication::class, 'a');
@@ -49,12 +50,11 @@ class ActivitiesNegativeDeclarationTestCase extends DeclarationTestCase
     }
 
     /**
-     * @testdox Checks for errors when declaring a private method with an activity method attribute declaration
-     * @dataProvider activityReaderDataProvider
-     *
      * @param ActivityReader $reader
      * @throws \ReflectionException
      */
+    #[TestDox("Checks for errors when declaring a private method with an activity method attribute declaration")]
+    #[DataProvider('activityReaderDataProvider')]
     public function testPrivateMethod(ActivityReader $reader): void
     {
         $this->expectException(\LogicException::class);
@@ -70,12 +70,11 @@ class ActivitiesNegativeDeclarationTestCase extends DeclarationTestCase
     }
 
     /**
-     * @testdox Checks for errors when declaring a protected method with an activity method attribute declaration
-     * @dataProvider activityReaderDataProvider
-     *
      * @param ActivityReader $reader
      * @throws \ReflectionException
      */
+    #[TestDox("Checks for errors when declaring a protected method with an activity method attribute declaration")]
+    #[DataProvider('activityReaderDataProvider')]
     public function testProtectedMethod(ActivityReader $reader): void
     {
         $this->expectException(\LogicException::class);
@@ -91,12 +90,11 @@ class ActivitiesNegativeDeclarationTestCase extends DeclarationTestCase
     }
 
     /**
-     * @testdox Checks for errors when declaring a public static method with an activity method attribute declaration
-     * @dataProvider activityReaderDataProvider
-     *
      * @param ActivityReader $reader
      * @throws \ReflectionException
      */
+    #[TestDox("Checks for errors when declaring a public static method with an activity method attribute declaration")]
+    #[DataProvider('activityReaderDataProvider')]
     public function testPublicStaticMethod(ActivityReader $reader): void
     {
         $this->expectException(\LogicException::class);

--- a/tests/Unit/Declaration/ActivityDeclarationTestCase.php
+++ b/tests/Unit/Declaration/ActivityDeclarationTestCase.php
@@ -22,7 +22,7 @@ use Temporal\Tests\Unit\Declaration\Fixture\ChildActivityMethods;
  * @group unit
  * @group declaration
  */
-class ActivityDeclarationTestCase extends DeclarationTestCase
+class ActivityDeclarationTestCase extends AbstractDeclaration
 {
     /**
      * @param array<ActivityPrototype> $prototypes

--- a/tests/Unit/Declaration/ActivityDeclarationTestCase.php
+++ b/tests/Unit/Declaration/ActivityDeclarationTestCase.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Unit\Declaration;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
 use Temporal\Internal\Declaration\Prototype\ActivityPrototype;
 use Temporal\Internal\Declaration\Reader\ActivityReader;
 use Temporal\Tests\Unit\Declaration\Fixture\ActivitiesWithPublicMethods;
@@ -32,12 +34,11 @@ class ActivityDeclarationTestCase extends DeclarationTestCase
     }
 
     /**
-     * @testdox Reading activities (should return activity prototypes for all non-static public methods)
-     * @dataProvider activityReaderDataProvider
-     *
      * @param ActivityReader $reader
      * @throws \ReflectionException
      */
+    #[TestDox("Reading activities (should return activity prototypes for all non-static public methods)")]
+    #[DataProvider('activityReaderDataProvider')]
     public function testActivitiesFromPublicNonStaticMethods(ActivityReader $reader): void
     {
         $prototypes = $reader->fromClass(ActivitiesWithPublicMethods::class);
@@ -48,12 +49,11 @@ class ActivityDeclarationTestCase extends DeclarationTestCase
     }
 
     /**
-     * @testdox
-     * @dataProvider activityReaderDataProvider
-     *
      * @param ActivityReader $reader
      * @throws \ReflectionException
      */
+    #[TestDox('')]
+    #[DataProvider('activityReaderDataProvider')]
     public function testInheritedActivities(ActivityReader $reader): void
     {
         $prototypes = $reader->fromClass(ChildActivityMethods::class);

--- a/tests/Unit/Declaration/DeclarationTestCase.php
+++ b/tests/Unit/Declaration/DeclarationTestCase.php
@@ -26,7 +26,7 @@ abstract class DeclarationTestCase extends UnitTestCase
     /**
      * @return WorkflowReader[][]
      */
-    public function workflowReaderDataProvider(): array
+    public static function workflowReaderDataProvider(): array
     {
         return [
             AttributeReader::class  => [new WorkflowReader(new AttributeReader())],
@@ -37,7 +37,7 @@ abstract class DeclarationTestCase extends UnitTestCase
     /**
      * @return ActivityReader[][]
      */
-    public function activityReaderDataProvider(): array
+    public static function activityReaderDataProvider(): array
     {
         return [
             AttributeReader::class  => [new ActivityReader(new AttributeReader())],

--- a/tests/Unit/Declaration/WorkflowDeclarationTestCase.php
+++ b/tests/Unit/Declaration/WorkflowDeclarationTestCase.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 namespace Temporal\Tests\Unit\Declaration;
 
 use Carbon\CarbonInterval;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
 use Temporal\Common\CronSchedule;
 use Temporal\Internal\Declaration\Reader\WorkflowReader;
 use Temporal\Tests\Unit\Declaration\Fixture\SimpleWorkflow;
@@ -31,12 +33,11 @@ use Temporal\Tests\Unit\Declaration\Fixture\WorkflowWithSignals;
 class WorkflowDeclarationTestCase extends DeclarationTestCase
 {
     /**
-     * @testdox Reading workflow without handler
-     * @dataProvider workflowReaderDataProvider
-     *
      * @param WorkflowReader $reader
      * @throws \ReflectionException
      */
+    #[TestDox("Reading workflow without handler")]
+    #[DataProvider('workflowReaderDataProvider')]
     public function testWorkflowWithoutHandler(WorkflowReader $reader): void
     {
         $prototype = $reader->fromClass(WorkflowWithoutHandler::class);
@@ -45,12 +46,11 @@ class WorkflowDeclarationTestCase extends DeclarationTestCase
     }
 
     /**
-     * @testdox Reading workflow without cron attribute (cron prototype value should be null)
-     * @dataProvider workflowReaderDataProvider
-     *
      * @param WorkflowReader $reader
      * @throws \ReflectionException
      */
+    #[TestDox("Reading workflow without cron attribute (cron prototype value should be null)")]
+    #[DataProvider('workflowReaderDataProvider')]
     public function testWorkflowWithoutCron(WorkflowReader $reader): void
     {
         $prototype = $reader->fromClass(SimpleWorkflow::class);
@@ -59,12 +59,11 @@ class WorkflowDeclarationTestCase extends DeclarationTestCase
     }
 
     /**
-     * @testdox Reading workflow with cron attribute (cron prototype value should not be null)
-     * @dataProvider workflowReaderDataProvider
-     *
      * @param WorkflowReader $reader
      * @throws \ReflectionException
      */
+    #[TestDox("Reading workflow with cron attribute (cron prototype value should not be null)")]
+    #[DataProvider('workflowReaderDataProvider')]
     public function testWorkflowWithCron(WorkflowReader $reader): void
     {
         $prototype = $reader->fromClass(WorkflowWithCron::class);
@@ -74,12 +73,11 @@ class WorkflowDeclarationTestCase extends DeclarationTestCase
     }
 
     /**
-     * @testdox Reading workflow without method retry attribute (method retry prototype value should be null)
-     * @dataProvider workflowReaderDataProvider
-     *
      * @param WorkflowReader $reader
      * @throws \ReflectionException
      */
+    #[TestDox("Reading workflow without method retry attribute (method retry prototype value should be null)")]
+    #[DataProvider('workflowReaderDataProvider')]
     public function testWorkflowWithoutRetry(WorkflowReader $reader): void
     {
         $prototype = $reader->fromClass(SimpleWorkflow::class);
@@ -88,12 +86,11 @@ class WorkflowDeclarationTestCase extends DeclarationTestCase
     }
 
     /**
-     * @testdox Reading workflow with method retry attribute (method retry prototype value should not be null)
-     * @dataProvider workflowReaderDataProvider
-     *
      * @param WorkflowReader $reader
      * @throws \ReflectionException
      */
+    #[TestDox("Reading workflow with method retry attribute (method retry prototype value should not be null)")]
+    #[DataProvider('workflowReaderDataProvider')]
     public function testWorkflowWithRetry(WorkflowReader $reader): void
     {
         $prototype = $reader->fromClass(WorkflowWithRetry::class);
@@ -105,12 +102,11 @@ class WorkflowDeclarationTestCase extends DeclarationTestCase
     }
 
     /**
-     * @testdox Reading workflow with method retry and cron attributes (prototypes value should not be null)
-     * @dataProvider workflowReaderDataProvider
-     *
      * @param WorkflowReader $reader
      * @throws \ReflectionException
      */
+    #[TestDox("Reading workflow with method retry and cron attributes (prototypes value should not be null)")]
+    #[DataProvider('workflowReaderDataProvider')]
     public function testWorkflowWithCronAndRetry(WorkflowReader $reader): void
     {
         $prototype = $reader->fromClass(WorkflowWithCronAndRetry::class);
@@ -125,12 +121,11 @@ class WorkflowDeclarationTestCase extends DeclarationTestCase
     }
 
     /**
-     * @testdox Reading workflow without query methods (query methods count equals 0)
-     * @dataProvider workflowReaderDataProvider
-     *
      * @param WorkflowReader $reader
      * @throws \ReflectionException
      */
+    #[TestDox("Reading workflow without query methods (query methods count equals 0)")]
+    #[DataProvider('workflowReaderDataProvider')]
     public function testWorkflowWithoutQueries(WorkflowReader $reader): void
     {
         $prototype = $reader->fromClass(SimpleWorkflow::class);
@@ -139,12 +134,11 @@ class WorkflowDeclarationTestCase extends DeclarationTestCase
     }
 
     /**
-     * @testdox Reading workflow with query methods (query methods count not equals 0)
-     * @dataProvider workflowReaderDataProvider
-     *
      * @param WorkflowReader $reader
      * @throws \ReflectionException
      */
+    #[TestDox("Reading workflow with query methods (query methods count not equals 0)")]
+    #[DataProvider('workflowReaderDataProvider')]
     public function testWorkflowWithQueries(WorkflowReader $reader): void
     {
         $prototype = $reader->fromClass(WorkflowWithQueries::class);
@@ -154,12 +148,11 @@ class WorkflowDeclarationTestCase extends DeclarationTestCase
     }
 
     /**
-     * @testdox Reading workflow without signal methods (signal methods count equals 0)
-     * @dataProvider workflowReaderDataProvider
-     *
      * @param WorkflowReader $reader
      * @throws \ReflectionException
      */
+    #[TestDox("Reading workflow without signal methods (signal methods count equals 0)")]
+    #[DataProvider('workflowReaderDataProvider')]
     public function testWorkflowWithoutSignals(WorkflowReader $reader): void
     {
         $prototype = $reader->fromClass(SimpleWorkflow::class);
@@ -168,12 +161,11 @@ class WorkflowDeclarationTestCase extends DeclarationTestCase
     }
 
     /**
-     * @testdox Reading workflow with signal methods (signal methods count not equals 0)
-     * @dataProvider workflowReaderDataProvider
-     *
      * @param WorkflowReader $reader
      * @throws \ReflectionException
      */
+    #[TestDox("Reading workflow with signal methods (signal methods count not equals 0)")]
+    #[DataProvider('workflowReaderDataProvider')]
     public function testWorkflowWithSignals(WorkflowReader $reader): void
     {
         $prototype = $reader->fromClass(WorkflowWithSignals::class);
@@ -184,12 +176,11 @@ class WorkflowDeclarationTestCase extends DeclarationTestCase
     }
 
     /**
-     * @testdox Workflow should be named same as method name
-     * @dataProvider workflowReaderDataProvider
-     *
      * @param WorkflowReader $reader
      * @throws \ReflectionException
      */
+    #[TestDox("Workflow should be named same as method name")]
+    #[DataProvider('workflowReaderDataProvider')]
     public function testWorkflowHandlerDefaultNaming(WorkflowReader $reader): void
     {
         $withoutName = $reader->fromClass(SimpleWorkflow::class);
@@ -198,12 +189,11 @@ class WorkflowDeclarationTestCase extends DeclarationTestCase
     }
 
     /**
-     * @testdox Workflow should be named same as the name specified in the workflow method attribute
-     * @dataProvider workflowReaderDataProvider
-     *
      * @param WorkflowReader $reader
      * @throws \ReflectionException
      */
+    #[TestDox("Workflow should be named same as the name specified in the workflow method attribute")]
+    #[DataProvider('workflowReaderDataProvider')]
     public function testWorkflowHandlerWithName(WorkflowReader $reader): void
     {
         $prototype = $reader->fromClass(WorkflowWithCustomName::class);

--- a/tests/Unit/Declaration/WorkflowDeclarationTestCase.php
+++ b/tests/Unit/Declaration/WorkflowDeclarationTestCase.php
@@ -30,7 +30,7 @@ use Temporal\Tests\Unit\Declaration\Fixture\WorkflowWithSignals;
  * @group unit
  * @group declaration
  */
-class WorkflowDeclarationTestCase extends DeclarationTestCase
+class WorkflowDeclarationTestCase extends AbstractDeclaration
 {
     /**
      * @param WorkflowReader $reader

--- a/tests/Unit/Declaration/WorkflowNegativeDeclarationTestCase.php
+++ b/tests/Unit/Declaration/WorkflowNegativeDeclarationTestCase.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Unit\Declaration;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
 use Temporal\Exception\InstantiationException;
 use Temporal\Internal\Declaration\Instantiator\WorkflowInstantiator;
 use Temporal\Internal\Declaration\Reader\WorkflowReader;
@@ -28,12 +30,11 @@ use Temporal\Workflow\WorkflowMethod;
 class WorkflowNegativeDeclarationTestCase extends DeclarationTestCase
 {
     /**
-     * @testdox Validate errors while loading workflow without WorkflowInterface attribute
-     * @dataProvider workflowReaderDataProvider
-     *
      * @param WorkflowReader $reader
      * @throws \ReflectionException
      */
+    #[TestDox("Validate errors while loading workflow without WorkflowInterface attribute")]
+    #[DataProvider('workflowReaderDataProvider')]
     public function testWorkflowWithoutInterfaceAttribute(WorkflowReader $reader): void
     {
         $this->expectException(\LogicException::class);
@@ -49,12 +50,11 @@ class WorkflowNegativeDeclarationTestCase extends DeclarationTestCase
     }
 
     /**
-     * @testdox Workflow handlers duplication
-     * @dataProvider workflowReaderDataProvider
-     *
      * @param WorkflowReader $reader
      * @throws \ReflectionException
      */
+    #[TestDox("Workflow handlers duplication")]
+    #[DataProvider('workflowReaderDataProvider')]
     public function testWorkflowMethodDuplication(WorkflowReader $reader): void
     {
         $this->expectException(\LogicException::class);
@@ -63,12 +63,11 @@ class WorkflowNegativeDeclarationTestCase extends DeclarationTestCase
     }
 
     /**
-     * @testdox Workflow without handler instantiation
-     * @dataProvider workflowReaderDataProvider
-     *
      * @param WorkflowReader $reader
      * @throws \ReflectionException
      */
+    #[TestDox("Workflow without handler instantiation")]
+    #[DataProvider('workflowReaderDataProvider')]
     public function testWorkflowWithoutHandlerInstantiation(WorkflowReader $reader): void
     {
         $this->expectException(InstantiationException::class);

--- a/tests/Unit/Declaration/WorkflowNegativeDeclarationTestCase.php
+++ b/tests/Unit/Declaration/WorkflowNegativeDeclarationTestCase.php
@@ -27,7 +27,7 @@ use Temporal\Workflow\WorkflowMethod;
  * @group unit
  * @group declaration
  */
-class WorkflowNegativeDeclarationTestCase extends DeclarationTestCase
+class WorkflowNegativeDeclarationTestCase extends AbstractDeclaration
 {
     /**
      * @param WorkflowReader $reader

--- a/tests/Unit/Exception/FailureConverterTestCase.php
+++ b/tests/Unit/Exception/FailureConverterTestCase.php
@@ -8,9 +8,9 @@ use Temporal\DataConverter\DataConverter;
 use Temporal\DataConverter\EncodedValues;
 use Temporal\Exception\Failure\ApplicationFailure;
 use Temporal\Exception\Failure\FailureConverter;
-use Temporal\Tests\Unit\UnitTestCase;
+use Temporal\Tests\Unit\AbstractUnit;
 
-final class FailureConverterTestCase extends UnitTestCase
+final class FailureConverterTestCase extends AbstractUnit
 {
     public function testApplicationFailureCanTransferData(): void
     {

--- a/tests/Unit/Framework/WorkerMock.php
+++ b/tests/Unit/Framework/WorkerMock.php
@@ -66,7 +66,7 @@ final class WorkerMock implements Identifiable, WorkerInterface, DispatcherInter
         $router = new Router();
         $router->add(new Router\StartWorkflow($this->services));
         $router->add(new Router\InvokeActivity($this->services, Goridge::create(), $this->interceptorProvider));
-        $router->add(new Router\DestroyWorkflow($this->services->running));
+        $router->add(new Router\DestroyWorkflow($this->services->running, $this->services->loop));
         $router->add(new Router\InvokeSignal($this->services->running));
 
         return $router;

--- a/tests/Unit/Framework/WorkerTestCase.php
+++ b/tests/Unit/Framework/WorkerTestCase.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Unit\Framework;
 
-use Temporal\Tests\Unit\UnitTestCase;
-use Temporal\Tests\Workflow\SimpleWorkflow;
+use Temporal\Tests\Unit\AbstractUnit;
 use Temporal\Worker\WorkerFactoryInterface;
 use Temporal\Worker\WorkerInterface;
 use Temporal\Workflow;
@@ -16,7 +15,7 @@ use function PHPUnit\Framework\assertFalse;
 /**
  * @internal
  */
-final class WorkerTestCase extends UnitTestCase
+final class WorkerTestCase extends AbstractUnit
 {
     private WorkerFactoryInterface $factory;
     /** @var WorkerMock|WorkerInterface */

--- a/tests/Unit/Interceptor/HeaderTestCase.php
+++ b/tests/Unit/Interceptor/HeaderTestCase.php
@@ -15,13 +15,13 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use Temporal\DataConverter\DataConverter;
 use Temporal\DataConverter\DataConverterInterface;
 use Temporal\Interceptor\Header;
-use Temporal\Tests\Unit\UnitTestCase;
+use Temporal\Tests\Unit\AbstractUnit;
 
 /**
  * @group unit
  * @group interceptor
  */
-class HeaderTestCase extends UnitTestCase
+class HeaderTestCase extends AbstractUnit
 {
     public function testToHeaderFromValuesWithoutConverterException(): void
     {

--- a/tests/Unit/Interceptor/HeaderTestCase.php
+++ b/tests/Unit/Interceptor/HeaderTestCase.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Unit\Interceptor;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Temporal\DataConverter\DataConverter;
 use Temporal\DataConverter\DataConverterInterface;
 use Temporal\Interceptor\Header;
@@ -62,9 +63,7 @@ class HeaderTestCase extends UnitTestCase
         $this->assertNotSame($collection, $source);
     }
 
-    /**
-     * @dataProvider fromValuesProvider()
-     */
+    #[DataProvider('fromValuesProvider')]
     public function testFromValues(array $input, array $output): void
     {
         $collection = Header::fromValues($input);
@@ -131,7 +130,7 @@ class HeaderTestCase extends UnitTestCase
         $this->assertSame('bar', $converter->fromPayload($collection->offsetGet('foo'), null));
     }
 
-    public function fromValuesProvider(): iterable
+    public static function fromValuesProvider(): iterable
     {
         yield [
             ['foo' => 'bar', 'bar' => 'baz', 'baz' => 'foo'],

--- a/tests/Unit/Internal/Client/WorkflowStarterTestCase.php
+++ b/tests/Unit/Internal/Client/WorkflowStarterTestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Unit\Internal\Client;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Temporal\Api\Workflowservice\V1\StartWorkflowExecutionRequest;
 use Temporal\Api\Workflowservice\V1\StartWorkflowExecutionResponse;
@@ -17,8 +18,8 @@ use Temporal\Internal\Support\DateInterval;
 /**
  * @internal
  *
- * @covers \Temporal\Internal\Client\WorkflowStub
  */
+#[CoversClass(\Temporal\Internal\Client\WorkflowStub::class)]
 final class WorkflowStarterTestCase extends TestCase
 {
     private const NAMESPACE = 'test-namespace';

--- a/tests/Unit/Internal/Client/WorkflowStubTestCase.php
+++ b/tests/Unit/Internal/Client/WorkflowStubTestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Unit\Internal\Client;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Temporal\Api\Common\V1\Payload;
@@ -27,9 +28,8 @@ use Temporal\Workflow\WorkflowExecution;
 
 /**
  * @internal
- *
- * @covers \Temporal\Internal\Client\WorkflowStub
  */
+#[CoversClass(\Temporal\Internal\Client\WorkflowStub::class)]
 final class WorkflowStubTestCase extends TestCase
 {
     private WorkflowStub $workflowStub;

--- a/tests/Unit/Internal/Marshaller/MarshallerTestCase.php
+++ b/tests/Unit/Internal/Marshaller/MarshallerTestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Unit\Internal\Marshaller;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Rfc4122\UuidV4;
 use Spiral\Attributes\AttributeReader;
@@ -16,9 +17,8 @@ use Temporal\Tests\Unit\Internal\Marshaller\Fixture\Uuid;
 
 /**
  * @internal
- *
- * @covers \Temporal\Internal\Marshaller\Marshaller
  */
+#[CoversClass(\Temporal\Internal\Marshaller\Marshaller::class)]
 final class MarshallerTestCase extends TestCase
 {
     public function testNestedNullableObjectWasSerialized(): void

--- a/tests/Unit/Internal/Support/GarbageCollectorTestCase.php
+++ b/tests/Unit/Internal/Support/GarbageCollectorTestCase.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Internal\Support;
+
+use PHPUnit\Framework\TestCase;
+use Temporal\Internal\Support\GarbageCollector;
+
+/**
+ * @internal
+ *
+ * @covers \Temporal\Internal\Support\GarbageCollector
+ */
+final class GarbageCollectorTestCase extends TestCase
+{
+    /**
+     * @dataProvider provideCheck
+     */
+    public function testCheckTicks(int $counter, int $iterations, bool $result): void
+    {
+        $gc = new GarbageCollector($counter, 3600);
+
+        for ($i = 1; $i < $iterations; ++$i) {
+            $this->assertFalse($gc->check());
+        }
+
+        $this->assertSame($result, $gc->check());
+    }
+
+    public function testCheckOverticked(): void
+    {
+        $gc = new GarbageCollector(5, 3600);
+
+        $this->assertFalse($gc->check());
+        $this->assertFalse($gc->check());
+        $this->assertFalse($gc->check());
+        $this->assertFalse($gc->check());
+        $this->assertTrue($gc->check());
+        $this->assertTrue($gc->check());
+        $this->assertTrue($gc->check());
+        $this->assertTrue($gc->check());
+    }
+
+    public function testCheckTimeout(): void
+    {
+        $gc = new GarbageCollector(100, 2);
+
+        $this->assertFalse($gc->check());
+    }
+
+    public function testCheckTriggerTimeout(): void
+    {
+        $gc = new GarbageCollector(100, 1, \time() - 2);
+
+        $this->assertTrue($gc->check());
+    }
+
+    public function provideCheck(): iterable
+    {
+        yield [1, 1, true];
+        yield [2, 1, false];
+        yield [3, 2, false];
+        yield [10, 9, false];
+        yield [10, 10, true];
+    }
+}

--- a/tests/Unit/Internal/Support/GarbageCollectorTestCase.php
+++ b/tests/Unit/Internal/Support/GarbageCollectorTestCase.php
@@ -4,19 +4,19 @@ declare(strict_types=1);
 
 namespace Internal\Support;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Temporal\Internal\Support\GarbageCollector;
 
 /**
  * @internal
  *
- * @covers \Temporal\Internal\Support\GarbageCollector
  */
+#[CoversClass(\Temporal\Internal\Support\GarbageCollector::class)]
 final class GarbageCollectorTestCase extends TestCase
 {
-    /**
-     * @dataProvider provideCheck
-     */
+    #[DataProvider('provideCheck')]
     public function testCheckTicks(int $counter, int $iterations, bool $result): void
     {
         $gc = new GarbageCollector($counter, 3600);
@@ -56,7 +56,7 @@ final class GarbageCollectorTestCase extends TestCase
         $this->assertTrue($gc->check());
     }
 
-    public function provideCheck(): iterable
+    public static function provideCheck(): iterable
     {
         yield [1, 1, true];
         yield [2, 1, false];

--- a/tests/Unit/Protocol/AbstractProtocol.php
+++ b/tests/Unit/Protocol/AbstractProtocol.php
@@ -9,13 +9,14 @@
 
 declare(strict_types=1);
 
-namespace Temporal\Tests\Feature;
+namespace Temporal\Tests\Unit\Protocol;
 
-use Temporal\Tests\TestCase;
+use Temporal\Tests\Unit\AbstractUnit;
 
 /**
- * @group feature
+ * @group unit
+ * @group protocol
  */
-abstract class FeatureTestCase extends TestCase
+abstract class AbstractProtocol extends AbstractUnit
 {
 }

--- a/tests/Unit/Protocol/DecodingCommandsTestCase.php
+++ b/tests/Unit/Protocol/DecodingCommandsTestCase.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\Attributes\Test;
  * @group unit
  * @group protocol
  */
-class DecodingCommandsTestCase extends ProtocolTestCase
+class DecodingCommandsTestCase extends AbstractProtocol
 {
     #[Test]
     public function todo(): void

--- a/tests/Unit/Protocol/DecodingCommandsTestCase.php
+++ b/tests/Unit/Protocol/DecodingCommandsTestCase.php
@@ -11,13 +11,15 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Unit\Protocol;
 
+use PHPUnit\Framework\Attributes\Test;
+
 /**
  * @group unit
  * @group protocol
  */
 class DecodingCommandsTestCase extends ProtocolTestCase
 {
-    /** @test */
+    #[Test]
     public function todo(): void
     {
         $this->expectNotToPerformAssertions();

--- a/tests/Unit/Protocol/DecodingHeadersTestCase.php
+++ b/tests/Unit/Protocol/DecodingHeadersTestCase.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\Attributes\Test;
  * @group unit
  * @group protocol
  */
-class DecodingHeadersTestCase extends ProtocolTestCase
+class DecodingHeadersTestCase extends AbstractProtocol
 {
     #[Test]
     public function todo(): void

--- a/tests/Unit/Protocol/DecodingHeadersTestCase.php
+++ b/tests/Unit/Protocol/DecodingHeadersTestCase.php
@@ -11,13 +11,15 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Unit\Protocol;
 
+use PHPUnit\Framework\Attributes\Test;
+
 /**
  * @group unit
  * @group protocol
  */
 class DecodingHeadersTestCase extends ProtocolTestCase
 {
-    /** @test */
+    #[Test]
     public function todo(): void
     {
         $this->expectNotToPerformAssertions();

--- a/tests/Unit/Protocol/EncodingTestCase.php
+++ b/tests/Unit/Protocol/EncodingTestCase.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Unit\Protocol;
 
+use PHPUnit\Framework\Attributes\Test;
 use Temporal\DataConverter\DataConverter;
 use Temporal\DataConverter\EncodedValues;
 
@@ -20,7 +21,7 @@ use Temporal\DataConverter\EncodedValues;
  */
 class EncodingTestCase extends ProtocolTestCase
 {
-    /** @test */
+    #[Test]
     public function nullValuesAreReturned(): void
     {
         $encodedValues = EncodedValues::fromValues([null, 'something'], new DataConverter());

--- a/tests/Unit/Protocol/EncodingTestCase.php
+++ b/tests/Unit/Protocol/EncodingTestCase.php
@@ -19,7 +19,7 @@ use Temporal\DataConverter\EncodedValues;
  * @group unit
  * @group protocol
  */
-class EncodingTestCase extends ProtocolTestCase
+class EncodingTestCase extends AbstractProtocol
 {
     #[Test]
     public function nullValuesAreReturned(): void

--- a/tests/Unit/Router/InvokeActivityTestCase.php
+++ b/tests/Unit/Router/InvokeActivityTestCase.php
@@ -23,12 +23,12 @@ use Temporal\Internal\ServiceContainer;
 use Temporal\Internal\Transport\ClientInterface;
 use Temporal\Internal\Transport\Router\InvokeActivity;
 use Temporal\Tests\Unit\Framework\Requests\InvokeActivity as Request;
-use Temporal\Tests\Unit\UnitTestCase;
+use Temporal\Tests\Unit\AbstractUnit;
 use Temporal\Worker\Environment\EnvironmentInterface;
 use Temporal\Worker\LoopInterface;
 use Temporal\Worker\Transport\RPCConnectionInterface;
 
-final class InvokeActivityTestCase extends UnitTestCase
+final class InvokeActivityTestCase extends AbstractUnit
 {
     private ServiceContainer $services;
     private InvokeActivity $router;

--- a/tests/Unit/Router/StartWorkflowTestCase.php
+++ b/tests/Unit/Router/StartWorkflowTestCase.php
@@ -27,13 +27,13 @@ use Temporal\Internal\Transport\Router\StartWorkflow;
 use Temporal\Internal\Workflow\Input;
 use Temporal\Internal\Workflow\WorkflowContext;
 use Temporal\Tests\Unit\Framework\Requests\StartWorkflow as Request;
-use Temporal\Tests\Unit\UnitTestCase;
+use Temporal\Tests\Unit\AbstractUnit;
 use Temporal\Worker\Environment\EnvironmentInterface;
 use Temporal\Worker\LoopInterface;
 use Temporal\Workflow\WorkflowExecution;
 use Temporal\Workflow\WorkflowInfo;
 
-final class StartWorkflowTestCase extends UnitTestCase
+final class StartWorkflowTestCase extends AbstractUnit
 {
     private ServiceContainer $services;
     private StartWorkflow $router;

--- a/tests/Unit/Router/StartWorkflowTestCase.php
+++ b/tests/Unit/Router/StartWorkflowTestCase.php
@@ -15,6 +15,7 @@ use Temporal\DataConverter\DataConverterInterface;
 use Temporal\DataConverter\EncodedValues;
 use Temporal\Exception\ExceptionInterceptorInterface;
 use Temporal\Interceptor\SimplePipelineProvider;
+use Temporal\Internal\Declaration\Destroyable;
 use Temporal\Internal\Declaration\Reader\WorkflowReader;
 use Temporal\Internal\Declaration\WorkflowInstanceInterface;
 use Temporal\Internal\Marshaller\MarshallerInterface;
@@ -59,7 +60,7 @@ final class StartWorkflowTestCase extends UnitTestCase
         $this->workflowContext = new WorkflowContext(
             $this->services,
             $this->services->client,
-            $this->createMock(WorkflowInstanceInterface::class),
+            $this->createMockForIntersectionOfInterfaces([WorkflowInstanceInterface::class, Destroyable::class]),
             new Input(),
             EncodedValues::empty()
         );

--- a/tests/Unit/Schedule/Action/StartWorkflowActionTestCase.php
+++ b/tests/Unit/Schedule/Action/StartWorkflowActionTestCase.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Schedule\Action;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Temporal\Client\Schedule\Action\StartWorkflowAction;
 use Temporal\Common\IdReusePolicy as WorkflowIdReusePolicy;
@@ -12,9 +14,7 @@ use Temporal\DataConverter\EncodedCollection;
 use Temporal\DataConverter\EncodedValues;
 use Temporal\Workflow\WorkflowType;
 
-/**
- * @covers \Temporal\Client\Schedule\Action\StartWorkflowAction
- */
+#[CoversClass(\Temporal\Client\Schedule\Action\StartWorkflowAction::class)]
 class StartWorkflowActionTestCase extends TestCase
 {
     public function testWithWorkflowTypeString(): void
@@ -71,9 +71,7 @@ class StartWorkflowActionTestCase extends TestCase
         $this->assertSame('task-queue', $new->taskQueue->name);
     }
 
-    /**
-     * @dataProvider provideInput
-     */
+    #[DataProvider('provideInput')]
     public function testWithInput(mixed $input, array $expect, mixed $initInput = null, array $initExpect = []): void
     {
         $init = StartWorkflowAction::new('TestWorkflow');
@@ -116,9 +114,7 @@ class StartWorkflowActionTestCase extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideTimeouts
-     */
+    #[DataProvider('provideTimeouts')]
     public function testWithWorkflowExecutionTimeout(
         mixed $timeout,
         string $expect,
@@ -135,9 +131,7 @@ class StartWorkflowActionTestCase extends TestCase
         $this->assertSame($expect, $new->workflowExecutionTimeout->format('%y/%m/%d/%h/%i/%s'));
     }
 
-    /**
-     * @dataProvider provideTimeouts
-     */
+    #[DataProvider('provideTimeouts')]
     public function testWithWorkflowRunTimeout(
         mixed $timeout,
         string $expect,
@@ -154,9 +148,7 @@ class StartWorkflowActionTestCase extends TestCase
         $this->assertSame($expect, $new->workflowRunTimeout->format('%y/%m/%d/%h/%i/%s'));
     }
 
-    /**
-     * @dataProvider provideTimeouts
-     */
+    #[DataProvider('provideTimeouts')]
     public function testWithWorkflowTaskTimeout(
         mixed $timeout,
         string $expect,
@@ -215,9 +207,7 @@ class StartWorkflowActionTestCase extends TestCase
         yield 'clear' => [[], [], ['foo' => 'bar'], ['foo' => 'bar']];
     }
 
-    /**
-     * @dataProvider provideEncodedValues
-     */
+    #[DataProvider('provideEncodedValues')]
     public function testWithMemo(mixed $values, array $expect, mixed $initValues = null, array $initExpect = []): void
     {
         $init = StartWorkflowAction::new('TestWorkflow');
@@ -232,9 +222,7 @@ class StartWorkflowActionTestCase extends TestCase
         $this->assertSame($expect, $new->memo->getValues());
     }
 
-    /**
-     * @dataProvider provideEncodedValues
-     */
+    #[DataProvider('provideEncodedValues')]
     public function testWithSearchAttributes(mixed $values, array $expect, mixed $initValues = null, array $initExpect = []): void
     {
         $init = StartWorkflowAction::new('TestWorkflow');

--- a/tests/Unit/Schedule/BackfillPeriodTestCase.php
+++ b/tests/Unit/Schedule/BackfillPeriodTestCase.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Unit\Schedule;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Temporal\Client\Schedule\BackfillPeriod;
 use Temporal\Client\Schedule\Policy\ScheduleOverlapPolicy;
 
-/**
- * @covers \Temporal\Client\Schedule\BackfillPeriod
- */
+#[CoversClass(\Temporal\Client\Schedule\BackfillPeriod::class)]
 class BackfillPeriodTestCase extends TestCase
 {
     public function testCreateFromDatetimeImmutable(): void

--- a/tests/Unit/Schedule/Mapper/WorkflowExecutionInfoMapperTestCase.php
+++ b/tests/Unit/Schedule/Mapper/WorkflowExecutionInfoMapperTestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Unit\Schedule\Mapper;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Spiral\Attributes\AttributeReader;
 use Temporal\Api\Enums\V1\ScheduleOverlapPolicy;
@@ -19,9 +20,7 @@ use Temporal\Internal\Mapper\ScheduleMapper;
 use Temporal\Internal\Marshaller\Mapper\AttributeMapperFactory;
 use Temporal\Internal\Marshaller\Marshaller;
 
-/**
- * @covers \Temporal\Internal\Mapper\ScheduleMapper
- */
+#[CoversClass(\Temporal\Internal\Mapper\ScheduleMapper::class)]
 final class WorkflowExecutionInfoMapperTestCase extends TestCase
 {
     private DataConverterInterface $dataConverter;

--- a/tests/Unit/Schedule/ScheduleClientTestCase.php
+++ b/tests/Unit/Schedule/ScheduleClientTestCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Temporal\Tests\Unit\Schedule;
 
 use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Spiral\Attributes\AttributeReader;
 use Temporal\Api\Workflowservice\V1\CreateScheduleRequest;
@@ -31,9 +32,7 @@ use Temporal\Internal\Marshaller\Mapper\AttributeMapperFactory;
 use Temporal\Internal\Marshaller\Marshaller;
 use Temporal\Internal\Marshaller\ProtoToArrayConverter;
 
-/**
- * @covers \Temporal\Client\ScheduleClient
- */
+#[CoversClass(\Temporal\Client\ScheduleClient::class)]
 class ScheduleClientTestCase extends TestCase
 {
     public function testCreateSchedule(): void

--- a/tests/Unit/Schedule/ScheduleHandleTestCase.php
+++ b/tests/Unit/Schedule/ScheduleHandleTestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Unit\Schedule;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use Spiral\Attributes\AttributeReader;
 use Temporal\Api\Schedule\V1\BackfillRequest;
 use Temporal\Api\Workflowservice\V1\DeleteScheduleRequest;
@@ -31,9 +32,7 @@ use Temporal\Internal\Marshaller\Marshaller;
 use Temporal\Internal\Marshaller\MarshallerInterface;
 use Temporal\Internal\Marshaller\ProtoToArrayConverter;
 
-/**
- * @covers \Temporal\Client\Schedule\ScheduleHandle
- */
+#[CoversClass(\Temporal\Client\Schedule\ScheduleHandle::class)]
 class ScheduleHandleTestCase extends TestCase
 {
     public function testGetId(): void

--- a/tests/Unit/Schedule/ScheduleOptionsTestCase.php
+++ b/tests/Unit/Schedule/ScheduleOptionsTestCase.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace Schedule;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Temporal\Client\Schedule\BackfillPeriod;
 use Temporal\Client\Schedule\Policy\ScheduleOverlapPolicy;
 use Temporal\Client\Schedule\ScheduleOptions;
 use Temporal\DataConverter\EncodedCollection;
 
-/**
- * @covers \Temporal\Client\Schedule\ScheduleOptions
- */
+#[CoversClass(\Temporal\Client\Schedule\ScheduleOptions::class)]
 class ScheduleOptionsTestCase extends TestCase
 {
     public function testWithNamespace(): void
@@ -91,9 +91,7 @@ class ScheduleOptionsTestCase extends TestCase
         yield 'clear' => [[], [], ['foo' => 'bar'], ['foo' => 'bar']];
     }
 
-    /**
-     * @dataProvider provideEncodedValues
-     */
+    #[DataProvider('provideEncodedValues')]
     public function testWithMemo(mixed $values, array $expect, mixed $initValues = null, array $initExpect = []): void
     {
         $init = ScheduleOptions::new();
@@ -108,9 +106,7 @@ class ScheduleOptionsTestCase extends TestCase
         $this->assertSame($expect, $new->memo->getValues());
     }
 
-    /**
-     * @dataProvider provideEncodedValues
-     */
+    #[DataProvider('provideEncodedValues')]
     public function testWithSearchAttributes(mixed $values, array $expect, mixed $initValues = null, array $initExpect = []): void
     {
         $init = ScheduleOptions::new();

--- a/tests/Unit/Schedule/ScheduleTestCase.php
+++ b/tests/Unit/Schedule/ScheduleTestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Schedule;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Temporal\Client\Schedule\Action\StartWorkflowAction;
 use Temporal\Client\Schedule\Policy\SchedulePolicies;
@@ -11,9 +12,7 @@ use Temporal\Client\Schedule\Schedule;
 use Temporal\Client\Schedule\Spec\ScheduleSpec;
 use Temporal\Client\Schedule\Spec\ScheduleState;
 
-/**
- * @covers \Temporal\Client\Schedule\Schedule
- */
+#[CoversClass(\Temporal\Client\Schedule\Schedule::class)]
 class ScheduleTestCase extends TestCase
 {
     public function testWithAction(): void

--- a/tests/Unit/Schedule/Spec/CalendarSpecTestCase.php
+++ b/tests/Unit/Schedule/Spec/CalendarSpecTestCase.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Unit\Schedule\Spec;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Temporal\Client\Schedule\Spec\CalendarSpec;
 
-/**
- * @covers \Temporal\Client\Schedule\Spec\CalendarSpec
- */
+#[CoversClass(\Temporal\Client\Schedule\Spec\CalendarSpec::class)]
 class CalendarSpecTestCase extends TestCase
 {
     public function testWithSecondString(): void

--- a/tests/Unit/Schedule/Spec/IntervalSpecTestCase.php
+++ b/tests/Unit/Schedule/Spec/IntervalSpecTestCase.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Unit\Schedule\Spec;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Temporal\Client\Schedule\Spec\IntervalSpec;
 
-/**
- * @covers \Temporal\Client\Schedule\Spec\IntervalSpec
- */
+#[CoversClass(\Temporal\Client\Schedule\Spec\IntervalSpec::class)]
 class IntervalSpecTestCase extends TestCase
 {
     public function testWithIntervalInt(): void

--- a/tests/Unit/Schedule/Spec/RangeTestCase.php
+++ b/tests/Unit/Schedule/Spec/RangeTestCase.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Unit\Schedule\Spec;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Temporal\Client\Schedule\Spec\Range;
 
-/**
- * @covers \Temporal\Client\Schedule\Spec\Range
- */
+#[CoversClass(\Temporal\Client\Schedule\Spec\Range::class)]
 class RangeTestCase extends TestCase
 {
     public function testWithStart(): void

--- a/tests/Unit/Schedule/Spec/ScheduleSpecTestCase.php
+++ b/tests/Unit/Schedule/Spec/ScheduleSpecTestCase.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Unit\Schedule\Spec;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Temporal\Client\Schedule\Spec\CalendarSpec;
 use Temporal\Client\Schedule\Spec\IntervalSpec;
@@ -11,9 +13,7 @@ use Temporal\Client\Schedule\Spec\Range;
 use Temporal\Client\Schedule\Spec\ScheduleSpec;
 use Temporal\Client\Schedule\Spec\StructuredCalendarSpec;
 
-/**
- * @covers \Temporal\Client\Schedule\Spec\ScheduleSpec
- */
+#[CoversClass(\Temporal\Client\Schedule\Spec\ScheduleSpec::class)]
 class ScheduleSpecTestCase extends TestCase
 {
     public function testWithTimezoneName(): void
@@ -38,9 +38,7 @@ class ScheduleSpecTestCase extends TestCase
         $this->assertSame('+01:00', $new->timezoneData);
     }
 
-    /**
-     * @dataProvider provideStartEndTime
-     */
+    #[DataProvider('provideStartEndTime')]
     public function testWithStartTime(
         mixed $withValue,
         ?string $expectedValue,
@@ -57,9 +55,7 @@ class ScheduleSpecTestCase extends TestCase
         $this->assertSame($expectedValue, $new->startTime?->format(\DateTimeInterface::ATOM));
     }
 
-    /**
-     * @dataProvider provideStartEndTime
-     */
+    #[DataProvider('provideStartEndTime')]
     public function testWithEndTime(
         mixed $withValue,
         ?string $expectedValue,
@@ -83,9 +79,7 @@ class ScheduleSpecTestCase extends TestCase
         yield 'unset' => [null, null, '2024-10-01T00:00:00Z', '2024-10-01T00:00:00+00:00'];
     }
 
-    /**
-     * @dataProvider provideJitter
-     */
+    #[DataProvider('provideJitter')]
     public function testWithJitter(
         mixed $withValue,
         string $expectedValue,

--- a/tests/Unit/Schedule/Spec/ScheduleStateTestCase.php
+++ b/tests/Unit/Schedule/Spec/ScheduleStateTestCase.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Unit\Schedule\Spec;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Temporal\Client\Schedule\Spec\ScheduleState;
 
-/**
- * @covers \Temporal\Client\Schedule\Spec\ScheduleState
- */
+#[CoversClass(\Temporal\Client\Schedule\Spec\ScheduleState::class)]
 class ScheduleStateTestCase extends TestCase
 {
     public function testWithNotes(): void

--- a/tests/Unit/Schedule/Spec/StructuredCalendarSpecTestCase.php
+++ b/tests/Unit/Schedule/Spec/StructuredCalendarSpecTestCase.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Unit\Schedule\Spec;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Temporal\Client\Schedule\Spec\Range;
 use Temporal\Client\Schedule\Spec\StructuredCalendarSpec;
 
-/**
- * @covers \Temporal\Client\Schedule\Spec\StructuredCalendarSpec
- */
+#[CoversClass(\Temporal\Client\Schedule\Spec\StructuredCalendarSpec::class)]
 class StructuredCalendarSpecTestCase extends TestCase
 {
     public function testWithSeconds(): void

--- a/tests/Unit/Worker/AbstractWorker.php
+++ b/tests/Unit/Worker/AbstractWorker.php
@@ -9,13 +9,14 @@
 
 declare(strict_types=1);
 
-namespace Temporal\Tests\Unit;
+namespace Temporal\Tests\Unit\Worker;
 
-use Temporal\Tests\TestCase;
+use Temporal\Tests\Unit\AbstractUnit;
 
 /**
+ * @group worker
  * @group unit
  */
-abstract class UnitTestCase extends TestCase
+abstract class AbstractWorker extends AbstractUnit
 {
 }

--- a/tests/Unit/Worker/AutowiringTestCase.php
+++ b/tests/Unit/Worker/AutowiringTestCase.php
@@ -26,7 +26,7 @@ function global_function(): int
  * @group unit
  * @group worker
  */
-class AutowiringTestCase extends WorkerTestCase
+class AutowiringTestCase extends AbstractWorker
 {
     public static function staticMethod(): int
     {

--- a/tests/Unit/Worker/Transport/RoadRunnerTestCase.php
+++ b/tests/Unit/Worker/Transport/RoadRunnerTestCase.php
@@ -8,14 +8,14 @@ use RoadRunner\VersionChecker\Version\ComparatorInterface;
 use RoadRunner\VersionChecker\Version\InstalledInterface;
 use RoadRunner\VersionChecker\Version\RequiredInterface;
 use RoadRunner\VersionChecker\VersionChecker;
-use Temporal\Tests\Unit\UnitTestCase;
+use Temporal\Tests\Unit\AbstractUnit;
 use Temporal\Worker\Transport\RoadRunner;
 use Temporal\Worker\Transport\RoadRunnerVersionChecker;
 
 /**
  * @group unit
  */
-final class RoadRunnerTestCase extends UnitTestCase
+final class RoadRunnerTestCase extends AbstractUnit
 {
     public function testCreateShouldCallVersionCheck(): void
     {

--- a/tests/Unit/Worker/Transport/RoadRunnerVersionCheckerTestCase.php
+++ b/tests/Unit/Worker/Transport/RoadRunnerVersionCheckerTestCase.php
@@ -9,13 +9,13 @@ use RoadRunner\VersionChecker\Exception\RoadrunnerNotInstalledException;
 use RoadRunner\VersionChecker\Version\InstalledInterface;
 use RoadRunner\VersionChecker\Version\RequiredInterface;
 use RoadRunner\VersionChecker\VersionChecker;
-use Temporal\Tests\Unit\UnitTestCase;
+use Temporal\Tests\Unit\AbstractUnit;
 use Temporal\Worker\Transport\RoadRunnerVersionChecker;
 
 /**
  * @group unit
  */
-final class RoadRunnerVersionCheckerTestCase extends UnitTestCase
+final class RoadRunnerVersionCheckerTestCase extends AbstractUnit
 {
     public function testCheckSuccess(): void
     {

--- a/tests/Unit/WorkerFactory/AbstractWorkerFactory.php
+++ b/tests/Unit/WorkerFactory/AbstractWorkerFactory.php
@@ -9,14 +9,14 @@
 
 declare(strict_types=1);
 
-namespace Temporal\Tests\Unit\Protocol;
+namespace Temporal\Tests\Unit\WorkerFactory;
 
-use Temporal\Tests\Unit\UnitTestCase;
+use Temporal\Tests\Unit\AbstractUnit;
 
 /**
+ * @group worker
  * @group unit
- * @group protocol
  */
-abstract class ProtocolTestCase extends UnitTestCase
+abstract class AbstractWorkerFactory extends AbstractUnit
 {
 }

--- a/tests/Unit/WorkerFactory/CustomReaderTestCase.php
+++ b/tests/Unit/WorkerFactory/CustomReaderTestCase.php
@@ -15,7 +15,7 @@ namespace Temporal\Tests\Unit\WorkerFactory;
 use Temporal\Tests\Unit\Declaration\Fixture\CustomReaderWorkerFactory;
 use Temporal\Tests\Unit\Declaration\Fixture\UnannotatedClass;
 
-class CustomReaderTestCase extends WorkerFactoryTestCase
+class CustomReaderTestCase extends AbstractWorkerFactory
 {
     public function testCustomReader()
     {

--- a/tests/Unit/WorkflowContext/AwaitWithTimeoutTestCase.php
+++ b/tests/Unit/WorkflowContext/AwaitWithTimeoutTestCase.php
@@ -6,7 +6,7 @@ namespace Temporal\Tests\Unit\WorkflowContext;
 
 use Temporal\Tests\Unit\Framework\WorkerFactoryMock;
 use Temporal\Tests\Unit\Framework\WorkerMock;
-use Temporal\Tests\Unit\UnitTestCase;
+use Temporal\Tests\Unit\AbstractUnit;
 use Temporal\Worker\WorkerFactoryInterface;
 use Temporal\Worker\WorkerInterface;
 use Temporal\Workflow;
@@ -15,7 +15,7 @@ use Temporal\Workflow\WorkflowMethod;
 use function PHPUnit\Framework\assertFalse;
 use function PHPUnit\Framework\assertTrue;
 
-final class AwaitWithTimeoutTestCase extends UnitTestCase
+final class AwaitWithTimeoutTestCase extends AbstractUnit
 {
     private WorkerFactoryInterface $factory;
     /** @var WorkerMock|WorkerInterface */

--- a/tests/Unit/WorkflowContext/GetVersionTestCase.php
+++ b/tests/Unit/WorkflowContext/GetVersionTestCase.php
@@ -6,13 +6,13 @@ namespace Temporal\Tests\Unit\WorkflowContext;
 
 use Temporal\Tests\Unit\Framework\WorkerFactoryMock;
 use Temporal\Tests\Unit\Framework\WorkerMock;
-use Temporal\Tests\Unit\UnitTestCase;
+use Temporal\Tests\Unit\AbstractUnit;
 use Temporal\Worker\WorkerFactoryInterface;
 use Temporal\Worker\WorkerInterface;
 use Temporal\Workflow;
 use Temporal\Workflow\WorkflowMethod;
 
-final class GetVersionTestCase extends UnitTestCase
+final class GetVersionTestCase extends AbstractUnit
 {
     private WorkerFactoryInterface $factory;
     /** @var WorkerMock|WorkerInterface */

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 use Temporal\Testing\Environment;
 use Temporal\Tests\SearchAttributeTestInvoker;
 
-error_reporting(E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED);
 require __DIR__ . '/../vendor/autoload.php';
 
 if (getenv('RUN_TEMPORAL_TEST_SERVER') !== false) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Temporal\Testing\Environment;
 use Temporal\Tests\SearchAttributeTestInvoker;
 
+error_reporting(E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED);
 require __DIR__ . '/../vendor/autoload.php';
 
 if (getenv('RUN_TEMPORAL_TEST_SERVER') !== false) {


### PR DESCRIPTION
## What was changed

- Added `destroy()` methods to Workflow-related classes
- Added a `GarbageCollector` which is responsible for the frequency of calling the finding circular references function (garbage collecting).
- `phpunit` has been updated to version 10. This is a necessary measure because changes in the PR broke some tests that couldn't be handled using `phpunit` 9.

## Why?

A few months ago, when we were troubleshooting a memory leak issue, I added a call to the `gc_collect_cycles()` method after each `DestroyWorkflow` command execution.

Garbage collection is quite a costly operation, and Workflows in Temporal are created and destroyed very frequently. We can verify this by looking at the [metrics provided by the user Pyjac](https://app.slack.com/client/TNWA8QCGZ/C01LK9FAMM0/thread/C01LK9FAMM0-1700254848.292919?cdn_fallback=1)

![image](https://github.com/temporalio/sdk-php/assets/4152481/7c9fca55-de72-4bfe-989b-8f80dd0e1139)

We recently returned to the issue of potential memory leaks. In the process, some important optimizations were implemented:
1. Added methods for manual destruction of Workflow-related objects, which free resources and break circular references between objects. Thus, all SDK code works without leaks, using PHP's self-cleaning mechanisms.
2. We left the call to `gc_collect_cycles()`, but introduced control over the frequency of these calls. The collecting of circular references is now called by a 30-second timeout or when 1000 Workflows are destroyed. This way we are combating memory leaks in user code.

After this update, we are seeing a significant increase in the throughput of the Workflow worker and almost no TaskTimeout errors under highload.

<details>

Before

![Screenshot 2024-01-16 153241](https://github.com/temporalio/sdk-php/assets/796136/e56760b0-3cbf-44fe-8745-472fab51ae6e)

After
![Screenshot 2024-01-16 161004](https://github.com/temporalio/sdk-php/assets/796136/e31deaad-631c-4e9a-aab5-7fac2d7adcda)

</details>