### PR TITLE
Fix static analysis issues

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.19.0@06b71be009a6bd6d81b9811855d6629b9fe90e1b">
+<files psalm-version="5.20.0@3f284e96c9d9be6fe6b15c79416e1d1903dcfef4">
   <file src="src/Activity.php">
     <ImplicitToStringCast>
       <code>$type</code>
@@ -921,7 +921,7 @@
     <MissingTemplateParam>
       <code>\IteratorAggregate</code>
     </MissingTemplateParam>
-  </file>c
+  </file>
   <file src="src/Internal/Repository/ArrayRepository.php">
     <InvalidReturnStatement>
       <code><![CDATA[$this->entries[$id] ?? null]]></code>

--- a/src/Client/Schedule/Spec/ScheduleSpec.php
+++ b/src/Client/Schedule/Spec/ScheduleSpec.php
@@ -312,12 +312,13 @@ final class ScheduleSpec
      */
     public function withJitter(mixed $interval): self
     {
+        /** @psalm-suppress RiskyTruthyFalsyComparison */
         if (empty($interval)) {
             /** @see self::$jitter */
             return $this->with('jitter', new \DateInterval('PT0S'));
         }
 
-        assert(DateInterval::assert($interval));
+        \assert(DateInterval::assert($interval));
         $interval = DateInterval::parse($interval, DateInterval::FORMAT_SECONDS);
 
         /** @see self::$jitter */

--- a/src/Internal/Marshaller/TypeFactory.php
+++ b/src/Internal/Marshaller/TypeFactory.php
@@ -87,7 +87,8 @@ class TypeFactory implements RuleFactoryInterface
         }
 
         foreach ($this->matchers as $matcher) {
-            if ($result = $matcher($type)) {
+            $result = $matcher($type);
+            if ($result !== null) {
                 return $result;
             }
         }

--- a/src/Worker/WorkerOptions.php
+++ b/src/Worker/WorkerOptions.php
@@ -449,7 +449,7 @@ class WorkerOptions
     {
         $self = clone $this;
 
-        $self->sessionResourceId = $identifier ?: null;
+        $self->sessionResourceId = $identifier === '' ? null : $identifier;
 
         return $self;
     }


### PR DESCRIPTION
## What was changed

Fix PSALM issues

## Why?

During the preparation for the 2.7.4 release, a new version of the static analyzer was released, which added new heuristics. These heuristics found several questionable places in the code.