### PR TITLE
Fix FailureConverter when an exception CallStack contains an incomplete set of keys

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -395,9 +395,6 @@
     <InvalidOperand>
       <code><![CDATA[count($arg)]]></code>
     </InvalidOperand>
-    <MissingClosureReturnType>
-      <code><![CDATA[static fn() => \sprintf(]]></code>
-    </MissingClosureReturnType>
     <NullableReturnStatement>
       <code><![CDATA[$e->getFailure()]]></code>
     </NullableReturnStatement>
@@ -429,13 +426,6 @@
       <code><![CDATA[hasLastHeartbeatDetails]]></code>
       <code><![CDATA[setStackTrace]]></code>
     </PossiblyNullReference>
-    <RedundantCastGivenDocblockType>
-      <code><![CDATA[(string) ($frame['class'] ?? '')]]></code>
-    </RedundantCastGivenDocblockType>
-    <RiskyTruthyFalsyComparison>
-      <code><![CDATA[empty($args)]]></code>
-      <code><![CDATA[empty($frame['line'])]]></code>
-    </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/Exception/Failure/TemporalFailure.php">
     <MissingClosureParamType>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -430,7 +430,7 @@
       <code><![CDATA[setStackTrace]]></code>
     </PossiblyNullReference>
     <RedundantCastGivenDocblockType>
-      <code><![CDATA[(string)$frame['class']]]></code>
+      <code><![CDATA[(string) ($frame['class'] ?? '')]]></code>
     </RedundantCastGivenDocblockType>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[empty($args)]]></code>

--- a/src/Exception/Failure/FailureConverter.php
+++ b/src/Exception/Failure/FailureConverter.php
@@ -320,7 +320,6 @@ final class FailureConverter
                 self::renderTraceAttributes($frame['args'] ?? []),
             );
 
-
             if ($skipInternal && \str_starts_with($frame['class'] ?? '', 'Temporal\\')) {
                 if (!$isFirst) {
                     $internals[] = $renderer;

--- a/src/Exception/Failure/FailureConverter.php
+++ b/src/Exception/Failure/FailureConverter.php
@@ -286,12 +286,12 @@ final class FailureConverter
     private static function generateStackTraceString(\Throwable $e, bool $skipInternal = true): string
     {
         /** @var list<array{
-         *     function?: non-empty-string,
-         *     line?: int<0, max>,
-         *     file?: non-empty-string,
-         *     class?: class-string,
-         *     object?: object,
-         *     type?: string,
+         *     function?: non-empty-string|null,
+         *     line?: int<0, max>|null,
+         *     file?: non-empty-string|null,
+         *     class?: class-string|null,
+         *     object?: object|null,
+         *     type?: string|null,
          *     args?: array|null
          * }> $frames
          */
@@ -336,12 +336,11 @@ final class FailureConverter
                     '[%d hidden internal calls]',
                     \count($internals),
                 );
-                $internals = [];
             } else {
                 $result = [...$result, ...\array_map(static fn(callable $renderer) => $renderer(), $internals)];
-                $internals = [];
             }
 
+            $internals = [];
             $result[] = $renderer();
         }
 

--- a/src/Exception/Failure/FailureConverter.php
+++ b/src/Exception/Failure/FailureConverter.php
@@ -321,7 +321,7 @@ final class FailureConverter
             );
 
 
-            if ($skipInternal && \str_starts_with((string)$frame['class'], 'Temporal\\')) {
+            if ($skipInternal && \str_starts_with((string) ($frame['class'] ?? ''), 'Temporal\\')) {
                 if (!$isFirst) {
                     $internals[] = $renderer;
                     $isFirst = false;

--- a/src/Exception/Failure/FailureConverter.php
+++ b/src/Exception/Failure/FailureConverter.php
@@ -351,10 +351,9 @@ final class FailureConverter
         return \implode("\n", $result);
     }
 
-    private static function renderTraceAttributes(?array $args): string
+    private static function renderTraceAttributes(array $args): string
     {
-        /** @psalm-suppress RiskyTruthyFalsyComparison */
-        if (empty($args)) {
+        if ($args === []) {
             return '';
         }
 

--- a/src/Exception/Failure/FailureConverter.php
+++ b/src/Exception/Failure/FailureConverter.php
@@ -286,13 +286,13 @@ final class FailureConverter
     private static function generateStackTraceString(\Throwable $e, bool $skipInternal = true): string
     {
         /** @var list<array{
-         *     function: string,
-         *     line: int<0, max>|null,
-         *     file: non-empty-string|null,
-         *     class: class-string,
+         *     function?: non-empty-string,
+         *     line?: int<0, max>,
+         *     file?: non-empty-string,
+         *     class?: class-string,
          *     object?: object,
-         *     type: string,
-         *     args: array|null
+         *     type?: string,
+         *     args?: array|null
          * }> $frames
          */
         $frames = $e->getTrace();
@@ -308,11 +308,11 @@ final class FailureConverter
                 continue;
             }
 
-            $renderer = static fn() => \sprintf(
+            $renderer = static fn(): string => \sprintf(
                 "%s%s%s\n%s%s%s%s(%s)",
                 \str_pad("#$i", $numPad, ' '),
                 $frame['file'] ?? '[internal function]',
-                empty($frame['line']) ? '' : ":{$frame['line']}",
+                isset($frame['line']) ? ":{$frame['line']}" : '',
                 \str_repeat(' ', $numPad),
                 $frame['class'] ?? '',
                 $frame['type'] ?? '',
@@ -321,7 +321,7 @@ final class FailureConverter
             );
 
 
-            if ($skipInternal && \str_starts_with((string) ($frame['class'] ?? ''), 'Temporal\\')) {
+            if ($skipInternal && \str_starts_with($frame['class'] ?? '', 'Temporal\\')) {
                 if (!$isFirst) {
                     $internals[] = $renderer;
                     $isFirst = false;
@@ -355,6 +355,7 @@ final class FailureConverter
 
     private static function renderTraceAttributes(?array $args): string
     {
+        /** @psalm-suppress RiskyTruthyFalsyComparison */
         if (empty($args)) {
             return '';
         }

--- a/src/Exception/Failure/FailureConverter.php
+++ b/src/Exception/Failure/FailureConverter.php
@@ -314,10 +314,10 @@ final class FailureConverter
                 $frame['file'] ?? '[internal function]',
                 empty($frame['line']) ? '' : ":{$frame['line']}",
                 \str_repeat(' ', $numPad),
-                $frame['class'],
-                $frame['type'],
-                $frame['function'],
-                self::renderTraceAttributes($frame['args']),
+                $frame['class'] ?? '',
+                $frame['type'] ?? '',
+                $frame['function'] ?? '',
+                self::renderTraceAttributes($frame['args'] ?? []),
             );
 
 

--- a/tests/Unit/Exception/FailureConverterTestCase.php
+++ b/tests/Unit/Exception/FailureConverterTestCase.php
@@ -52,10 +52,17 @@ final class FailureConverterTestCase extends AbstractUnit
 
     public function testShouldSetStackTraceStringForAdditionalContextEvenWhenClassIsNotPresented(): void
     {
+        \ini_set('zend.exception_ignore_args', 'Off');
+
         $trace = FailureConverter::mapExceptionToFailure(
             call_user_func(fn () => new Exception()),
             DataConverter::createDefault(),
         )->getStackTrace();
+
+        self::assertStringContainsString(
+            '[internal function]',
+            $trace,
+        );
 
         self::assertStringContainsString(
             'Temporal\Tests\Unit\Exception\FailureConverterTestCase->Temporal\Tests\Unit\Exception\{closure}()',

--- a/tests/Unit/Exception/FailureConverterTestCase.php
+++ b/tests/Unit/Exception/FailureConverterTestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Unit\Exception;
 
+use Exception;
 use Temporal\DataConverter\DataConverter;
 use Temporal\DataConverter\EncodedValues;
 use Temporal\Exception\Failure\ApplicationFailure;
@@ -29,5 +30,46 @@ final class FailureConverterTestCase extends AbstractUnit
 
         $this->assertSame('abc', $restoredDetails->getValue(0));
         $this->assertSame(123, $restoredDetails->getValue(1));
+    }
+
+    public function testShouldSetStackTraceStringForAdditionalContext(): void
+    {
+        $trace = FailureConverter::mapExceptionToFailure(
+            new Exception(),
+            DataConverter::createDefault(),
+        )->getStackTrace();
+
+        self::assertStringContainsString(
+            'Temporal\Tests\Unit\Exception\FailureConverterTestCase->testShouldSetStackTraceStringForAdditionalContext()',
+            $trace,
+        );
+
+        self::assertStringContainsString(
+            'PHPUnit\Framework\TestCase->runTest()',
+            $trace,
+        );
+    }
+
+    public function testShouldSetStackTraceStringForAdditionalContextEvenWhenClassIsNotPresented(): void
+    {
+        $trace = FailureConverter::mapExceptionToFailure(
+            call_user_func(fn () => new Exception()),
+            DataConverter::createDefault(),
+        )->getStackTrace();
+
+        self::assertStringContainsString(
+            'Temporal\Tests\Unit\Exception\FailureConverterTestCase->Temporal\Tests\Unit\Exception\{closure}()',
+            $trace,
+        );
+
+        self::assertStringContainsString(
+            'call_user_func(Closure)',
+            $trace,
+        );
+
+        self::assertStringContainsString(
+            'PHPUnit\Framework\TestCase->runTest()',
+            $trace,
+        );
     }
 }


### PR DESCRIPTION
## What was changed
All elements returned by https://www.php.net/manual/en/function.debug-backtrace.php are possible, but not guaranteed. Safeguard added for elements without "class" property.

## Why?
I encountered this problem when I was using https://laravel.com/docs/10.x/helpers#method-throw-if helper function, that doesn't belong to a class. See screenshot:

![Screenshot 2024-03-11 at 12 07 15](https://github.com/temporalio/sdk-php/assets/4995979/0a650ddd-af64-4cf1-97a3-7bcee26bd3db)