### PR TITLE
Remove experimental flag from StartDelay

### DIFF
--- a/src/Client/WorkflowOptions.php
+++ b/src/Client/WorkflowOptions.php
@@ -302,8 +302,6 @@ final class WorkflowOptions extends Options
      * of the delay will be ignored. A Signal from {@see WorkflowClientInterface::startWithSignal()} won't
      * trigger a workflow task. Cannot be set the same time as a {@see $cronSchedule}.
      *
-     * NOTE: Experimental
-     *
      * @psalm-suppress ImpureMethodCall
      *
      * @param DateIntervalValue $delay


### PR DESCRIPTION
## What was changed
Removed the experimental flag from StartDelay workflow option

## Why?
To accurately reflect the current state of the StartDelay workflow option 