### PR TITLE
fix: duration json type parsing fix

### DIFF
--- a/src/Internal/Marshaller/Type/DurationJsonType.php
+++ b/src/Internal/Marshaller/Type/DurationJsonType.php
@@ -70,6 +70,11 @@ class DurationJsonType extends Type implements DetectableTypeInterface, RuleFact
      */
     public function parse($value, $current): CarbonInterval
     {
+        if (is_array($value) && isset($value['seconds']) && isset($value['nanos'])) {
+            // The highest precision is milliseconds either way.
+            $value = ($value['seconds'] * 1000000000 + $value['nanos']) / 1000;
+        }
+
         return DateInterval::parse($value);
     }
 }

--- a/src/Internal/Marshaller/Type/DurationJsonType.php
+++ b/src/Internal/Marshaller/Type/DurationJsonType.php
@@ -31,7 +31,7 @@ class DurationJsonType extends Type implements DetectableTypeInterface, RuleFact
 
     /**
      * @param MarshallerInterface $marshaller
-     * @param string $format Fall back format for parsing when the value is not an array.
+     * @param DateIntervalFormat $format Fall back format for parsing when the value is not an array.
      */
     public function __construct(MarshallerInterface $marshaller, string $format = DateInterval::FORMAT_NANOSECONDS)
     {

--- a/tests/Unit/DTO/RetryOptionsTestCase.php
+++ b/tests/Unit/DTO/RetryOptionsTestCase.php
@@ -72,8 +72,8 @@ class RetryOptionsTestCase extends AbstractDTOMarshalling
 
         $this->unmarshal($expected, $unmarshalled = new RetryOptions());
 
-        self::assertSame(10.0, $unmarshalled->initialInterval->totalSeconds);
-        self::assertSame(15.0, $unmarshalled->maximumInterval->totalSeconds);
+        self::assertSame(10.0, (float)$unmarshalled->initialInterval->totalSeconds);
+        self::assertSame(15.0, (float)$unmarshalled->maximumInterval->totalSeconds);
         self::assertSame(3.0, $unmarshalled->backoffCoefficient);
         self::assertSame(5, $unmarshalled->maximumAttempts);
     }

--- a/tests/Unit/DTO/RetryOptionsTestCase.php
+++ b/tests/Unit/DTO/RetryOptionsTestCase.php
@@ -59,4 +59,22 @@ class RetryOptionsTestCase extends AbstractDTOMarshalling
 
         $this->assertSame($expected, $this->marshal($dto));
     }
+
+    public function testUnmarshalLegacyIntervals(): void
+    {
+        $expected = [
+            'initial_interval' => 10_000_000_000,
+            'backoff_coefficient' => 3.0,
+            'maximum_interval' => 15_000_000_000,
+            'maximum_attempts' => 5,
+            'non_retryable_error_types' => [],
+        ];
+
+        $this->unmarshal($expected, $unmarshalled = new RetryOptions());
+
+        self::assertSame(10.0, $unmarshalled->initialInterval->totalSeconds);
+        self::assertSame(15.0, $unmarshalled->maximumInterval->totalSeconds);
+        self::assertSame(3.0, $unmarshalled->backoffCoefficient);
+        self::assertSame(5, $unmarshalled->maximumAttempts);
+    }
 }

--- a/tests/Unit/DTO/Type/DurationJsonType/DurationJsonTestCase.php
+++ b/tests/Unit/DTO/Type/DurationJsonType/DurationJsonTestCase.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\DTO\Type\DurationJsonType;
+
+use Carbon\CarbonInterval;
+use Temporal\Internal\Marshaller\Type\DurationJsonType;
+use Temporal\Internal\Support\DateInterval;
+use Temporal\Tests\Unit\DTO\AbstractDTOMarshalling;
+use Temporal\Tests\Unit\DTO\Type\DurationJsonType\Stub\DurationJsonDto;
+
+class DurationJsonTestCase extends AbstractDTOMarshalling
+{
+    public function testMarshalAndUnmarshalDuration(): void
+    {
+        $dto = new DurationJsonDto();
+        $dto->duration = DateInterval::parse(1);
+
+        $result = $this->marshal($dto);
+        $unmarshal = $this->unmarshal($result, new DurationJsonDto());
+
+        self::assertInstanceOf(CarbonInterval::class, $unmarshal->duration);
+    }
+
+    protected function getTypeMatchers(): array
+    {
+        return [
+            DurationJsonType::class,
+        ];
+    }
+}

--- a/tests/Unit/DTO/Type/DurationJsonType/DurationJsonTestCase.php
+++ b/tests/Unit/DTO/Type/DurationJsonType/DurationJsonTestCase.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Unit\DTO\Type\DurationJsonType;
 
-use Carbon\CarbonInterval;
 use Temporal\Internal\Marshaller\Type\DurationJsonType;
 use Temporal\Internal\Support\DateInterval;
 use Temporal\Tests\Unit\DTO\AbstractDTOMarshalling;
@@ -27,7 +26,7 @@ class DurationJsonTestCase extends AbstractDTOMarshalling
         $result = $this->marshal($dto);
         $unmarshal = $this->unmarshal($result, new DurationJsonDto());
 
-        self::assertInstanceOf(CarbonInterval::class, $unmarshal->duration);
+        self::assertInstanceOf(\DateInterval::class, $unmarshal->duration);
     }
 
     protected function getTypeMatchers(): array

--- a/tests/Unit/DTO/Type/DurationJsonType/Stub/DurationJsonDto.php
+++ b/tests/Unit/DTO/Type/DurationJsonType/Stub/DurationJsonDto.php
@@ -11,9 +11,7 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Unit\DTO\Type\DurationJsonType\Stub;
 
-use Carbon\CarbonInterval;
-
 class DurationJsonDto
 {
-    public CarbonInterval $duration;
+    public \DateInterval $duration;
 }

--- a/tests/Unit/DTO/Type/DurationJsonType/Stub/DurationJsonDto.php
+++ b/tests/Unit/DTO/Type/DurationJsonType/Stub/DurationJsonDto.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\DTO\Type\DurationJsonType\Stub;
+
+use Carbon\CarbonInterval;
+
+class DurationJsonDto
+{
+    public CarbonInterval $duration;
+}


### PR DESCRIPTION


## What was changed
Added ability to parse DurationJsonType instance.
## Why?
It no longer works, and if you need to pass it around to other services or save ActivityOptions somewhere, stuff breaks. I've made this as a check, so it should be BC, and messages using older format shouldn't fail during deployment.

