### PR TITLE
Expose API to describe Workflow

### DIFF
--- a/src/Client/Workflow/WorkflowExecutionDescription.php
+++ b/src/Client/Workflow/WorkflowExecutionDescription.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Client\Workflow;
+
+use Temporal\Workflow\WorkflowExecutionInfo;
+
+/**
+ * DTO that contains detailed information about Workflow Execution.
+ *
+ * @see \Temporal\Api\Workflowservice\V1\DescribeWorkflowExecutionResponse
+ *
+ * @internal
+ */
+final class WorkflowExecutionDescription
+{
+    public function __construct(
+        public readonly WorkflowExecutionInfo $info,
+    ) {
+    }
+}

--- a/src/Client/Workflow/WorkflowExecutionHistory.php
+++ b/src/Client/Workflow/WorkflowExecutionHistory.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Temporal\Client;
+namespace Temporal\Client\Workflow;
 
 use Generator;
 use IteratorAggregate;

--- a/src/Client/WorkflowClient.php
+++ b/src/Client/WorkflowClient.php
@@ -26,6 +26,7 @@ use Temporal\Client\Common\ClientContextTrait;
 use Temporal\Client\Common\Paginator;
 use Temporal\Client\GRPC\ServiceClientInterface;
 use Temporal\Client\Workflow\CountWorkflowExecutions;
+use Temporal\Client\Workflow\WorkflowExecutionHistory;
 use Temporal\DataConverter\DataConverter;
 use Temporal\DataConverter\DataConverterInterface;
 use Temporal\DataConverter\Type;

--- a/src/Client/WorkflowClientInterface.php
+++ b/src/Client/WorkflowClientInterface.php
@@ -16,6 +16,7 @@ use Temporal\Client\Common\ClientContextInterface;
 use Temporal\Client\Common\Paginator;
 use Temporal\Client\GRPC\ServiceClientInterface;
 use Temporal\Client\Workflow\CountWorkflowExecutions;
+use Temporal\Client\Workflow\WorkflowExecutionHistory;
 use Temporal\Workflow\WorkflowExecution;
 use Temporal\Workflow\WorkflowExecutionInfo as WorkflowExecutionInfoDto;
 use Temporal\Workflow\WorkflowRunInterface;

--- a/src/Interceptor/Trait/WorkflowClientCallsInterceptorTrait.php
+++ b/src/Interceptor/Trait/WorkflowClientCallsInterceptorTrait.php
@@ -11,8 +11,10 @@ declare(strict_types=1);
 
 namespace Temporal\Interceptor\Trait;
 
+use Temporal\Client\Workflow\WorkflowExecutionDescription;
 use Temporal\DataConverter\EncodedValues;
 use Temporal\Interceptor\WorkflowClient\CancelInput;
+use Temporal\Interceptor\WorkflowClient\DescribeInput;
 use Temporal\Interceptor\WorkflowClient\GetResultInput;
 use Temporal\Interceptor\WorkflowClient\QueryInput;
 use Temporal\Interceptor\WorkflowClient\SignalInput;
@@ -109,5 +111,15 @@ trait WorkflowClientCallsInterceptorTrait
     public function terminate(TerminateInput $input, callable $next): void
     {
         $next($input);
+    }
+
+    /**
+     * Default implementation of the `describe` method.
+     *
+     * @see WorkflowClientCallsInterceptor::describe()
+     */
+    public function describe(DescribeInput $input, callable $next): WorkflowExecutionDescription
+    {
+        return $next($input);
     }
 }

--- a/src/Interceptor/WorkflowClient/DescribeInput.php
+++ b/src/Interceptor/WorkflowClient/DescribeInput.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Temporal\Interceptor\WorkflowClient;
+
+use Temporal\Workflow\WorkflowExecution;
+
+/**
+ * @psalm-immutable
+ */
+class DescribeInput
+{
+    /**
+     * @no-named-arguments
+     * @internal Don't use the constructor. Use {@see self::with()} instead.
+     */
+    public function __construct(
+        public readonly WorkflowExecution $workflowExecution,
+        public readonly string $namespace,
+    ) {
+    }
+
+    public function with(
+        WorkflowExecution $workflowExecution = null,
+        string $namespace = null,
+    ): self {
+        return new self(
+            $workflowExecution ?? $this->workflowExecution,
+                $namespace ?? $this->namespace,
+        );
+    }
+}

--- a/src/Interceptor/WorkflowClientCallsInterceptor.php
+++ b/src/Interceptor/WorkflowClientCallsInterceptor.php
@@ -11,9 +11,11 @@ declare(strict_types=1);
 
 namespace Temporal\Interceptor;
 
+use Temporal\Client\Workflow\WorkflowExecutionDescription;
 use Temporal\DataConverter\ValuesInterface;
 use Temporal\Interceptor\Trait\WorkflowClientCallsInterceptorTrait;
 use Temporal\Interceptor\WorkflowClient\CancelInput;
+use Temporal\Interceptor\WorkflowClient\DescribeInput;
 use Temporal\Interceptor\WorkflowClient\GetResultInput;
 use Temporal\Interceptor\WorkflowClient\QueryInput;
 use Temporal\Interceptor\WorkflowClient\SignalInput;
@@ -110,4 +112,12 @@ interface WorkflowClientCallsInterceptor extends Interceptor
      * @return void
      */
     public function terminate(TerminateInput $input, callable $next): void;
+
+    /**
+     * @param DescribeInput $input
+     * @param callable(DescribeInput): void $next
+     *
+     * @return WorkflowExecutionDescription
+     */
+    public function describe(DescribeInput $input, callable $next): WorkflowExecutionDescription;
 }

--- a/src/Internal/Client/WorkflowRun.php
+++ b/src/Internal/Client/WorkflowRun.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Temporal\Internal\Client;
 
+use Temporal\Client\Workflow\WorkflowExecutionDescription;
 use Temporal\Client\WorkflowStubInterface;
 use Temporal\DataConverter\Type;
 use Temporal\Workflow\WorkflowExecution;
@@ -42,5 +43,10 @@ final class WorkflowRun implements WorkflowRunInterface
     public function getResult($type = null, int $timeout = null): mixed
     {
         return $this->stub->getResult($type ?? $this->returnType, $timeout);
+    }
+
+    public function describe(): WorkflowExecutionDescription
+    {
+        return $this->stub->describe();
     }
 }

--- a/src/Internal/Client/WorkflowStub.php
+++ b/src/Internal/Client/WorkflowStub.php
@@ -20,6 +20,7 @@ use Temporal\Api\Errordetails\V1\QueryFailedFailure;
 use Temporal\Api\History\V1\HistoryEvent;
 use Temporal\Api\Query\V1\WorkflowQuery;
 use Temporal\Api\Update\V1\Request as UpdateRequestMessage;
+use Temporal\Api\Workflowservice\V1\DescribeWorkflowExecutionRequest;
 use Temporal\Api\Workflowservice\V1\GetWorkflowExecutionHistoryRequest;
 use Temporal\Api\Workflowservice\V1\QueryWorkflowRequest;
 use Temporal\Api\Workflowservice\V1\RequestCancelWorkflowExecutionRequest;
@@ -34,6 +35,7 @@ use Temporal\Client\Update\LifecycleStage;
 use Temporal\Client\Update\UpdateHandle;
 use Temporal\Client\Update\UpdateOptions;
 use Temporal\Client\Update\WaitPolicy;
+use Temporal\Client\Workflow\WorkflowExecutionDescription;
 use Temporal\Client\WorkflowOptions;
 use Temporal\Client\WorkflowStubInterface;
 use Temporal\Common\Uuid;
@@ -58,6 +60,7 @@ use Temporal\Exception\WorkflowExecutionFailedException;
 use Temporal\Interceptor\Header;
 use Temporal\Interceptor\HeaderInterface;
 use Temporal\Interceptor\WorkflowClient\CancelInput;
+use Temporal\Interceptor\WorkflowClient\DescribeInput;
 use Temporal\Interceptor\WorkflowClient\GetResultInput;
 use Temporal\Interceptor\WorkflowClient\QueryInput;
 use Temporal\Interceptor\WorkflowClient\SignalInput;
@@ -68,6 +71,7 @@ use Temporal\Interceptor\WorkflowClient\UpdateRef;
 use Temporal\Interceptor\WorkflowClientCallsInterceptor;
 use Temporal\Internal\Interceptor\HeaderCarrier;
 use Temporal\Internal\Interceptor\Pipeline;
+use Temporal\Internal\Mapper\WorkflowExecutionInfoMapper;
 use Temporal\Workflow\WorkflowExecution;
 
 final class WorkflowStub implements WorkflowStubInterface, HeaderCarrier
@@ -494,6 +498,31 @@ final class WorkflowStub implements WorkflowStubInterface, HeaderCarrier
         }
 
         return $result->getValue(0, $type);
+    }
+
+    public function describe(): WorkflowExecutionDescription
+    {
+        $this->assertStarted(__FUNCTION__);
+
+        return $this->interceptors->with(
+            function (DescribeInput $input): WorkflowExecutionDescription {
+                $request = new DescribeWorkflowExecutionRequest();
+                $request->setNamespace($input->namespace);
+                $request->setExecution($input->workflowExecution->toProtoWorkflowExecution());
+
+                $response = $this->serviceClient->DescribeWorkflowExecution($request);
+                $mapper = new WorkflowExecutionInfoMapper($this->converter);
+
+                return new WorkflowExecutionDescription(
+                    info: $mapper->fromMessage($response->getWorkflowExecutionInfo()),
+                );
+            },
+            /** @see WorkflowClientCallsInterceptor::describe() */
+            'describe',
+        )(new DescribeInput(
+            $this->execution,
+            $this->clientOptions->namespace,
+        ));
     }
 
     /**

--- a/src/Internal/Client/WorkflowStub.php
+++ b/src/Internal/Client/WorkflowStub.php
@@ -513,6 +513,7 @@ final class WorkflowStub implements WorkflowStubInterface, HeaderCarrier
                 $response = $this->serviceClient->DescribeWorkflowExecution($request);
                 $mapper = new WorkflowExecutionInfoMapper($this->converter);
 
+                /** @psalm-suppress PossiblyNullArgument */
                 return new WorkflowExecutionDescription(
                     info: $mapper->fromMessage($response->getWorkflowExecutionInfo()),
                 );

--- a/src/Workflow/WorkflowRunInterface.php
+++ b/src/Workflow/WorkflowRunInterface.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Temporal\Workflow;
 
+use Temporal\Client\Workflow\WorkflowExecutionDescription;
 use Temporal\DataConverter\Type;
 use Temporal\Exception\Client\WorkflowFailedException;
 
@@ -47,4 +48,6 @@ interface WorkflowRunInterface
      * @see DateInterval
      */
     public function getResult($type = null, int $timeout = null): mixed;
+
+    public function describe(): WorkflowExecutionDescription;
 }


### PR DESCRIPTION
## What was changed

Exposed API to describe a Workflow.

Other changes:

- `Temporal\Client\WorkflowExecutionHistory` was moved into another namespace.


## Checklist

- Closes #413 
- [x] Tests

## Describe a Workflow

Use the API to obtain comprehensive information about a started Workflow.

```php
$stub = $workflowClient->newWorkflowStub(SimpleWorkflow::class);
$run = $workflowClient->start($stub, 'Hello World!');

/** @var WorkflowExecutionDescription $description */
$description = $run->describe();
```

You can use the Workflow Describe feature to get the status of a running Workflow.

```php
$stub = $workflowClient->newUntypedRunningWorkflowStub($wfId);

/** @var WorkflowExecutionStatus $status */
$status = $stub->describe()->info->status;
```
