### PR TITLE
Expose API key client option

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "psr/log": "^2.0 || ^3.0",
         "ramsey/uuid": "^4.7",
         "react/promise": "^2.9",
-        "roadrunner-php/roadrunner-api-dto": "^1.5.0",
+        "roadrunner-php/roadrunner-api-dto": "^1.7.0",
         "roadrunner-php/version-checker": "^1.0",
         "spiral/attributes": "^3.1.4",
         "spiral/roadrunner": "^2023.3.12 || ^2024.1",

--- a/resources/scripts/generate-client.php
+++ b/resources/scripts/generate-client.php
@@ -106,6 +106,14 @@ $m = new MethodGenerator(
 );
 $m->setReturnType('static');
 $interface->addMethodFromGenerator($m);
+// withAuthKey(string $key): static
+$m = new MethodGenerator(
+    'withAuthKey',
+    [Generator\ParameterGenerator::fromArray(['type' => '\Stringable|string', 'name' => 'key'])],
+    MethodGenerator::FLAG_PUBLIC,
+);
+$m->setReturnType('static');
+$interface->addMethodFromGenerator($m);
 // public function getConnection(): ConnectionInterface
 $m = new MethodGenerator(
     'getConnection',

--- a/src/Client/Common/ServerCapabilities.php
+++ b/src/Client/Common/ServerCapabilities.php
@@ -11,6 +11,9 @@ declare(strict_types=1);
 
 namespace Temporal\Client\Common;
 
+/**
+ * @see \Temporal\Api\Workflowservice\V1\GetSystemInfoResponse\Capabilities
+ */
 final class ServerCapabilities
 {
     /**

--- a/src/Client/GRPC/ServiceClient.php
+++ b/src/Client/GRPC/ServiceClient.php
@@ -729,7 +729,11 @@ class ServiceClient extends BaseClient
     }
 
     /**
-     * DescribeTaskQueue returns information about the target task queue.
+     * DescribeTaskQueue returns the following information about the target task queue,
+     * broken down by Build ID:
+     * - List of pollers
+     * - Workflow Reachability status
+     * - Backlog info for Workflow and/or Activity tasks
      *
      * @param V1\DescribeTaskQueueRequest $arg
      * @param ContextInterface|null $ctx
@@ -873,6 +877,8 @@ class ServiceClient extends BaseClient
     }
 
     /**
+     * Deprecated. Use `UpdateWorkerVersioningRules`.
+     *
      * Allows users to specify sets of worker build id versions on a per task queue
      * basis. Versions
      * are ordered, and may be either compatible with some extant version, or a new
@@ -906,6 +912,7 @@ class ServiceClient extends BaseClient
     }
 
     /**
+     * Deprecated. Use `GetWorkerVersioningRules`.
      * Fetches the worker build id versioning sets for a task queue.
      *
      * @param V1\GetWorkerBuildIdCompatibilityRequest $arg
@@ -919,6 +926,41 @@ class ServiceClient extends BaseClient
     }
 
     /**
+     * Allows updating the Build ID assignment and redirect rules for a given Task
+     * Queue.
+     * WARNING: Worker Versioning is not yet stable and the API and behavior may change
+     * incompatibly.
+     * (-- api-linter: core::0127::http-annotation=disabled
+     * aip.dev/not-precedent: We do yet expose versioning API to HTTP. --)
+     *
+     * @param V1\UpdateWorkerVersioningRulesRequest $arg
+     * @param ContextInterface|null $ctx
+     * @return V1\UpdateWorkerVersioningRulesResponse
+     * @throws ServiceClientException
+     */
+    public function UpdateWorkerVersioningRules(V1\UpdateWorkerVersioningRulesRequest $arg, ContextInterface $ctx = null) : V1\UpdateWorkerVersioningRulesResponse
+    {
+        return $this->invoke("UpdateWorkerVersioningRules", $arg, $ctx);
+    }
+
+    /**
+     * Fetches the Build ID assignment and redirect rules for a Task Queue.
+     * WARNING: Worker Versioning is not yet stable and the API and behavior may change
+     * incompatibly.
+     *
+     * @param V1\GetWorkerVersioningRulesRequest $arg
+     * @param ContextInterface|null $ctx
+     * @return V1\GetWorkerVersioningRulesResponse
+     * @throws ServiceClientException
+     */
+    public function GetWorkerVersioningRules(V1\GetWorkerVersioningRulesRequest $arg, ContextInterface $ctx = null) : V1\GetWorkerVersioningRulesResponse
+    {
+        return $this->invoke("GetWorkerVersioningRules", $arg, $ctx);
+    }
+
+    /**
+     * Deprecated. Use `DescribeTaskQueue`.
+     *
      * Fetches task reachability to determine whether a worker may be retired.
      * The request may specify task queues to query for or let the server fetch all
      * task queues mapped to the given

--- a/src/Client/GRPC/ServiceClientInterface.php
+++ b/src/Client/GRPC/ServiceClientInterface.php
@@ -16,6 +16,7 @@ interface ServiceClientInterface
 {
     public function getContext() : ContextInterface;
     public function withContext(ContextInterface $context) : static;
+    public function withAuthKey(\Stringable|string $key) : static;
     public function getConnection() : \Temporal\Client\GRPC\Connection\ConnectionInterface;
     public function getServerCapabilities() : ?\Temporal\Client\Common\ServerCapabilities;
     /**
@@ -585,7 +586,11 @@ interface ServiceClientInterface
      */
     public function DescribeWorkflowExecution(V1\DescribeWorkflowExecutionRequest $arg, ContextInterface $ctx = null) : V1\DescribeWorkflowExecutionResponse;
     /**
-     * DescribeTaskQueue returns information about the target task queue.
+     * DescribeTaskQueue returns the following information about the target task queue,
+     * broken down by Build ID:
+     * - List of pollers
+     * - Workflow Reachability status
+     * - Backlog info for Workflow and/or Activity tasks
      *
      * @param V1\DescribeTaskQueueRequest $arg
      * @param ContextInterface|null $ctx
@@ -685,6 +690,8 @@ interface ServiceClientInterface
      */
     public function ListSchedules(V1\ListSchedulesRequest $arg, ContextInterface $ctx = null) : V1\ListSchedulesResponse;
     /**
+     * Deprecated. Use `UpdateWorkerVersioningRules`.
+     *
      * Allows users to specify sets of worker build id versions on a per task queue
      * basis. Versions
      * are ordered, and may be either compatible with some extant version, or a new
@@ -714,6 +721,7 @@ interface ServiceClientInterface
      */
     public function UpdateWorkerBuildIdCompatibility(V1\UpdateWorkerBuildIdCompatibilityRequest $arg, ContextInterface $ctx = null) : V1\UpdateWorkerBuildIdCompatibilityResponse;
     /**
+     * Deprecated. Use `GetWorkerVersioningRules`.
      * Fetches the worker build id versioning sets for a task queue.
      *
      * @param V1\GetWorkerBuildIdCompatibilityRequest $arg
@@ -723,6 +731,33 @@ interface ServiceClientInterface
      */
     public function GetWorkerBuildIdCompatibility(V1\GetWorkerBuildIdCompatibilityRequest $arg, ContextInterface $ctx = null) : V1\GetWorkerBuildIdCompatibilityResponse;
     /**
+     * Allows updating the Build ID assignment and redirect rules for a given Task
+     * Queue.
+     * WARNING: Worker Versioning is not yet stable and the API and behavior may change
+     * incompatibly.
+     * (-- api-linter: core::0127::http-annotation=disabled
+     * aip.dev/not-precedent: We do yet expose versioning API to HTTP. --)
+     *
+     * @param V1\UpdateWorkerVersioningRulesRequest $arg
+     * @param ContextInterface|null $ctx
+     * @return V1\UpdateWorkerVersioningRulesResponse
+     * @throws ServiceClientException
+     */
+    public function UpdateWorkerVersioningRules(V1\UpdateWorkerVersioningRulesRequest $arg, ContextInterface $ctx = null) : V1\UpdateWorkerVersioningRulesResponse;
+    /**
+     * Fetches the Build ID assignment and redirect rules for a Task Queue.
+     * WARNING: Worker Versioning is not yet stable and the API and behavior may change
+     * incompatibly.
+     *
+     * @param V1\GetWorkerVersioningRulesRequest $arg
+     * @param ContextInterface|null $ctx
+     * @return V1\GetWorkerVersioningRulesResponse
+     * @throws ServiceClientException
+     */
+    public function GetWorkerVersioningRules(V1\GetWorkerVersioningRulesRequest $arg, ContextInterface $ctx = null) : V1\GetWorkerVersioningRulesResponse;
+    /**
+     * Deprecated. Use `DescribeTaskQueue`.
+     *
      * Fetches task reachability to determine whether a worker may be retired.
      * The request may specify task queues to query for or let the server fetch all
      * task queues mapped to the given

--- a/src/Common/WorkerVersionStamp.php
+++ b/src/Common/WorkerVersionStamp.php
@@ -17,6 +17,7 @@ final class WorkerVersionStamp
 {
     public function __construct(
         public string $buildId = '',
+        /** @deprecated that field was removed {@link https://github.com/temporalio/api/pull/393} */
         public string $bundleId = '',
         public bool $useVersioning = false,
     ) {

--- a/src/Internal/Mapper/WorkflowExecutionInfoMapper.php
+++ b/src/Internal/Mapper/WorkflowExecutionInfoMapper.php
@@ -64,7 +64,6 @@ final class WorkflowExecutionInfoMapper
             ? null
             : new WorkerVersionStampDto(
                 buildId: $versionStamp->getBuildId(),
-                bundleId: $versionStamp->getBundleId(),
                 useVersioning: $versionStamp->getUseVersioning(),
             );
     }

--- a/tests/Unit/Client/GRPC/BaseClientTestCase.php
+++ b/tests/Unit/Client/GRPC/BaseClientTestCase.php
@@ -13,6 +13,7 @@ use Temporal\Client\GRPC\BaseClient;
 use Temporal\Client\GRPC\Connection\ConnectionState;
 use Temporal\Client\GRPC\ContextInterface;
 use Temporal\Client\GRPC\ServiceClient;
+use Temporal\Internal\Interceptor\Pipeline;
 
 class BaseClientTestCase extends TestCase
 {
@@ -80,9 +81,55 @@ class BaseClientTestCase extends TestCase
         $this->assertNotSame($client, $client2);
     }
 
+    public function testWithAuthKey(): void
+    {
+        $client = $this->createClientMock();
+        $context = $client->getContext();
+        $client2 = $client->withAuthKey('test-key');
+
+        // Client immutability
+        $this->assertNotSame($client, $client2);
+        // Old context was not modified
+        $this->assertSame($context, $client->getContext());
+        // New context is the same as the old one
+        // because the auth key is added to the context before API method call
+        $this->assertSame($context, $client2->getContext());
+
+        $ctx1 = $client->testCall()->ctx;
+        self::assertInstanceOf(ContextInterface::class, $ctx1);
+        $this->assertArrayNotHasKey('Authorization', $ctx1->getMetadata());
+
+        $ctx2 = $client2->testCall()->ctx;
+        self::assertInstanceOf(ContextInterface::class, $ctx2);
+        $this->assertArrayHasKey('Authorization', $ctx2->getMetadata());
+        $this->assertSame(['Bearer test-key'], $ctx2->getMetadata()['Authorization']);
+    }
+
+    public function testWithDynamicAuthKey(): void
+    {
+        $client = $this->createClientMock()->withAuthKey(new class implements \Stringable {
+            public function __toString(): string
+            {
+                static $counter = 0;
+                $counter++;
+                return "test-key-$counter";
+            }
+        });
+
+        $ctx = $client->testCall()->ctx;
+        self::assertInstanceOf(ContextInterface::class, $ctx);
+        $this->assertArrayHasKey('Authorization', $ctx->getMetadata());
+        $this->assertSame(['Bearer test-key-1'], $ctx->getMetadata()['Authorization']);
+
+        $ctx2 = $client->testCall()->ctx;
+        self::assertInstanceOf(ContextInterface::class, $ctx2);
+        $this->assertArrayHasKey('Authorization', $ctx2->getMetadata());
+        $this->assertSame(['Bearer test-key-2'], $ctx2->getMetadata()['Authorization']);
+    }
+
     private function createClientMock(?callable $serviceClientFactory = null): BaseClient
     {
-        return new class($serviceClientFactory ?? static fn() => new class extends WorkflowServiceClient {
+        return (new class($serviceClientFactory ?? static fn() => new class extends WorkflowServiceClient {
             public function __construct()
             {
             }
@@ -104,6 +151,22 @@ class BaseClientTestCase extends TestCase
                     ->setCapabilities((new Capabilities)->setSupportsSchedules(true))
                     ->setServerVersion('1.2.3');
             }
-        };
+
+            public function testCall(): mixed
+            {
+                return $this->invoke("testCall", (object)[], null);
+            }
+        })->withInterceptorPipeline(
+            Pipeline::prepare([new class implements \Temporal\Interceptor\GrpcClientInterceptor {
+                public function interceptCall(
+                    string $method,
+                    object $arg,
+                    ContextInterface $ctx,
+                    callable $next
+                ): object {
+                    return (object)['method' => $method, 'arg' => $arg, 'ctx' => $ctx, 'next' => $next];
+                }
+            }]),
+        );
     }
 }

--- a/tests/Unit/Client/Mapper/WorkflowExecutionInfoMapperTestCase.php
+++ b/tests/Unit/Client/Mapper/WorkflowExecutionInfoMapperTestCase.php
@@ -64,7 +64,6 @@ final class WorkflowExecutionInfoMapperTestCase extends TestCase
                 'state_transition_count' => 1,
                 'history_size_bytes' => 1,
                 'most_recent_worker_version_stamp' => (new \Temporal\Api\Common\V1\WorkerVersionStamp())
-                    ->setBundleId('bundleId')
                     ->setBuildId('buildId')
                     ->setUseVersioning(true),
             ]),
@@ -94,7 +93,6 @@ final class WorkflowExecutionInfoMapperTestCase extends TestCase
         $this->assertTrue($info->autoResetPoints[0]->resettable);
         $this->assertSame('binaryChecksum', $info->autoResetPoints[0]->binaryChecksum);
         $this->assertSame(1, $info->historySizeBytes);
-        $this->assertSame('bundleId', $info->mostRecentWorkerVersionStamp->bundleId);
         $this->assertSame('buildId', $info->mostRecentWorkerVersionStamp->buildId);
         $this->assertTrue($info->mostRecentWorkerVersionStamp->useVersioning);
     }


### PR DESCRIPTION
## What was changed

Added method `ServiceClient::withAuthKey()`

## Checklist

1. Closes #410 
2. How was this tested: added unit tests


## Service Client with API auth key

The ClientService now can accept an API key for authentication.

```php
$serviceClient = \Temporal\Client\GRPC\ServiceClient::createSSL(
    'temporal.my-project.com:7233',
    __DIR__ . '/my-project.key',
    __DIR__ . '/my-project.crt',
)->withAuthKey($authKey);

$workflowClient = new \Temporal\Client\WorkflowClient($serviceClient);
```

You may pass your own `Stringable` implementation as a Key to be able to change the key dynamically.

