### PR TITLE
[BUG] Broken DateInterval to protobuf Duration casting 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "psr/log": "^2.0 || ^3.0",
         "ramsey/uuid": "^4.7",
         "react/promise": "^2.9",
-        "roadrunner-php/roadrunner-api-dto": "^1.5.0",
+        "roadrunner-php/roadrunner-api-dto": "^1.5.0 <1.7.0",
         "roadrunner-php/version-checker": "^1.0",
         "spiral/attributes": "^3.1.4",
         "spiral/roadrunner": "^2023.3.12 || ^2024.1",

--- a/src/Internal/Support/DateInterval.php
+++ b/src/Internal/Support/DateInterval.php
@@ -162,7 +162,7 @@ final class DateInterval
         $d = new Duration();
         $parsed = self::parse($i);
         $d->setSeconds((int)$parsed->totalSeconds);
-        $d->setNanos($parsed->microseconds * 1000);
+        $d->setNanos(($parsed->totalMicroseconds % 1_000_000) * 1000);
 
         return $d;
     }

--- a/src/Internal/Support/DateInterval.php
+++ b/src/Internal/Support/DateInterval.php
@@ -162,7 +162,7 @@ final class DateInterval
         $d = new Duration();
         $parsed = self::parse($i);
         $d->setSeconds((int)$parsed->totalSeconds);
-        $d->setNanos(($parsed->totalMicroseconds % 1_000_000) * 1000);
+        $d->setNanos(($parsed->microseconds % 1_000_000) * 1000);
 
         return $d;
     }

--- a/tests/Unit/Internal/Support/DateIntervalTestCase.php
+++ b/tests/Unit/Internal/Support/DateIntervalTestCase.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Temporal\Tests\Unit\Internal\Support;
+
+use PHPUnit\Framework\TestCase;
+use Temporal\Internal\Support\DateInterval;
+
+class DateIntervalTestCase extends TestCase
+{
+    public function testFloatyDateIntervalToDuration(): void
+    {
+        $interval = DateInterval::toDuration(DateInterval::parse(5_000_356_000, DateInterval::FORMAT_NANOSECONDS));
+
+        $this->assertEquals(356_000, $interval->getNanos());
+        $this->assertEquals(5, $interval->getSeconds());
+    }
+}


### PR DESCRIPTION
## What was changed
Fixed DateInterval to protobuf duration casting.

## Why?
Would cause ```proto_codec_parse_message: json: cannot unmarshal number 5000000000 into Go struct field Duration.Nanos of type int32``` in some cases, specifically:

```
DurationJsonType:93 turns from protobuf format to CarbonInterval
DateInterval:117 division causes f property (float) in CarbonInterval to be set
DateInterval:165 set f propoerty in CarbonInterval causes an interval of 5 seconds to be parsed into protobuf object of [seconds => 5, nanos => 5 000 000 000]

5 000 000 000 doesnt fit into int32 of Duration struct and roadrunner/temporal panics

This would always be an issue with carbon 2 or 3, as the f always can include seconds
```
## Checklist

How was this tested:
Unit tests

> [!NOTE]
> It's the same PR as https://github.com/temporalio/sdk-php/pull/423 with few fixes and with the different base branch