### PR TITLE
fix: bring back psr/log ^1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "google/protobuf": "^3.22",
         "grpc/grpc": "^1.42",
         "nesbot/carbon": "^2.66 || ^3.0.2",
-        "psr/log": "^2.0 || ^3.0",
+        "psr/log": "^1.0 || ^2.0 || ^3.0",
         "ramsey/uuid": "^4.7",
         "react/promise": "^2.9",
         "roadrunner-php/roadrunner-api-dto": "^1.5.0 <1.7.0",


### PR DESCRIPTION

## What was changed
Added support for psr/log ^1

## Why?
It makes now sense to support ^2 |^3 but not support ^1, the changes are only in the way types are specified in interfaces.  Symfony and projects like that all support ^1|^2|^3.

