### PR TITLE
Use namespace from the Service Client in ScheduleClient::listSchedules()

### DIFF
--- a/src/Client/ScheduleClient.php
+++ b/src/Client/ScheduleClient.php
@@ -147,12 +147,12 @@ final class ScheduleClient implements ScheduleClientInterface
     }
 
     public function listSchedules(
-        string $namespace = 'default',
+        ?string $namespace = null,
         int $pageSize = 0,
     ): Paginator {
         // Build request
         $request = (new ListSchedulesRequest())
-            ->setNamespace($namespace)
+            ->setNamespace($namespace ?? $this->clientOptions->namespace)
             ->setMaximumPageSize($pageSize);
 
         $loader = function (ListSchedulesRequest $request): \Generator {

--- a/src/Client/ScheduleClientInterface.php
+++ b/src/Client/ScheduleClientInterface.php
@@ -44,10 +44,10 @@ interface ScheduleClientInterface extends ClientContextInterface
     /**
      * List all schedules in a namespace.
      *
-     * @param non-empty-string $namespace
+     * @param non-empty-string|null $namespace If null, the preconfigured namespace will be used.
      * @param int<0, max> $pageSize Maximum number of Schedule info per page.
      *
      * @return Paginator<ScheduleListEntry>
      */
-    public function listSchedules(string $namespace = 'default', int $pageSize = 0,): Paginator;
+    public function listSchedules(?string $namespace = null, int $pageSize = 0,): Paginator;
 }


### PR DESCRIPTION
## What was changed

`ScheduleClient::listSchedules()`: use namespace value from the Service Client by default

