### PR TITLE
Fix unmarshalling of typed assoc arrays

### DIFF
--- a/src/Internal/Marshaller/Type/ArrayType.php
+++ b/src/Internal/Marshaller/Type/ArrayType.php
@@ -83,7 +83,7 @@ class ArrayType extends Type implements DetectableTypeInterface, RuleFactoryInte
             $result = [];
 
             foreach ($value as $i => $item) {
-                $result[] = $this->type->parse($item, $current[$i] ?? null);
+                $result[$i] = $this->type->parse($item, $current[$i] ?? null);
             }
 
             return $result;

--- a/tests/Unit/DTO/Type/ArrayType/ArrayDto.php
+++ b/tests/Unit/DTO/Type/ArrayType/ArrayDto.php
@@ -33,4 +33,9 @@ class ArrayDto
     public iterable $iterable;
 
     public ?iterable $iterableNullable;
+
+    public array $assoc;
+
+    #[MarshalArray(of: \stdClass::class)]
+    public array $assocOfType;
 }

--- a/tests/Unit/DTO/Type/ArrayType/ArrayTestCase.php
+++ b/tests/Unit/DTO/Type/ArrayType/ArrayTestCase.php
@@ -29,6 +29,8 @@ class ArrayTestCase extends AbstractDTOMarshalling
             yield 'foo';
         })();
         $dto->iterableNullable = null;
+        $dto->assoc = ['foo' => 'bar'];
+        $dto->assocOfType = ['foo' => (object)['baz' => 'bar']];
 
         $result = $this->marshal($dto);
         $this->assertSame([
@@ -40,6 +42,8 @@ class ArrayTestCase extends AbstractDTOMarshalling
             'nullableBar' => null,
             'iterable' => ['foo'],
             'iterableNullable' => null,
+            'assoc' => ['foo' => 'bar'],
+            'assocOfType' => ['foo' => ['baz' => 'bar']],
         ], $result);
     }
 
@@ -54,6 +58,8 @@ class ArrayTestCase extends AbstractDTOMarshalling
             'nullableBar' => null,
             'iterable' => ['it'],
             'iterableNullable' => ['itn'],
+            'assoc' => ['foo' => 'bar'],
+            'assocOfType' => ['key' => ['foo' => 'bar']],
         ], new ArrayDto());
 
         $this->assertSame(['foo'], $dto->foo);
@@ -64,6 +70,8 @@ class ArrayTestCase extends AbstractDTOMarshalling
         $this->assertSame(['it'], $dto->iterable);
         $this->assertSame(['itn'], $dto->iterableNullable);
         $this->assertSame(null, $dto->nullableBar);
+        $this->assertSame(['foo' => 'bar'], $dto->assoc);
+        $this->assertEquals(['key' => (object)['foo' => 'bar']], $dto->assocOfType);
     }
 
     public function testSetNullToNotNullable(): void


### PR DESCRIPTION
## What was changed

Fixed unmarshalling of typed assoc arrays when a property configured like `MarshalArray(of: SomeClass::class)`

## Why?

It's more consistently to have assoc array in result in both cases: when typed is specified and when it isn't

## Checklist

1. Closes #433
2. [x] Unit tests
