### PR TITLE
Fixes null values receival from Golang Activity SDK

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -244,9 +244,6 @@
     <MissingClosureParamType>
       <code><![CDATA[$value]]></code>
     </MissingClosureParamType>
-    <MoreSpecificImplementedParamType>
-      <code><![CDATA[$type]]></code>
-    </MoreSpecificImplementedParamType>
     <NullableReturnStatement>
       <code><![CDATA[$result]]></code>
       <code><![CDATA[$result]]></code>
@@ -1200,9 +1197,6 @@
       <code><![CDATA[$name]]></code>
       <code><![CDATA[$name]]></code>
     </ArgumentTypeCoercion>
-    <ImplicitToStringCast>
-      <code><![CDATA[$returnType]]></code>
-    </ImplicitToStringCast>
     <LessSpecificReturnStatement>
       <code><![CDATA[EncodedValues::decodePromise($this->request($request), $returnType)]]></code>
     </LessSpecificReturnStatement>
@@ -1319,9 +1313,6 @@
       <code><![CDATA[$type]]></code>
       <code><![CDATA[$type]]></code>
     </ArgumentTypeCoercion>
-    <ImplicitToStringCast>
-      <code><![CDATA[$returnType]]></code>
-    </ImplicitToStringCast>
     <InvalidArgument>
       <code><![CDATA[$options]]></code>
     </InvalidArgument>
@@ -1348,7 +1339,6 @@
       <code><![CDATA[$result]]></code>
     </MissingClosureParamType>
     <MissingClosureReturnType>
-      <code><![CDATA[fn() => EncodedValues::decodePromise(]]></code>
       <code><![CDATA[function ($result) use ($conditionGroupId) {]]></code>
     </MissingClosureReturnType>
     <MissingImmutableAnnotation>

--- a/src/DataConverter/ValuesInterface.php
+++ b/src/DataConverter/ValuesInterface.php
@@ -35,8 +35,11 @@ interface ValuesInterface extends \Countable
     /**
      * Get value by it's index.
      *
+     * Returns {@see null} if there are no values and $type has null value
+     * like {@see null}, {@see Type::TYPE_VOID} or {@see Type::TYPE_NULL}.
+     *
      * @param int $index
-     * @param Type|TypeEnum|mixed $type
+     * @param string|\ReflectionClass|\ReflectionType|Type|null $type
      * @return mixed
      */
     public function getValue(int $index, $type);

--- a/src/Internal/Workflow/WorkflowContext.php
+++ b/src/Internal/Workflow/WorkflowContext.php
@@ -228,7 +228,7 @@ class WorkflowContext implements WorkflowContextInterface, HeaderCarrier, Destro
     public function sideEffect(callable $context): PromiseInterface
     {
         $value = null;
-        $closure = \Closure::fromCallable($context);
+        $closure = $context(...);
 
         try {
             if (!$this->isReplaying()) {
@@ -249,7 +249,7 @@ class WorkflowContext implements WorkflowContextInterface, HeaderCarrier, Destro
         } catch (\Throwable) {
         }
 
-        $last = fn() => EncodedValues::decodePromise(
+        $last = fn(): PromiseInterface => EncodedValues::decodePromise(
             $this->request(new SideEffect(EncodedValues::fromValues([$value]))),
             $returnType,
         );

--- a/tests/Fixtures/src/Activity/SimpleActivity.php
+++ b/tests/Fixtures/src/Activity/SimpleActivity.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Activity;
 
+use React\Promise\PromiseInterface;
 use Temporal\Activity;
 use Temporal\Activity\ActivityInterface;
 use Temporal\Activity\ActivityMethod;
@@ -148,5 +149,13 @@ class SimpleActivity
             'optionalBool' => $optionalBool,
             'optionalNullableString' => $optionalNullableString,
         ];
+    }
+
+    /**
+     * @return PromiseInterface<null>
+     */
+    #[ActivityMethod]
+    public function empty(): void
+    {
     }
 }

--- a/tests/Fixtures/src/Workflow/VoidActivityStubWorkflow.php
+++ b/tests/Fixtures/src/Workflow/VoidActivityStubWorkflow.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Workflow;
+
+use Temporal\Activity\ActivityOptions;
+use Temporal\Tests\Activity\SimpleActivity;
+use Temporal\Workflow;
+use Temporal\Workflow\WorkflowMethod;
+
+#[Workflow\WorkflowInterface]
+class VoidActivityStubWorkflow
+{
+    #[WorkflowMethod(name: 'VoidActivityStubWorkflow')]
+    public function handler()
+    {
+        // typed stub
+        $simple = Workflow::newActivityStub(
+            SimpleActivity::class,
+            ActivityOptions::new()->withStartToCloseTimeout(5)
+        );
+
+        return yield $simple->empty();
+    }
+}

--- a/tests/Functional/WorkflowTestCase.php
+++ b/tests/Functional/WorkflowTestCase.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Functional;
 
+use Temporal\Api\Common\V1\Payloads;
 use Temporal\Common\Uuid;
 use Temporal\Tests\Fixtures\Splitter;
 use Temporal\Tests\Fixtures\WorkerMock;
@@ -29,105 +30,105 @@ class WorkflowTestCase extends AbstractFunctional
         $_SERVER['RR_RPC'] = 'tcp://127.0.0.1:6001';
     }
 
-    public function testSplitter()
+    public function testSplitter(): void
     {
         $splitter = Splitter::create('Test_ExecuteSimpleWorkflow_1.log');
 
         $this->assertNotEmpty($splitter->getQueue());
     }
 
-    public function testSimpleWorkflow()
+    public function testSimpleWorkflow(): void
     {
         $worker = WorkerMock::createMock();
 
         $worker->run($this, Splitter::create('Test_ExecuteSimpleWorkflow_1.log')->getQueue());
     }
 
-    public function testTimer()
+    public function testTimer(): void
     {
         $worker = WorkerMock::createMock();
 
         $worker->run($this, Splitter::create('Test_Timer.log')->getQueue());
     }
 
-    public function testGetQuery()
+    public function testGetQuery(): void
     {
         $worker = WorkerMock::createMock();
 
         $worker->run($this, Splitter::create('Test_GetQuery.log')->getQueue());
     }
 
-    public function testCancelledWithCompensationWorkflow()
+    public function testCancelledWithCompensationWorkflow(): void
     {
         $worker = WorkerMock::createMock();
 
         $worker->run($this, Splitter::create('Test_CancelledWithCompensationWorkflow.log')->getQueue());
     }
 
-    public function testCancelledNestedWorkflow()
+    public function testCancelledNestedWorkflow(): void
     {
         $worker = WorkerMock::createMock();
 
         $worker->run($this, Splitter::create('Test_CancelledNestedWorkflow.log')->getQueue());
     }
 
-    public function testCancelledMidflightWorkflow()
+    public function testCancelledMidflightWorkflow(): void
     {
         $worker = WorkerMock::createMock();
 
         $worker->run($this, Splitter::create('Test_CancelledMidflightWorkflow.log')->getQueue());
     }
 
-    public function testSendSignalBeforeCompletingWorkflow()
+    public function testSendSignalBeforeCompletingWorkflow(): void
     {
         $worker = WorkerMock::createMock();
 
         $worker->run($this, Splitter::create('Test_SendSignalBeforeCompletingWorkflow.log')->getQueue());
     }
 
-    public function testActivityStubWorkflow()
+    public function testActivityStubWorkflow(): void
     {
         $worker = WorkerMock::createMock();
 
         $worker->run($this, Splitter::create('Test_ActivityStubWorkflow.log')->getQueue());
     }
 
-    public function testBinaryPayload()
+    public function testBinaryPayload(): void
     {
         $worker = WorkerMock::createMock();
 
         $worker->run($this, Splitter::create('Test_BinaryPayload.log')->getQueue());
     }
 
-    public function testContinueAsNew()
+    public function testContinueAsNew(): void
     {
         $worker = WorkerMock::createMock();
 
         $worker->run($this, Splitter::create('Test_ContinueAsNew.log')->getQueue());
     }
 
-    public function testEmptyWorkflow()
+    public function testEmptyWorkflow(): void
     {
         $worker = WorkerMock::createMock();
 
         $worker->run($this, Splitter::create('Test_EmptyWorkflow.log')->getQueue());
     }
 
-    public function testSideEffectWorkflow()
+    public function testSideEffectWorkflow(): void
     {
         $worker = WorkerMock::createMock();
 
         $worker->run($this, Splitter::create('Test_SideEffect.log')->getQueue());
     }
 
-    public function testExecuteWorkflowWithParallelScopes()
+    public function testExecuteWorkflowWithParallelScopes(): void
     {
         $worker = WorkerMock::createMock();
 
         $worker->run($this, Splitter::create('Test_ExecuteWorkflowWithParallelScopes.log')->getQueue());
     }
 
-    public function testActivity()
+    public function testActivity(): void
     {
         $worker = WorkerMock::createMock();
 
@@ -137,63 +138,63 @@ class WorkflowTestCase extends AbstractFunctional
     /**
      * @group skip-ext-protobuf
      */
-    public function testExecuteProtoWorkflow()
+    public function testExecuteProtoWorkflow(): void
     {
         $worker = WorkerMock::createMock();
 
         $worker->run($this, Splitter::create('Test_ExecuteProtoWorkflow.log')->getQueue());
     }
 
-    public function testExecuteSimpleDTOWorkflow()
+    public function testExecuteSimpleDTOWorkflow(): void
     {
         $worker = WorkerMock::createMock();
 
         $worker->run($this, Splitter::create('Test_ExecuteSimpleDTOWorkflow.log')->getQueue());
     }
 
-    public function testExecuteSimpleWorkflowWithSequenceInBatch()
+    public function testExecuteSimpleWorkflowWithSequenceInBatch(): void
     {
         $worker = WorkerMock::createMock();
 
         $worker->run($this, Splitter::create('Test_ExecuteSimpleWorkflowWithSequenceInBatch.log')->getQueue());
     }
 
-    public function testPromiseChaining()
+    public function testPromiseChaining(): void
     {
         $worker = WorkerMock::createMock();
 
         $worker->run($this, Splitter::create('Test_PromiseChaining.log')->getQueue());
     }
 
-    public function testMultipleWorkflowsInSingleWorker()
+    public function testMultipleWorkflowsInSingleWorker(): void
     {
         $worker = WorkerMock::createMock();
 
         $worker->run($this, Splitter::create('Test_MultipleWorkflowsInSingleWorker.log')->getQueue());
     }
 
-    public function testSignalChildViaStubWorkflow()
+    public function testSignalChildViaStubWorkflow(): void
     {
         $worker = WorkerMock::createMock();
 
         $worker->run($this, Splitter::create('Test_SignalChildViaStubWorkflow.log')->getQueue());
     }
 
-    public function testExecuteChildStubWorkflow()
+    public function testExecuteChildStubWorkflow(): void
     {
         $worker = WorkerMock::createMock();
 
         $worker->run($this, Splitter::create('Test_ExecuteChildStubWorkflow.log')->getQueue());
     }
 
-    public function testExecuteChildStubWorkflow_02()
+    public function testExecuteChildStubWorkflow_02(): void
     {
         $worker = WorkerMock::createMock();
 
         $worker->run($this, Splitter::create('Test_ExecuteChildStubWorkflow_02.log')->getQueue());
     }
 
-    public function testExecuteChildWorkflow()
+    public function testExecuteChildWorkflow(): void
     {
         $worker = WorkerMock::createMock();
 
@@ -210,28 +211,28 @@ class WorkflowTestCase extends AbstractFunctional
         $worker->run($this, Splitter::create('Test_ExecuteChildWorkflowNamespaced.log')->getQueue());
     }
 
-    public function testRuntimeSignal()
+    public function testRuntimeSignal(): void
     {
         $worker = WorkerMock::createMock();
 
         $worker->run($this, Splitter::create('Test_RuntimeSignal.log')->getQueue());
     }
 
-    public function testSignalStepsAndRuntimeQuery()
+    public function testSignalStepsAndRuntimeQuery(): void
     {
         $worker = WorkerMock::createMock();
 
         $worker->run($this, Splitter::create('Test_SignalSteps.log')->getQueue());
     }
 
-    public function testBatchedSignal_WithPauses()
+    public function testBatchedSignal_WithPauses(): void
     {
         $worker = WorkerMock::createMock();
 
         $worker->run($this, Splitter::create('Test_BatchedSignal.log')->getQueue());
     }
 
-    public function testBatchedSignal_Combined()
+    public function testBatchedSignal_Combined(): void
     {
         $worker = WorkerMock::createMock();
 
@@ -332,7 +333,7 @@ class WorkflowTestCase extends AbstractFunctional
      * That case mustn't leak.
      * @see \Temporal\Tests\Workflow\AwaitWithSingleTimeoutWorkflow
      */
-    public function testAwaitWithOneTimer_Leaks()
+    public function testAwaitWithOneTimer_Leaks(): void
     {
         $worker = WorkerMock::createMock();
 
@@ -357,4 +358,34 @@ class WorkflowTestCase extends AbstractFunctional
 
         $this->assertSame(0, $after - $before);
     }
+
+    /**
+     * Test case when an external Temporal SDK returns empty payload that doesn't contain even NULL value.
+     *
+     * In this case {@see \Temporal\DataConverter\EncodedValues::getValue()} should return {@see null}
+     * if there is no non-nullable expected type.
+     */
+    public function testEmptyPayload(): void
+    {
+        $worker = WorkerMock::createMock();
+
+        $id1 = 9001;
+        $id2 = 9002;
+        $uuid1 = Uuid::v4();
+        $uuid2 = Uuid::v4();
+        $emptyPayload = (new Payloads());
+        $emptyPayloadStr = \base64_encode($emptyPayload->serializeToString());
+
+        $log = <<<LOG
+            2021/01/12 15:25:13	[97mDEBUG[0m	[{"command":"StartWorkflow","options":{"info":{"WorkflowExecution":{"ID":"$uuid1","RunID":"$uuid2"},"WorkflowType":{"Name":"VoidActivityStubWorkflow"},"TaskQueueName":"default","WorkflowExecutionTimeout":315360000000000000,"WorkflowRunTimeout":315360000000000000,"WorkflowTaskTimeout":0,"Namespace":"default","Attempt":1,"CronSchedule":"","ContinuedExecutionRunID":"","ParentWorkflowNamespace":"","ParentWorkflowExecution":null,"Memo":null,"SearchAttributes":null,"BinaryChecksum":"8646d54f9f6b22f407d6d22254eea9f5"}},"payloads":"$emptyPayloadStr"}] {"taskQueue":"default","tickTime":"2021-01-12T15:25:13.3983204Z"}
+            2021/01/12 15:25:13	[97mDEBUG[0m	[{"id":$id1,"command":"ExecuteActivity","options":{"name":"SimpleActivity.empty","options":{"TaskQueueName":null,"ScheduleToCloseTimeout":0,"ScheduleToStartTimeout":0,"StartToCloseTimeout":5000000000,"HeartbeatTimeout":0,"WaitForCancellation":false,"ActivityID":"","RetryPolicy":null}},"payloads":"$emptyPayloadStr","header":""},{"payloads":"ChkKFwoIZW5jb2RpbmcSC2JpbmFyeS9udWxs"}]	{"receive": true}
+            2021/01/12 15:25:13	[97mDEBUG[0m	[{"id":$id1,"payloads":"$emptyPayloadStr"}] {"taskQueue":"default","tickTime":"2021-01-12T15:25:13.4849445Z"}
+            2021/01/12 15:25:13	[97mDEBUG[0m	[{"id":$id2,"command":"CompleteWorkflow","options":{},"payloads":"ChkKFwoIZW5jb2RpbmcSC2JpbmFyeS9udWxs","header":""}]	{"receive": true}
+            2021/01/12 15:25:13	[97mDEBUG[0m	[{"id":$id2,"payloads":"CiUKFgoIZW5jb2RpbmcSCmpzb24vcGxhaW4SCyJjb21wbGV0ZWQi"},{"command":"DestroyWorkflow","options":{"runId":"$uuid2"}}] {"taskQueue":"default","tickTime":"2021-01-12T15:25:13.5143426Z","replay":true}
+            2021/01/12 15:25:13	[97mDEBUG[0m	[{"payloads":"ChkKFwoIZW5jb2RpbmcSC2JpbmFyeS9udWxs"}]	{"receive": true}
+            LOG;
+
+        $worker->run($this, Splitter::createFromString($log)->getQueue());
+    }
 }
+


### PR DESCRIPTION
After some recent updates PHP SDK begin to fail on empty array payloads from Golang SDK, while we get EncodedValues their payloads are empty, as such - we don't require DataConverter to decode them.