### PR TITLE
Client: fix connection timeout

### DIFF
--- a/src/Client/GRPC/Context.php
+++ b/src/Client/GRPC/Context.php
@@ -20,6 +20,7 @@ use Temporal\Internal\Support\DateInterval;
 final class Context implements ContextInterface
 {
     private ?\DateTimeInterface $deadline = null;
+    private ?\DateInterval $timeout = null;
     private array $options = [];
     private array $metadata;
     private RetryOptions $retryOptions;
@@ -41,7 +42,8 @@ final class Context implements ContextInterface
         $internal = DateInterval::parse($timeout, $format);
 
         $ctx = clone $this;
-        $ctx->deadline = (new \DateTimeImmutable())->add($internal);
+        $ctx->timeout = $internal;
+        $ctx->deadline =null;
 
         return $ctx;
     }
@@ -50,6 +52,7 @@ final class Context implements ContextInterface
     {
         $ctx = clone $this;
         $ctx->deadline = $deadline;
+        $ctx->timeout = null;
 
         return $ctx;
     }
@@ -90,7 +93,11 @@ final class Context implements ContextInterface
 
     public function getDeadline(): ?\DateTimeInterface
     {
-        return $this->deadline;
+        return match (true) {
+            $this->deadline !== null => $this->deadline,
+            $this->timeout !== null => (new \DateTime())->add($this->timeout),
+            default => null,
+        };
     }
 
     public function getRetryOptions(): RetryOptions

--- a/src/Client/GRPC/Context.php
+++ b/src/Client/GRPC/Context.php
@@ -43,7 +43,7 @@ final class Context implements ContextInterface
 
         $ctx = clone $this;
         $ctx->timeout = $internal;
-        $ctx->deadline =null;
+        $ctx->deadline = null;
 
         return $ctx;
     }

--- a/tests/Unit/Client/GRPC/BaseClientTestCase.php
+++ b/tests/Unit/Client/GRPC/BaseClientTestCase.php
@@ -16,7 +16,6 @@ use Temporal\Client\GRPC\Connection\ConnectionState;
 use Temporal\Client\GRPC\ContextInterface;
 use Temporal\Client\GRPC\ServiceClient;
 use Temporal\Client\GRPC\StatusCode;
-use Temporal\Common\RetryOptions;
 use Temporal\Exception\Client\ServiceClientException;
 use Temporal\Exception\Client\TimeoutException;
 use Temporal\Internal\Interceptor\Pipeline;
@@ -85,6 +84,30 @@ class BaseClientTestCase extends TestCase
         $this->assertSame($context, $client->getContext());
         $this->assertSame($context2, $client2->getContext());
         $this->assertNotSame($client, $client2);
+    }
+
+    public function testWithTimeoutDynamicDeadline(): void
+    {
+        $client = $this->createClientMock();
+        $context = $client->getContext()->withTimeout(1.234);
+
+        $this->assertNotSame($context->getDeadline(), $context->getDeadline());
+    }
+
+    public function testContextGetDeadlineWithoutDeadline(): void
+    {
+        $client = $this->createClientMock();
+        $context = $client->getContext();
+
+        $this->assertNull($context->getDeadline());
+    }
+
+    public function testContextGetDeadlineWithStaticDeadline(): void
+    {
+        $client = $this->createClientMock();
+        $context = $client->getContext()->withDeadline(new DateTimeImmutable('+1 second'));
+
+        $this->assertSame($context->getDeadline(), $context->getDeadline());
     }
 
     public function testWithAuthKey(): void


### PR DESCRIPTION
## What was changed

Client: fix connection timeout that was converted into static deadline for all requests

## Why?

Previously, the deadline was calculated at the moment the timeout was set and applied to all subsequent requests. However, the deadline should be recalculated before each request.

## Checklist

- How was this tested: manually