### PR TITLE
Add ProtoBinary decoder in default set

### DIFF
--- a/src/DataConverter/DataConverter.php
+++ b/src/DataConverter/DataConverter.php
@@ -87,6 +87,7 @@ final class DataConverter implements DataConverterInterface
             new NullConverter(),
             new BinaryConverter(),
             new ProtoJsonConverter(),
+            new ProtoConverter(),
             new JsonConverter()
         );
     }

--- a/tests/Unit/DataConverter/DataConverterTestCase.php
+++ b/tests/Unit/DataConverter/DataConverterTestCase.php
@@ -14,8 +14,12 @@ namespace Temporal\Tests\Unit\DataConverter;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Temporal\DataConverter\DataConverter;
 use Temporal\DataConverter\DataConverterInterface;
+use Temporal\DataConverter\EncodingKeys;
+use Temporal\DataConverter\ProtoConverter;
+use Temporal\DataConverter\ProtoJsonConverter;
 use Temporal\DataConverter\Type;
 use Temporal\Exception\DataConverterException;
+use Temporal\Tests\Proto\Test;
 use Temporal\Tests\Unit\AbstractUnit;
 
 /**
@@ -176,5 +180,29 @@ class DataConverterTestCase extends AbstractUnit
         $payload = $converter->toPayload($value);
 
         $this->assertNull($converter->fromPayload($payload, $type));
+    }
+
+    /**
+     * DataConverter may decode protobuf binary messages
+     */
+    public function testProtobufBinaryDecoding(): void
+    {
+        $message = (new Test())->setValue('foo');
+        $payload = (new ProtoConverter())->toPayload($message);
+
+        $decoded = DataConverter::createDefault()->fromPayload($payload, Test::class);
+
+        self::assertEquals($message, $decoded);
+    }
+
+    /**
+     * DataConverter decodes Protobuf messages using ProtoJson converter
+     */
+    public function testProtobufEncodingToJson(): void
+    {
+        $message = (new Test())->setValue('foo');
+        $payload = DataConverter::createDefault()->toPayload($message);
+
+        self::assertSame(EncodingKeys::METADATA_ENCODING_PROTOBUF_JSON, $payload->getMetadata()['encoding']);
     }
 }


### PR DESCRIPTION
## What was changed

Added `ProtoBinary` decoder in default set to have an ability to decode protobuf binary messages.
In this case `json/protobuf` converter will still be used for marshalling protobuf messages by default.

## Checklist
<!--- add/delete as needed --->

1. Closes #455 
2. How was this tested: added tests
