### PR TITLE
Fix TaskQueue inheritance when workflow is continued as new

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1202,7 +1202,7 @@
                 $request = new SignalExternalWorkflow(
                     $this->getOptions()->namespace,
                     $execution->getID(),
-                    $execution->getRunID(),
+                    null,
                     $name,
                     EncodedValues::fromValues($args),
                     true,

--- a/src/Workflow/ContinueAsNewOptions.php
+++ b/src/Workflow/ContinueAsNewOptions.php
@@ -18,6 +18,7 @@ use Temporal\Internal\Marshaller\Type\DateIntervalType;
 use Temporal\Internal\Support\DateInterval;
 use Temporal\Worker\WorkerFactoryInterface;
 use Temporal\Worker\Worker;
+use Temporal\Workflow;
 
 /**
  * @psalm-import-type DateIntervalValue from DateInterval
@@ -55,6 +56,12 @@ final class ContinueAsNewOptions
     {
         $this->workflowRunTimeout = CarbonInterval::seconds(0);
         $this->workflowTaskTimeout = CarbonInterval::seconds(0);
+        try {
+            // Inherit TaskQueue from the current Workflow if possible
+            $this->taskQueue = Workflow::getInfo()->taskQueue;
+        } catch (\Throwable) {
+            // Do nothing
+        }
     }
 
     /**

--- a/tests/Fixtures/src/Workflow/ContinuaWithTaskQueueWorkflow.php
+++ b/tests/Fixtures/src/Workflow/ContinuaWithTaskQueueWorkflow.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Workflow;
+
+use Temporal\Activity\ActivityOptions;
+use Temporal\Tests\Activity\SimpleActivity;
+use Temporal\Workflow;
+use Temporal\Workflow\WorkflowMethod;
+
+#[Workflow\WorkflowInterface]
+class ContinuaWithTaskQueueWorkflow
+{
+    #[WorkflowMethod(name: 'ContinuaWithTaskQueueWorkflow')]
+    public function handler(
+        int $generation
+    ) {
+        $simple = Workflow::newActivityStub(
+            SimpleActivity::class,
+            ActivityOptions::new()->withStartToCloseTimeout(5)
+        );
+
+        if ($generation > 5) {
+            // complete
+            return Workflow::getInfo()->taskQueue . $generation;
+        }
+
+        if ($generation !== 1) {
+            assert(!empty(Workflow::getInfo()->continuedExecutionRunId));
+        }
+
+        for ($i = 0; $i < $generation; $i++) {
+            yield $simple->echo((string)$generation);
+        }
+
+        return Workflow::newContinueAsNewStub(self::class)->handler(++$generation);
+    }
+}

--- a/tests/Functional/NamedArgumentsTestCase.php
+++ b/tests/Functional/NamedArgumentsTestCase.php
@@ -6,6 +6,9 @@ namespace Temporal\Tests\Functional;
 
 use Temporal\Client\GRPC\ServiceClient;
 use Temporal\Client\WorkflowClient;
+use Temporal\Client\WorkflowOptions;
+use Temporal\Tests\Workflow\ContinuableWorkflow;
+use Temporal\Tests\Workflow\ContinuaWithTaskQueueWorkflow;
 use Temporal\Tests\Workflow\NamedArguments\ContinueAsNewNamedArgumentsWorkflow;
 use Temporal\Tests\Workflow\NamedArguments\ExecuteChildNamedArgumentsWorkflow;
 use Temporal\Tests\Workflow\NamedArguments\ActivityNamedArgumentsWorkflow;
@@ -211,6 +214,24 @@ final class NamedArgumentsTestCase extends TestCase
             'nullableString' => 'test',
             'array' => ['test'],
         ], $result);
+    }
+
+    /**
+     * TaskQueue must be inherited from the parent workflow
+     */
+    public function testContinueAsNewTaskQueue(): void
+    {
+        $workflow = $this->workflowClient->newWorkflowStub(
+            ContinuaWithTaskQueueWorkflow::class,
+            WorkflowOptions::new()->withTaskQueue('FooBar'),
+        );
+
+        $result = $this->workflowClient->start(
+            $workflow,
+            generation: 1,
+        )->getResult();
+
+        self::assertSame('FooBar6', $result);
     }
 
     public function testExecuteChildNamedArguments()


### PR DESCRIPTION
## What was changed

Add inheritance of TaskQueue from the parent when ContinueAsNew options DTO is created

## Why?

It's expected behavior

## Checklist
<!--- add/delete as needed --->

1. Closes #453 
2. How was this tested: added autotest
