### PR TITLE
Divide errors and failures in updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.9.x-dev"
+            "dev-master": "2.11.x-dev"
         }
     },
     "config": {

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.24.0@462c80e31c34e58cc4f750c656be3927e80e550e">
+<files psalm-version="5.25.0@01a8eb06b9e9cc6cfb6a320bf9fb14331919d505">
   <file src="src/Activity.php">
     <ImplicitToStringCast>
       <code><![CDATA[$type]]></code>
@@ -581,9 +581,6 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Internal/Declaration/WorkflowInstance.php">
-    <InvalidPropertyAssignmentValue>
-      <code><![CDATA[$validator]]></code>
-    </InvalidPropertyAssignmentValue>
     <MissingClosureReturnType>
       <code><![CDATA[function (QueryInput $input) use ($fn) {]]></code>
     </MissingClosureReturnType>
@@ -1157,12 +1154,6 @@
       <code><![CDATA[$result]]></code>
       <code><![CDATA[$result]]></code>
     </MissingClosureParamType>
-    <PossiblyNullArgument>
-      <code><![CDATA[$request->getOptions()['updateId'] ?? null]]></code>
-    </PossiblyNullArgument>
-    <UndefinedClass>
-      <code><![CDATA[UpdateResult]]></code>
-    </UndefinedClass>
   </file>
   <file src="src/Internal/Workflow/ActivityProxy.php">
     <ArgumentTypeCoercion>
@@ -1232,16 +1223,9 @@
     </PropertyTypeCoercion>
   </file>
   <file src="src/Internal/Workflow/Process/Process.php">
-    <InvalidArgument>
-      <code><![CDATA[$input->arguments]]></code>
-    </InvalidArgument>
     <MissingClosureParamType>
       <code><![CDATA[$result]]></code>
     </MissingClosureParamType>
-    <MissingClosureReturnType>
-      <code><![CDATA[function () use ($handler, $inboundPipeline, $input) {]]></code>
-      <code><![CDATA[function (UpdateInput $input) use ($handler) {]]></code>
-    </MissingClosureReturnType>
     <PropertyNotSetInConstructor>
       <code><![CDATA[Process]]></code>
     </PropertyNotSetInConstructor>

--- a/src/Internal/Declaration/WorkflowInstance.php
+++ b/src/Internal/Declaration/WorkflowInstance.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Temporal\Internal\Declaration;
 
+use React\Promise\Deferred;
 use React\Promise\PromiseInterface;
 use Temporal\DataConverter\ValuesInterface;
 use Temporal\Interceptor\WorkflowInbound\QueryInput;
@@ -23,10 +24,10 @@ use Temporal\Internal\Interceptor;
 /**
  * @psalm-import-type DispatchableHandler from InstanceInterface
  * @psalm-type QueryHandler = \Closure(QueryInput): mixed
- * @psalm-type UpdateHandler = \Closure(UpdateInput): PromiseInterface
+ * @psalm-type UpdateHandler = \Closure(UpdateInput, Deferred): PromiseInterface
  * @psalm-type ValidateUpdateHandler = \Closure(UpdateInput): void
  * @psalm-type QueryExecutor = \Closure(QueryInput, callable(ValuesInterface): mixed): mixed
- * @psalm-type UpdateExecutor = \Closure(UpdateInput, callable(ValuesInterface): mixed): PromiseInterface
+ * @psalm-type UpdateExecutor = \Closure(UpdateInput, callable(ValuesInterface): mixed, Deferred): PromiseInterface
  * @psalm-type ValidateUpdateExecutor = \Closure(UpdateInput, callable(ValuesInterface): mixed): mixed
  * @psalm-type UpdateValidator = \Closure(UpdateInput, UpdateHandler): void
  */
@@ -85,7 +86,8 @@ final class WorkflowInstance extends Instance implements WorkflowInstanceInterfa
         $updateValidators = $prototype->getValidateUpdateHandlers();
         foreach ($prototype->getUpdateHandlers() as $method => $reflection) {
             $fn = $this->createHandler($reflection);
-            $this->updateHandlers[$method] = fn(UpdateInput $input): mixed => ($this->updateExecutor)($input, $fn);
+            $this->updateHandlers[$method] = fn(UpdateInput $input, Deferred $deferred): mixed =>
+                ($this->updateExecutor)($input, $fn, $deferred);
             // Register validate update handlers
             $this->validateUpdateHandlers[$method] = \array_key_exists($method, $updateValidators)
                 ? fn(UpdateInput $input): mixed => ($this->updateValidator)(
@@ -168,7 +170,7 @@ final class WorkflowInstance extends Instance implements WorkflowInstanceInterfa
     /**
      * @param non-empty-string $name
      *
-     * @return null|\Closure(UpdateInput): PromiseInterface
+     * @return null|\Closure(UpdateInput, Deferred): PromiseInterface
      * @psalm-return UpdateHandler|null
      */
     public function findUpdateHandler(string $name): ?\Closure
@@ -215,8 +217,8 @@ final class WorkflowInstance extends Instance implements WorkflowInstanceInterfa
         $fn = $this->createCallableHandler($handler);
 
         $this->updateHandlers[$name] = $this->pipeline->with(
-            function (UpdateInput $input) use ($fn) {
-                return ($this->updateExecutor)($input, $fn);
+            function (UpdateInput $input, Deferred $deferred) use ($fn) {
+                return ($this->updateExecutor)($input, $fn, $deferred);
             },
             /** @see WorkflowInboundCallsInterceptor::handleUpdate() */
             'handleUpdate',

--- a/src/Internal/Declaration/WorkflowInstance.php
+++ b/src/Internal/Declaration/WorkflowInstance.php
@@ -130,7 +130,7 @@ final class WorkflowInstance extends Instance implements WorkflowInstanceInterfa
     }
 
     /**
-     * @param UpdateValidator $validator
+     * @param ValidateUpdateExecutor $validator
      */
     public function setUpdateValidator(\Closure $validator): self
     {

--- a/src/Internal/Declaration/WorkflowInstanceInterface.php
+++ b/src/Internal/Declaration/WorkflowInstanceInterface.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Temporal\Internal\Declaration;
 
+use React\Promise\Deferred;
 use React\Promise\PromiseInterface;
 use Temporal\DataConverter\ValuesInterface;
 use Temporal\Interceptor\WorkflowInbound\QueryInput;
@@ -49,7 +50,7 @@ interface WorkflowInstanceInterface extends InstanceInterface
 
     /**
      * @param non-empty-string $name
-     * @return null|\Closure(UpdateInput): PromiseInterface
+     * @return null|\Closure(UpdateInput, Deferred): PromiseInterface
      */
     public function findUpdateHandler(string $name): ?\Closure;
 

--- a/src/Internal/Transport/Server.php
+++ b/src/Internal/Transport/Server.php
@@ -17,8 +17,6 @@ use Temporal\Worker\Transport\Command\FailureResponse;
 use Temporal\Worker\Transport\Command\RequestInterface;
 use Temporal\Worker\Transport\Command\ServerRequestInterface;
 use Temporal\Worker\Transport\Command\SuccessResponse;
-use Temporal\Worker\Transport\Command\UpdateResponse;
-use Temporal\Workflow\Update\UpdateResult;
 
 /**
  * @psalm-import-type OnMessageHandler from ServerInterface
@@ -82,17 +80,7 @@ final class Server implements ServerInterface
     private function onFulfilled(ServerRequestInterface $request): \Closure
     {
         return function ($result) use ($request) {
-            if ($result::class === UpdateResult::class) {
-                $response = new UpdateResponse(
-                    command: $result->command,
-                    values: $result->result,
-                    failure: $result->failure,
-                    updateId: $request->getOptions()['updateId'] ?? null,
-                );
-            } else {
-                $response = new SuccessResponse($result, $request->getID());
-            }
-
+            $response = new SuccessResponse($result, $request->getID());
             $this->queue->push($response);
 
             return $response;

--- a/src/Internal/Workflow/Process/Process.php
+++ b/src/Internal/Workflow/Process/Process.php
@@ -105,12 +105,10 @@ class Process extends Scope implements ProcessInterface
                 );
 
                 $scope->startUpdate(
-                    function () use ($handler, $inboundPipeline, $input) {
+                    function () use ($handler, $inboundPipeline, $input): mixed {
                         Workflow::setCurrentContext($this->scopeContext);
                         return $inboundPipeline->with(
-                            function (UpdateInput $input) use ($handler) {
-                                return $handler($input->arguments);
-                            },
+                            static fn(UpdateInput $input): mixed => $handler($input->arguments),
                             /** @see WorkflowInboundCallsInterceptor::handleUpdate() */
                             'handleUpdate',
                         )($input);

--- a/tests/Fixtures/src/Workflow/UpdateExceptionsWorkflow.php
+++ b/tests/Fixtures/src/Workflow/UpdateExceptionsWorkflow.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Workflow;
+
+use Carbon\CarbonInterval;
+use InvalidArgumentException;
+use Temporal\Activity\ActivityOptions;
+use Temporal\Common\RetryOptions;
+use Temporal\Workflow;
+use Temporal\Workflow\SignalMethod;
+use Temporal\Workflow\WorkflowInterface;
+use Temporal\Workflow\WorkflowMethod;
+
+#[WorkflowInterface]
+class UpdateExceptionsWorkflow
+{
+    private array $greetings = [];
+    private bool $exit = false;
+
+    #[WorkflowMethod(name: "UpdateExceptionsWorkflow.greet")]
+    public function greet()
+    {
+        $received = [];
+        while (true) {
+            yield Workflow::await(fn() => $this->greetings !== [] || $this->exit);
+            if ($this->greetings === [] && $this->exit) {
+                return $received;
+            }
+
+            $message = array_shift($this->greetings);
+            $received[] = $message;
+        }
+    }
+
+    #[Workflow\UpdateMethod]
+    public function failWithName(string $name): void
+    {
+        $this->greetings[] = $name;
+        throw new \RuntimeException("Signal exception $name");
+    }
+
+    #[Workflow\UpdateMethod]
+    public function failInvalidArgument($name = 'foo'): void
+    {
+        $this->greetings[] = "invalidArgument $name";
+        throw new InvalidArgumentException("Invalid argument $name");
+    }
+
+    #[Workflow\UpdateMethod]
+    public function failActivity($name = 'foo')
+    {
+        yield Workflow::newUntypedActivityStub(
+            ActivityOptions::new()
+                ->withScheduleToStartTimeout(1)
+                ->withRetryOptions(
+                    RetryOptions::new()->withMaximumAttempts(1)
+                )
+                ->withStartToCloseTimeout(1),
+        )->execute('nonExistingActivityName', [$name]);
+    }
+
+    #[Workflow\UpdateMethod]
+    public function error()
+    {
+        yield Workflow::timer(CarbonInterval::millisecond(10));
+        10 / 0;
+    }
+
+    #[SignalMethod]
+    public function exit(): void
+    {
+        $this->exit = true;
+    }
+}


### PR DESCRIPTION
## What was changed

Now exceptionInterceptor is used to detect that exception is error that breaks task or failure that fails update

## Checklist
<!--- add/delete as needed --->

1. Closes #463
2. How was this tested: added tests but it doesn't run in CI because not supported by test server
