### PR TITLE
Start Workflow Method after Signal if it's' signalWithStart

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         }
     },
     "require-dev": {
-        "buggregator/trap": "^1.2.2",
+        "buggregator/trap": "^1.10.1",
         "composer/composer": "^2.0",
         "dereuromark/composer-prefer-lowest": "^0.1.10",
         "doctrine/annotations": "^1.14|^2.0.0",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -109,11 +109,6 @@
       <code><![CDATA[$workflowType]]></code>
     </PropertyNotSetInConstructor>
   </file>
-  <file src="src/Client/Schedule/ScheduleHandle.php">
-    <PossiblyInvalidOperand>
-      <code><![CDATA[$timestamp->getSeconds()]]></code>
-    </PossiblyInvalidOperand>
-  </file>
   <file src="src/Client/Update/UpdateHandle.php">
     <PossiblyNullArgument>
       <code><![CDATA[$result->getSuccess()]]></code>
@@ -1123,9 +1118,6 @@
     </ArgumentTypeCoercion>
   </file>
   <file src="src/Internal/Transport/Router/StartWorkflow.php">
-    <MissingClosureReturnType>
-      <code><![CDATA[function (WorkflowInput $input) use (]]></code>
-    </MissingClosureReturnType>
     <UnnecessaryVarAnnotation>
       <code><![CDATA[Input]]></code>
     </UnnecessaryVarAnnotation>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -744,9 +744,6 @@
       <code><![CDATA[$this->format]]></code>
       <code><![CDATA[$this->format]]></code>
     </ArgumentTypeCoercion>
-    <InvalidNullableReturnType>
-      <code><![CDATA[int|Duration]]></code>
-    </InvalidNullableReturnType>
     <InvalidOperand>
       <code><![CDATA[$value * 1000000000]]></code>
       <code><![CDATA[($value * 1000000000) % 1000000000]]></code>
@@ -1228,12 +1225,6 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Internal/Workflow/Process/Scope.php">
-    <MissingClosureParamType>
-      <code><![CDATA[$result]]></code>
-    </MissingClosureParamType>
-    <MissingClosureReturnType>
-      <code><![CDATA[function ($result) {]]></code>
-    </MissingClosureReturnType>
     <PropertyNotSetInConstructor>
       <code><![CDATA[$coroutine]]></code>
     </PropertyNotSetInConstructor>
@@ -1262,9 +1253,6 @@
       <code><![CDATA[$parent]]></code>
       <code><![CDATA[$scope]]></code>
     </PropertyNotSetInConstructor>
-    <PropertyTypeCoercion>
-      <code><![CDATA[$this->parent->awaits]]></code>
-    </PropertyTypeCoercion>
   </file>
   <file src="src/Internal/Workflow/WorkflowContext.php">
     <ArgumentTypeCoercion>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -109,6 +109,11 @@
       <code><![CDATA[$workflowType]]></code>
     </PropertyNotSetInConstructor>
   </file>
+  <file src="src/Client/Schedule/ScheduleHandle.php">
+    <PossiblyInvalidOperand>
+      <code><![CDATA[$timestamp->getSeconds()]]></code>
+    </PossiblyInvalidOperand>
+  </file>
   <file src="src/Client/Update/UpdateHandle.php">
     <PossiblyNullArgument>
       <code><![CDATA[$result->getSuccess()]]></code>
@@ -739,6 +744,9 @@
       <code><![CDATA[$this->format]]></code>
       <code><![CDATA[$this->format]]></code>
     </ArgumentTypeCoercion>
+    <InvalidNullableReturnType>
+      <code><![CDATA[int|Duration]]></code>
+    </InvalidNullableReturnType>
     <InvalidOperand>
       <code><![CDATA[$value * 1000000000]]></code>
       <code><![CDATA[($value * 1000000000) % 1000000000]]></code>

--- a/src/FeatureFlags.php
+++ b/src/FeatureFlags.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal;
+
+/**
+ * Feature flags help to smoothly introduce behavior changes that may affect existing workflows.
+ * Also, there may be experimental features that are in the testing phase.
+ *
+ * The flags should be set before the SDK classes are initialized.
+ */
+final class FeatureFlags
+{
+    /**
+     * Workflow handler must be called after all signals of the same tick are processed.
+     * Set to TRUE to enable this behavior.
+     *
+     * @experimental
+     * @since SDK 2.11.0
+     * @link https://github.com/temporalio/sdk-php/issues/457
+     */
+    public static bool $workflowDeferredHandlerStart = false;
+}

--- a/src/Internal/Transport/Router/RouteInterface.php
+++ b/src/Internal/Transport/Router/RouteInterface.php
@@ -17,15 +17,12 @@ use Temporal\Worker\Transport\Command\ServerRequestInterface;
 interface RouteInterface
 {
     /**
-     * @return string
+     * @return non-empty-string
      */
     public function getName(): string;
 
     /**
-     * @param ServerRequestInterface $request
-     * @param array $headers
-     * @param Deferred $resolver
-     * @return void
+     * @throws \Throwable
      */
     public function handle(ServerRequestInterface $request, array $headers, Deferred $resolver): void;
 }

--- a/src/Internal/Transport/Router/StartWorkflow.php
+++ b/src/Internal/Transport/Router/StartWorkflow.php
@@ -39,7 +39,6 @@ final class StartWorkflow extends Route
 
     public function handle(ServerRequestInterface $request, array $headers, Deferred $resolver): void
     {
-        tr();
         $options = $request->getOptions();
         $payloads = $request->getPayloads();
         $lastCompletionResult = null;

--- a/src/Internal/Transport/Router/StartWorkflow.php
+++ b/src/Internal/Transport/Router/StartWorkflow.php
@@ -29,7 +29,7 @@ final class StartWorkflow extends Route
 {
     private const ERROR_NOT_FOUND = 'Workflow with the specified name "%s" was not registered';
 
-    private WorkflowInstantiator $instantiator;
+    private readonly WorkflowInstantiator $instantiator;
 
     public function __construct(
         private ServiceContainer $services,
@@ -39,6 +39,7 @@ final class StartWorkflow extends Route
 
     public function handle(ServerRequestInterface $request, array $headers, Deferred $resolver): void
     {
+        tr();
         $options = $request->getOptions();
         $payloads = $request->getPayloads();
         $lastCompletionResult = null;
@@ -88,7 +89,7 @@ final class StartWorkflow extends Route
             $this->services->running->add($process);
             $resolver->resolve(EncodedValues::fromValues([null]));
 
-            $process->start($instance->getHandler(), $context->getInput());
+            $process->start($instance->getHandler(), $context->getInput(), deferred: true);
         };
 
         // Define Context for interceptors Pipeline

--- a/src/Internal/Transport/Router/StartWorkflow.php
+++ b/src/Internal/Transport/Router/StartWorkflow.php
@@ -31,19 +31,12 @@ final class StartWorkflow extends Route
 
     private WorkflowInstantiator $instantiator;
 
-    /**
-     * @param ServiceContainer $services
-     */
     public function __construct(
         private ServiceContainer $services,
     ) {
         $this->instantiator = new WorkflowInstantiator($services->interceptorProvider);
     }
 
-    /**
-     * {@inheritDoc}
-     * @throws \Throwable
-     */
     public function handle(ServerRequestInterface $request, array $headers, Deferred $resolver): void
     {
         $options = $request->getOptions();
@@ -89,7 +82,7 @@ final class StartWorkflow extends Route
             $instance,
             $context,
             $runId,
-        ) {
+        ): void {
             $context = $context->withInput(new Input($input->info, $input->arguments, $input->header));
             $process = new Process($this->services, $context, $runId);
             $this->services->running->add($process);
@@ -113,10 +106,6 @@ final class StartWorkflow extends Route
             );
     }
 
-    /**
-     * @param WorkflowInfo $info
-     * @return WorkflowPrototype
-     */
     private function findWorkflowOrFail(WorkflowInfo $info): WorkflowPrototype
     {
         return $this->services->workflows->find($info->type->name) ?? throw new \OutOfRangeException(

--- a/src/Internal/Workflow/Process/DeferredGenerator.php
+++ b/src/Internal/Workflow/Process/DeferredGenerator.php
@@ -7,7 +7,10 @@ namespace Temporal\Internal\Workflow\Process;
 use Temporal\DataConverter\ValuesInterface;
 
 /**
+ * @implements \Iterator<mixed, mixed>
+ *
  * @internal
+ * @psalm-suppress PropertyNotSetInConstructor
  */
 final class DeferredGenerator implements \Iterator
 {

--- a/src/Internal/Workflow/Process/DeferredGenerator.php
+++ b/src/Internal/Workflow/Process/DeferredGenerator.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Internal\Workflow\Process;
+
+use Temporal\DataConverter\ValuesInterface;
+
+/**
+ * @internal
+ */
+final class DeferredGenerator implements \Iterator
+{
+    private bool $started = false;
+    private bool $finished = false;
+    private mixed $key = null;
+    private mixed $value = null;
+    private mixed $result = null;
+    private \Generator $generator;
+
+    /** @var array<\Closure(\Throwable): mixed> */
+    private array $catchers = [];
+
+    private \Closure $handler;
+    private ValuesInterface $values;
+
+    private function __construct() {}
+
+    /**
+     * @param \Closure(ValuesInterface): mixed $handler
+     */
+    public static function fromHandler(\Closure $handler, ValuesInterface $values): self
+    {
+        $self = new self();
+        $self->handler = $handler;
+        $self->values = $values;
+        return $self;
+    }
+
+    /**
+     * @param \Generator $generator Started generator.
+     */
+    public static function fromGenerator(\Generator $generator): self
+    {
+        $self = new self();
+        $self->generator = $generator;
+        $self->started = true;
+        $self->fill();
+        return $self;
+    }
+
+    /**
+     * Throw an exception into the generator.
+     *
+     * @note doesn't throw generator's exceptions; use {@see catch()} to handle them.
+     */
+    public function throw(\Throwable $exception): void
+    {
+        $this->started or throw new \LogicException('Cannot throw exception into a generator that was not started.');
+        $this->finished and throw new \LogicException(
+            'Cannot throw exception into a generator that was already finished.'
+        );
+        try {
+            $this->generator->throw($exception);
+            $this->fill();
+        } catch (\Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * Send a value to the generator.
+     *
+     * @note doesn't throw generator's exceptions; use {@see catch()} to handle them.
+     */
+    public function send(mixed $value): mixed
+    {
+        $this->started or throw new \LogicException('Cannot send value to a generator that was not started.');
+        $this->finished and throw new \LogicException('Cannot send value to a generator that was already finished.');
+        try {
+            $result = $this->generator->send($value);
+            $this->fill();
+            return $result;
+        } catch (\Throwable $e) {
+            $this->handleException($e);
+            return null;
+        }
+    }
+
+    /**
+     * Get the return value of the generator if it was finished.
+     */
+    public function getReturn(): mixed
+    {
+        $this->finished or throw new \LogicException('Cannot get return value of a generator that was not finished.');
+        return $this->result;
+    }
+
+    /**
+     * Get the current value of the generator.
+     */
+    public function current(): mixed
+    {
+        $this->start();
+        return $this->value;
+    }
+
+    /**
+     * Get the current key of the generator.
+     */
+    public function key(): mixed
+    {
+        $this->start();
+        return $this->key;
+    }
+
+    /**
+     * Start or resume the generator.
+     */
+    public function next(): void
+    {
+        if (!$this->started || $this->finished) {
+            $this->finished or $this->start();
+            return;
+        }
+
+        try {
+            $this->generator->next();
+            $this->fill();
+        } catch (\Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * Check if the generator is not finished.
+     *
+     * @note It starts the Generator.
+     */
+    public function valid(): bool
+    {
+        $this->start();
+        return !$this->finished;
+    }
+
+    public function rewind(): void
+    {
+        $this->started and throw new \LogicException('Cannot rewind a generator that was already run.');
+    }
+
+    /**
+     * Add an exception handler.
+     *
+     * @param \Closure(\Throwable): mixed $handler
+     */
+    public function catch(callable $handler): self
+    {
+        $this->catchers[] = $handler;
+        return $this;
+    }
+
+    private function start(): void
+    {
+        if ($this->started) {
+            return;
+        }
+
+        $this->started = true;
+        try {
+            $result = ($this->handler)($this->values);
+
+            if ($result instanceof \Generator) {
+                $this->generator = $result;
+                $this->fill();
+                return;
+            }
+
+            $this->result = $result;
+            $this->finished = true;
+        } catch (\Throwable $e) {
+            $this->handleException($e);
+        } finally {
+            unset($this->handler, $this->values);
+        }
+    }
+
+    private function fill(): void
+    {
+        $this->key = $this->generator->key();
+        $this->value = $this->generator->current();
+        $this->finished = !$this->generator->valid() and $this->result = $this->generator->getReturn();
+    }
+
+    private function handleException(\Throwable $e): void
+    {
+        $this->key = null;
+        $this->value = null;
+        $this->finished = true;
+        foreach ($this->catchers as $catch) {
+            $catch($e);
+        }
+    }
+}

--- a/src/Internal/Workflow/Process/Process.php
+++ b/src/Internal/Workflow/Process/Process.php
@@ -175,12 +175,12 @@ class Process extends Scope implements ProcessInterface
     /**
      * @param \Closure(ValuesInterface): mixed $handler
      */
-    public function start(\Closure $handler, ValuesInterface $values = null): void
+    public function start(\Closure $handler, ValuesInterface $values = null, bool $deferred = true): void
     {
         try {
             $this->makeCurrent();
             $this->context->getWorkflowInstance()->initConstructor();
-            parent::start($handler, $values);
+            parent::start($handler, $values, $deferred);
         } catch (\Throwable $e) {
             $this->complete($e);
         } finally {

--- a/src/Internal/Workflow/Process/Process.php
+++ b/src/Internal/Workflow/Process/Process.php
@@ -172,10 +172,6 @@ class Process extends Scope implements ProcessInterface
         );
     }
 
-    /**
-     * @param callable             $handler
-     * @param ValuesInterface|null $values
-     */
     public function start(callable $handler, ValuesInterface $values = null): void
     {
         try {

--- a/src/Internal/Workflow/Process/Process.php
+++ b/src/Internal/Workflow/Process/Process.php
@@ -175,7 +175,7 @@ class Process extends Scope implements ProcessInterface
     /**
      * @param \Closure(ValuesInterface): mixed $handler
      */
-    public function start(\Closure $handler, ValuesInterface $values = null, bool $deferred = true): void
+    public function start(\Closure $handler, ValuesInterface $values = null, bool $deferred): void
     {
         try {
             $this->makeCurrent();

--- a/src/Internal/Workflow/Process/Process.php
+++ b/src/Internal/Workflow/Process/Process.php
@@ -172,7 +172,10 @@ class Process extends Scope implements ProcessInterface
         );
     }
 
-    public function start(callable $handler, ValuesInterface $values = null): void
+    /**
+     * @param \Closure(ValuesInterface): mixed $handler
+     */
+    public function start(\Closure $handler, ValuesInterface $values = null): void
     {
         try {
             $this->makeCurrent();

--- a/src/Internal/Workflow/Process/Scope.php
+++ b/src/Internal/Workflow/Process/Scope.php
@@ -156,7 +156,6 @@ class Scope implements CancellationScopeInterface, Destroyable
         // Create a coroutine generator
         $this->coroutine = $this->call($handler, $values ?? EncodedValues::empty());
 
-        tr($deferred);
         $deferred
             ? $this->services->loop->once($this->layer, $this->next(...))
             : $this->next();

--- a/src/Internal/Workflow/Process/Scope.php
+++ b/src/Internal/Workflow/Process/Scope.php
@@ -151,11 +151,12 @@ class Scope implements CancellationScopeInterface, Destroyable
     /**
      * @param \Closure(ValuesInterface): mixed $handler
      */
-    public function start(\Closure $handler, ValuesInterface $values = null, bool $deferred = true): void
+    public function start(\Closure $handler, ValuesInterface $values = null, bool $deferred): void
     {
         // Create a coroutine generator
         $this->coroutine = $this->call($handler, $values ?? EncodedValues::empty());
 
+        tr($deferred);
         $deferred
             ? $this->services->loop->once($this->layer, $this->next(...))
             : $this->next();
@@ -246,7 +247,7 @@ class Scope implements CancellationScopeInterface, Destroyable
     public function startScope(callable $handler, bool $detached, string $layer = null): CancellationScopeInterface
     {
         $scope = $this->createScope($detached, $layer);
-        $scope->start($handler);
+        $scope->start($handler, null, false);
 
         return $scope;
     }

--- a/src/Internal/Workflow/Process/Scope.php
+++ b/src/Internal/Workflow/Process/Scope.php
@@ -151,12 +151,14 @@ class Scope implements CancellationScopeInterface, Destroyable
     /**
      * @param \Closure(ValuesInterface): mixed $handler
      */
-    public function start(\Closure $handler, ValuesInterface $values = null): void
+    public function start(\Closure $handler, ValuesInterface $values = null, bool $deferred = true): void
     {
         // Create a coroutine generator
         $this->coroutine = $this->call($handler, $values ?? EncodedValues::empty());
 
-        $this->next();
+        $deferred
+            ? $this->services->loop->once($this->layer, $this->next(...))
+            : $this->next();
     }
 
     /**

--- a/src/Internal/Workflow/ScopeContext.php
+++ b/src/Internal/Workflow/ScopeContext.php
@@ -26,23 +26,16 @@ class ScopeContext extends WorkflowContext implements ScopedContextInterface
 {
     private WorkflowContext $parent;
     private Scope $scope;
-    /** @var callable */
-    private $onRequest;
+    private \Closure $onRequest;
     private ?UpdateContext $updateContext = null;
 
     /**
      * Creates scope specific context.
-     *
-     * @param WorkflowContext $context
-     * @param Scope           $scope
-     * @param callable        $onRequest
-     *
-     * @return self
      */
     public static function fromWorkflowContext(
         WorkflowContext $context,
         Scope $scope,
-        callable $onRequest,
+        \Closure $onRequest,
         ?UpdateContext $updateContext,
     ): self {
         $ctx = new self(
@@ -61,31 +54,16 @@ class ScopeContext extends WorkflowContext implements ScopedContextInterface
         return $ctx;
     }
 
-    /**
-     * @param callable $handler
-     * @return CancellationScopeInterface
-     */
     public function async(callable $handler): CancellationScopeInterface
     {
         return $this->scope->startScope($handler, false);
     }
 
-    /**
-     * Cancellation scope which does not react to parent cancel and completes in background.
-     *
-     * @param callable $handler
-     * @return CancellationScopeInterface
-     */
     public function asyncDetached(callable $handler): CancellationScopeInterface
     {
         return $this->scope->startScope($handler, true);
     }
 
-    /**
-     * @param RequestInterface $request
-     * @param bool $cancellable
-     * @return PromiseInterface
-     */
     public function request(RequestInterface $request, bool $cancellable = true): PromiseInterface
     {
         if ($cancellable && $this->scope->isCancelled()) {
@@ -108,11 +86,6 @@ class ScopeContext extends WorkflowContext implements ScopedContextInterface
         return $this->updateContext;
     }
 
-    /**
-     * @param string $conditionGroupId
-     * @param callable $condition
-     * @return PromiseInterface
-     */
     protected function addCondition(string $conditionGroupId, callable $condition): PromiseInterface
     {
         $deferred = new Deferred();
@@ -127,9 +100,6 @@ class ScopeContext extends WorkflowContext implements ScopedContextInterface
         );
     }
 
-    /**
-     * Calculate unblocked conditions.
-     */
     public function resolveConditions(): void
     {
         $this->parent->resolveConditions();
@@ -145,9 +115,6 @@ class ScopeContext extends WorkflowContext implements ScopedContextInterface
         $this->parent->rejectConditionGroup($conditionGroupId);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function upsertSearchAttributes(array $searchAttributes): void
     {
         $this->request(

--- a/src/Worker/LoopInterface.php
+++ b/src/Worker/LoopInterface.php
@@ -33,36 +33,20 @@ interface LoopInterface extends EventListenerInterface
      *
      * This event MAY be emitted any number of times, which may be zero times
      * if this event loop does not send any data at all.
-     *
-     * @var string
      */
     public const ON_TICK = 'tick';
 
-    /**
-     * @var string
-     */
     public const ON_SIGNAL = 'signal';
 
-    /**
-     * @var string
-     */
     public const ON_QUERY = 'query';
 
-    /**
-     * @var string
-     */
     public const ON_CALLBACK = 'callback';
 
     /**
      * Must be emitted at the end of each loop iteration after all other events.
-     *
-     * @var string
      */
     public const ON_FINALLY = 'finally';
 
-    /**
-     * @return void
-     */
     public function tick(): void;
 
     /**
@@ -89,8 +73,6 @@ interface LoopInterface extends EventListenerInterface
      * for any of the attached listeners.
      *
      * This method MUST NOT be called while the loop is already running.
-     *
-     * @return int
      */
     public function run(): int;
 }

--- a/src/Workflow/ScopedContextInterface.php
+++ b/src/Workflow/ScopedContextInterface.php
@@ -22,9 +22,6 @@ interface ScopedContextInterface extends WorkflowContextInterface
      * The method calls an asynchronous task and returns a promise.
      *
      * @see Workflow::async()
-     *
-     * @param callable $handler
-     * @return CancellationScopeInterface
      */
     public function async(callable $handler): CancellationScopeInterface;
 
@@ -33,9 +30,6 @@ interface ScopedContextInterface extends WorkflowContextInterface
      * in background.
      *
      * @see Workflow::asyncDetached()
-     *
-     * @param callable $handler
-     * @return CancellationScopeInterface
      */
     public function asyncDetached(callable $handler): CancellationScopeInterface;
 }

--- a/tests/Acceptance/App/Feature/WorkflowStubInjector.php
+++ b/tests/Acceptance/App/Feature/WorkflowStubInjector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Acceptance\App\Feature;
 
+use Temporal\Common\IdReusePolicy;
 use Temporal\Tests\Acceptance\App\Attribute\Stub;
 use Temporal\Tests\Acceptance\App\Runtime\Feature;
 use Psr\Container\ContainerInterface;
@@ -43,7 +44,9 @@ final class WorkflowStubInjector implements InjectorInterface
             ->withTaskQueue($feature->taskQueue)
             ->withEagerStart($attribute->eagerStart);
 
-        $attribute->workflowId === null or $options = $options->withWorkflowId($attribute->workflowId);
+        $attribute->workflowId === null or $options = $options
+            ->withWorkflowId($attribute->workflowId)
+            ->withWorkflowIdReusePolicy(IdReusePolicy::AllowDuplicate);
         $attribute->memo === [] or $options = $options->withMemo($attribute->memo);
 
         $stub = $client->newUntypedWorkflowStub($attribute->type, $options);

--- a/tests/Acceptance/App/RuntimeBuilder.php
+++ b/tests/Acceptance/App/RuntimeBuilder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Temporal\Tests\Acceptance\App;
 
 use PHPUnit\Framework\Attributes\Test;
+use Temporal\FeatureFlags;
 use Temporal\Tests\Acceptance\App\Input\Command;
 use Temporal\Tests\Acceptance\App\Input\Feature;
 use Temporal\Tests\Acceptance\App\Runtime\State;
@@ -68,6 +69,7 @@ final class RuntimeBuilder
     public static function init(): void
     {
         \ini_set('display_errors', 'stderr');
+        FeatureFlags::$workflowDeferredHandlerStart = true;
     }
 
     /**

--- a/tests/Acceptance/Harness/Signal/SignalWithStartTest.php
+++ b/tests/Acceptance/Harness/Signal/SignalWithStartTest.php
@@ -23,8 +23,6 @@ class SignalWithStartTest extends TestCase
         WorkflowClientInterface $client,
         Feature $feature,
     ): void {
-        self::markTestSkipped('See https://github.com/temporalio/sdk-php/issues/457');
-
         $stub = $client->newWorkflowStub(
             FeatureWorkflow::class,
             WorkflowOptions::new()->withTaskQueue($feature->taskQueue),


### PR DESCRIPTION
## What was changed

A fix has been added where the Workflow Method starts after the initial signals on signalWithStart().
To avoid a breaking change, the class `\Temporal\FeatureFlags` with the flag `$workflowDeferredInitialization = false` was added. To activate the new behavior, set this flag to `true`.

```php
// Set flags
\Temporal\FeatureFlags::$workflowDeferredHandlerStart = true;

// Create Workers
$factory = WorkerFactory::create();
// ...
```

> [!NOTE]
> The feature marked as experimental

## Checklist

1. Closes #457 
2. How was this tested: added autotest
3. Any docs updates needed?
