### PR TITLE
Expose `WorkflowStub::getUpdateHandle`

### DIFF
--- a/src/Client/WorkflowStubInterface.php
+++ b/src/Client/WorkflowStubInterface.php
@@ -13,6 +13,7 @@ namespace Temporal\Client;
 
 use Temporal\Client\Update\UpdateHandle;
 use Temporal\Client\Update\UpdateOptions;
+use Temporal\DataConverter\Type;
 use Temporal\DataConverter\ValuesInterface;
 use Temporal\Exception\IllegalStateException;
 use Temporal\Workflow\CancellationScopeInterface;
@@ -109,6 +110,14 @@ interface WorkflowStubInterface extends WorkflowRunInterface
      * @return UpdateHandle
      */
     public function startUpdate(string|UpdateOptions $nameOrOptions, ...$args): UpdateHandle;
+
+    /**
+     * Get a handle to an existing update request.
+     *
+     * @param non-empty-string $updateId
+     * @param string|\ReflectionClass|\ReflectionType|Type|null $resultType
+     */
+    public function getUpdateHandle(string $updateId, mixed $resultType = null): UpdateHandle;
 
     /**
      * Request cancellation of a workflow execution.

--- a/src/Exception/Client/WorkflowFailedException.php
+++ b/src/Exception/Client/WorkflowFailedException.php
@@ -19,7 +19,7 @@ class WorkflowFailedException extends WorkflowException
 
     /**
      * @param WorkflowExecution $execution
-     * @param string|null $type
+     * @param non-empty-string|null $type
      * @param int $lastWorkflowTaskCompletedEventId
      * @param int $retryState
      * @param \Throwable|null $previous
@@ -31,12 +31,7 @@ class WorkflowFailedException extends WorkflowException
         int $retryState,
         \Throwable $previous = null
     ) {
-        parent::__construct(
-            null,
-            $execution,
-            $type,
-            $previous
-        );
+        parent::__construct(null, $execution, $type, $previous);
 
         $this->message = self::buildMessage(
             [

--- a/src/Internal/Client/WorkflowStub.php
+++ b/src/Internal/Client/WorkflowStub.php
@@ -90,10 +90,10 @@ final class WorkflowStub implements WorkflowStubInterface, HeaderCarrier
      * @param WorkflowOptions|null $options
      */
     public function __construct(
-        private ServiceClientInterface $serviceClient,
-        private ClientOptions $clientOptions,
-        private DataConverterInterface $converter,
-        private Pipeline $interceptors,
+        private readonly ServiceClientInterface $serviceClient,
+        private readonly ClientOptions $clientOptions,
+        private readonly DataConverterInterface $converter,
+        private readonly Pipeline $interceptors,
         private ?string $workflowType = null,
         private ?WorkflowOptions $options = null,
     ) {
@@ -401,9 +401,30 @@ final class WorkflowStub implements WorkflowStubInterface, HeaderCarrier
             client: $this->serviceClient,
             clientOptions: $clientOptions,
             converter: $this->converter,
-            updateInput: $updateInput,
-            updateRef: $result->getReference(),
+            execution: $result->getReference()->workflowExecution,
+            workflowType: $updateInput->workflowType,
+            updateName: $updateInput->updateName,
+            resultType: $updateInput->resultType,
+            updateId: $result->getReference()->updateId,
             result: $result->getResult(),
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getUpdateHandle(string $updateId, mixed $resultType = null): UpdateHandle
+    {
+        return new UpdateHandle(
+            client: $this->serviceClient,
+            clientOptions: $this->clientOptions,
+            converter: $this->converter,
+            execution: $this->getExecution(),
+            workflowType: $this->workflowType,
+            updateName: '',
+            resultType: $resultType,
+            updateId: $updateId,
+            result: null,
         );
     }
 

--- a/tests/Acceptance/Harness/Update/AsyncAcceptTest.php
+++ b/tests/Acceptance/Harness/Update/AsyncAcceptTest.php
@@ -34,9 +34,10 @@ class AsyncAcceptTest extends TestCase
         );
 
         $this->assertHandleIsBlocked($handle);
-        // todo: Create a separate handle to the same update
-        // $otherHandle = $stub->getUpdateHandle($updateId)
-        // $this->assertHandleIsBlocked($otherHandle);
+        // Create a separate handle to the same update
+        $otherHandle = $stub->getUpdateHandle($updateId);
+        $this->assertHandleIsBlocked($otherHandle);
+
         # Unblock last update
         $stub->signal('unblock');
         self::assertSame(123, $handle->getResult());


### PR DESCRIPTION
## What was changed

Added method `\Temporal\Client\WorkflowStubInterface::getUpdateHandle()`

```php
$stub = $workflowClient->newUntypedRunningWorkflowStub($wfId, $wfRunId, $wfType);

$handle = $stub->getUpdateHandle($updateId);
$handle->getResult(5);
```

## Checklist

1. Closes #458
2. How was this tested: added autotest
