### PR TITLE
Remove final from WorkflowInterface

### DIFF
--- a/src/Workflow/WorkflowInterface.php
+++ b/src/Workflow/WorkflowInterface.php
@@ -26,6 +26,6 @@ use Spiral\Attributes\NamedArgumentConstructor;
  *  Problem is relevant for doctrine/annotations 1.11 or lower on any PHP version.
  */
 #[\Attribute(\Attribute::TARGET_CLASS), NamedArgumentConstructor]
-final class WorkflowInterface
+class WorkflowInterface
 {
 }


### PR DESCRIPTION
## What was changed

I made the WorkflowInterface attribute not final

## Why?

I am extending this attribute to allow myself to add more properties. The additional properties will help me with building the container and workers. 

Example:

```php
use Temporal\Workflow\WorkflowInterface;

class MyWorkflowInterface extends WorkflowInterface
{
    public function __construct(
        public string $workerName, 
    ){}
}
```

Now I can create a bunch of worker configuration and map it with my workflows and let my applications service container build the workers for me. 

This is similar to `ActivityInterface` attribute. 

## Checklist
1. How was this tested:

I did not test at all. 

2. Any docs updates needed?

Nope
