### PR TITLE
Warn about unfinished handlers

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -533,11 +533,6 @@
       <code><![CDATA[$reflection]]></code>
     </RedundantCondition>
   </file>
-  <file src="src/Internal/Declaration/Prototype/WorkflowPrototype.php">
-    <PropertyTypeCoercion>
-      <code><![CDATA[$this->queryHandlers]]></code>
-    </PropertyTypeCoercion>
-  </file>
   <file src="src/Internal/Declaration/Reader/ActivityReader.php">
     <ArgumentTypeCoercion>
       <code><![CDATA[$contextualRetry]]></code>
@@ -558,7 +553,6 @@
       <code><![CDATA[$method]]></code>
       <code><![CDATA[$name]]></code>
       <code><![CDATA[$retry]]></code>
-      <code><![CDATA[$signal->name ?? $ctx->getName()]]></code>
     </ArgumentTypeCoercion>
     <InvalidArgument>
       <code><![CDATA[\reset($prototypes)]]></code>

--- a/src/FeatureFlags.php
+++ b/src/FeatureFlags.php
@@ -21,4 +21,10 @@ final class FeatureFlags
      * @link https://github.com/temporalio/sdk-php/issues/457
      */
     public static bool $workflowDeferredHandlerStart = false;
+
+    /**
+     * Warn about running Signal and Update handlers on Workflow finish.
+     * It uses `error_log()` function to output a warning message.
+     */
+    public static bool $warnOnWorkflowUnfinishedHandlers = true;
 }

--- a/src/Interceptor/WorkflowInbound/SignalInput.php
+++ b/src/Interceptor/WorkflowInbound/SignalInput.php
@@ -19,6 +19,8 @@ use Temporal\Workflow\WorkflowInfo;
 class SignalInput
 {
     /**
+     * @param non-empty-string $signalName
+     *
      * @no-named-arguments
      * @internal Don't use the constructor. Use {@see self::with()} instead.
      */

--- a/src/Internal/Client/WorkflowProxy.php
+++ b/src/Internal/Client/WorkflowProxy.php
@@ -59,11 +59,11 @@ final class WorkflowProxy extends Proxy
         }
 
         // Otherwise, we try to find a suitable workflow "query" method.
-        foreach ($this->prototype->getQueryHandlers() as $name => $query) {
-            if ($query->getName() === $method) {
-                $args = Reflection::orderArguments($query, $args);
+        foreach ($this->prototype->getQueryHandlers() as $name => $definition) {
+            if ($definition->method->getName() === $method) {
+                $args = Reflection::orderArguments($definition->method, $args);
 
-                return $this->stub->query($name, ...$args)?->getValue(0, $query->getReturnType());
+                return $this->stub->query($name, ...$args)?->getValue(0, $definition->returnType);
             }
         }
 

--- a/src/Internal/Client/WorkflowProxy.php
+++ b/src/Internal/Client/WorkflowProxy.php
@@ -40,6 +40,8 @@ final class WorkflowProxy extends Proxy
     /**
      * @param non-empty-string $method
      * @return mixed|void
+     *
+     * @psalm-suppress MoreSpecificImplementedParamType
      */
     public function __call(string $method, array $args)
     {

--- a/src/Internal/Client/WorkflowProxy.php
+++ b/src/Internal/Client/WorkflowProxy.php
@@ -85,18 +85,13 @@ final class WorkflowProxy extends Proxy
         }
 
         // Otherwise, we try to find a suitable workflow "update" method.
-        foreach ($this->prototype->getUpdateHandlers() as $name => $update) {
-            if ($update->getName() === $method) {
-                $args = Reflection::orderArguments($update, $args);
-                $attrs = $update->getAttributes(ReturnType::class);
-
-                $returnType = \array_key_exists(0, $attrs)
-                    ? $attrs[0]->newInstance()
-                    : $update->getReturnType();
+        foreach ($this->prototype->getUpdateHandlers() as $name => $definition) {
+            if ($definition->method->getName() === $method) {
+                $args = Reflection::orderArguments($definition->method, $args);
 
                 $options = UpdateOptions::new($name)
                     ->withUpdateName($name)
-                    ->withResultType($returnType)
+                    ->withResultType($definition->returnType)
                     ->withWaitPolicy(WaitPolicy::new()->withLifecycleStage(LifecycleStage::StageCompleted));
 
                 return $this->stub->startUpdate($options, ...$args)->getResult();

--- a/src/Internal/Declaration/Instance.php
+++ b/src/Internal/Declaration/Instance.php
@@ -28,7 +28,7 @@ abstract class Instance implements InstanceInterface
 
     public function __construct(
         Prototype $prototype,
-        protected readonly object $context,
+        protected object $context,
     ) {
         $handler = $prototype->getHandler();
 

--- a/src/Internal/Declaration/Instance.php
+++ b/src/Internal/Declaration/Instance.php
@@ -19,7 +19,7 @@ use Temporal\Internal\Declaration\Prototype\Prototype;
 /**
  * @psalm-import-type DispatchableHandler from InstanceInterface
  */
-abstract class Instance implements InstanceInterface
+abstract class Instance implements InstanceInterface, Destroyable
 {
     /**
      * @var \Closure(ValuesInterface): mixed
@@ -67,5 +67,10 @@ abstract class Instance implements InstanceInterface
 
         $context = $this->context;
         return static fn (ValuesInterface $values): mixed => $valueMapper->dispatchValues($context, $values);
+    }
+
+    public function destroy(): void
+    {
+        unset($this->handler, $this->context);
     }
 }

--- a/src/Internal/Declaration/Prototype/QueryDefinition.php
+++ b/src/Internal/Declaration/Prototype/QueryDefinition.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Internal\Declaration\Prototype;
+
+/**
+ * @internal
+ */
+final class QueryDefinition
+{
+    /**
+     * @param non-empty-string $name
+     */
+    public function __construct(
+        public readonly string $name,
+        public readonly mixed $returnType,
+        public readonly \ReflectionMethod $method,
+    ) {}
+}

--- a/src/Internal/Declaration/Prototype/SignalDefinition.php
+++ b/src/Internal/Declaration/Prototype/SignalDefinition.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Internal\Declaration\Prototype;
+
+use Temporal\Workflow\HandlerUnfinishedPolicy;
+
+/**
+ * @internal
+ */
+final class SignalDefinition
+{
+    /**
+     * @param non-empty-string $name
+     */
+    public function __construct(
+        public readonly string $name,
+        public readonly HandlerUnfinishedPolicy $policy,
+        public readonly \ReflectionMethod $method,
+    ) {}
+}

--- a/src/Internal/Declaration/Prototype/UpdateDefinition.php
+++ b/src/Internal/Declaration/Prototype/UpdateDefinition.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Internal\Declaration\Prototype;
+
+use Temporal\Workflow\HandlerUnfinishedPolicy;
+
+/**
+ * @internal
+ */
+final class UpdateDefinition
+{
+    /**
+     * @param non-empty-string $name
+     */
+    public function __construct(
+        public readonly string $name,
+        public readonly HandlerUnfinishedPolicy $policy,
+        public readonly mixed $returnType,
+        public readonly \ReflectionMethod $method,
+    ) {}
+}

--- a/src/Internal/Declaration/Prototype/WorkflowPrototype.php
+++ b/src/Internal/Declaration/Prototype/WorkflowPrototype.php
@@ -28,7 +28,7 @@ final class WorkflowPrototype extends Prototype
     private array $signalHandlers = [];
 
     /**
-     * @var array<non-empty-string, \ReflectionFunctionAbstract>
+     * @var array<non-empty-string, UpdateDefinition>
      */
     private array $updateHandlers = [];
 
@@ -136,11 +136,11 @@ final class WorkflowPrototype extends Prototype
 
     /**
      * @param non-empty-string $name
-     * @param \ReflectionFunctionAbstract $fun
+     * @param \ReflectionFunctionAbstract $reflection
      */
-    public function addUpdateHandler(string $name, \ReflectionFunctionAbstract $fun): void
+    public function addUpdateHandler(UpdateDefinition $definition): void
     {
-        $this->updateHandlers[$name] = $fun;
+        $this->updateHandlers[$definition->name] = $definition;
     }
 
     /**
@@ -153,7 +153,7 @@ final class WorkflowPrototype extends Prototype
     }
 
     /**
-     * @return array<non-empty-string, \ReflectionFunctionAbstract>
+     * @return array<non-empty-string, UpdateDefinition>
      */
     public function getUpdateHandlers(): array
     {

--- a/src/Internal/Declaration/Prototype/WorkflowPrototype.php
+++ b/src/Internal/Declaration/Prototype/WorkflowPrototype.php
@@ -23,7 +23,7 @@ final class WorkflowPrototype extends Prototype
     private array $queryHandlers = [];
 
     /**
-     * @var array<non-empty-string, \ReflectionFunctionAbstract>
+     * @var array<non-empty-string, SignalDefinition>
      */
     private array $signalHandlers = [];
 
@@ -117,27 +117,19 @@ final class WorkflowPrototype extends Prototype
         return $this->queryHandlers;
     }
 
-    /**
-     * @param non-empty-string $name
-     * @param \ReflectionFunctionAbstract $fun
-     */
-    public function addSignalHandler(string $name, \ReflectionFunctionAbstract $fun): void
+    public function addSignalHandler(SignalDefinition $definition): void
     {
-        $this->signalHandlers[$name] = $fun;
+        $this->signalHandlers[$definition->name] = $definition;
     }
 
     /**
-     * @return iterable<non-empty-string, \ReflectionFunctionAbstract>
+     * @return array<non-empty-string, SignalDefinition>
      */
     public function getSignalHandlers(): iterable
     {
         return $this->signalHandlers;
     }
 
-    /**
-     * @param non-empty-string $name
-     * @param \ReflectionFunctionAbstract $reflection
-     */
     public function addUpdateHandler(UpdateDefinition $definition): void
     {
         $this->updateHandlers[$definition->name] = $definition;

--- a/src/Internal/Declaration/Prototype/WorkflowPrototype.php
+++ b/src/Internal/Declaration/Prototype/WorkflowPrototype.php
@@ -18,7 +18,7 @@ use Temporal\Workflow\ReturnType;
 final class WorkflowPrototype extends Prototype
 {
     /**
-     * @var array<non-empty-string, \ReflectionFunctionAbstract>
+     * @var array<non-empty-string, QueryDefinition>
      */
     private array $queryHandlers = [];
 
@@ -100,19 +100,15 @@ final class WorkflowPrototype extends Prototype
         $this->returnType = $attribute;
     }
 
-    /**
-     * @param string $name
-     * @param \ReflectionFunctionAbstract $fun
-     */
-    public function addQueryHandler(string $name, \ReflectionFunctionAbstract $fun): void
+    public function addQueryHandler(QueryDefinition $definition): void
     {
-        $this->queryHandlers[$name] = $fun;
+        $this->queryHandlers[$definition->name] = $definition;
     }
 
     /**
-     * @return iterable<non-empty-string, \ReflectionFunctionAbstract>
+     * @return array<non-empty-string, QueryDefinition>
      */
-    public function getQueryHandlers(): iterable
+    public function getQueryHandlers(): array
     {
         return $this->queryHandlers;
     }
@@ -125,7 +121,7 @@ final class WorkflowPrototype extends Prototype
     /**
      * @return array<non-empty-string, SignalDefinition>
      */
-    public function getSignalHandlers(): iterable
+    public function getSignalHandlers(): array
     {
         return $this->signalHandlers;
     }

--- a/src/Internal/Declaration/Reader/WorkflowReader.php
+++ b/src/Internal/Declaration/Reader/WorkflowReader.php
@@ -15,6 +15,7 @@ use Temporal\Common\CronSchedule;
 use Temporal\Common\MethodRetry;
 use Temporal\Internal\Declaration\Graph\ClassNode;
 use Temporal\Internal\Declaration\Prototype\ActivityPrototype;
+use Temporal\Internal\Declaration\Prototype\QueryDefinition;
 use Temporal\Internal\Declaration\Prototype\SignalDefinition;
 use Temporal\Internal\Declaration\Prototype\UpdateDefinition;
 use Temporal\Internal\Declaration\Prototype\WorkflowPrototype;
@@ -200,7 +201,13 @@ class WorkflowReader extends Reader
                     );
                 }
 
-                $prototype->addQueryHandler($query->name ?? $method->getName(), $method);
+                $prototype->addQueryHandler(
+                    new QueryDefinition(
+                        name: $query->name ?? $method->getName(),
+                        returnType: $method->getReturnType(),
+                        method: $method,
+                    ),
+                );
             }
         }
 

--- a/src/Internal/Declaration/Reader/WorkflowReader.php
+++ b/src/Internal/Declaration/Reader/WorkflowReader.php
@@ -15,6 +15,7 @@ use Temporal\Common\CronSchedule;
 use Temporal\Common\MethodRetry;
 use Temporal\Internal\Declaration\Graph\ClassNode;
 use Temporal\Internal\Declaration\Prototype\ActivityPrototype;
+use Temporal\Internal\Declaration\Prototype\SignalDefinition;
 use Temporal\Internal\Declaration\Prototype\UpdateDefinition;
 use Temporal\Internal\Declaration\Prototype\WorkflowPrototype;
 use Temporal\Workflow\QueryMethod;
@@ -175,7 +176,13 @@ class WorkflowReader extends Reader
                     );
                 }
 
-                $prototype->addSignalHandler($signal->name ?? $method->getName(), $method);
+                $prototype->addSignalHandler(
+                    new SignalDefinition(
+                        name: $signal->name ?? $method->getName(),
+                        policy: $signal->unfinishedPolicy,
+                        method: $method,
+                    ),
+                );
             }
 
             /** @var QueryMethod|null $query */

--- a/src/Internal/Declaration/WorkflowInstance.php
+++ b/src/Internal/Declaration/WorkflowInstance.php
@@ -65,14 +65,13 @@ final class WorkflowInstance extends Instance implements WorkflowInstanceInterfa
     private \Closure $updateValidator;
 
     /**
-     * @param WorkflowPrototype $prototype
      * @param object $context Workflow object
      * @param Interceptor\Pipeline<WorkflowInboundCallsInterceptor, mixed> $pipeline
      */
     public function __construct(
-        WorkflowPrototype $prototype,
+        private WorkflowPrototype $prototype,
         object $context,
-        private readonly Interceptor\Pipeline $pipeline,
+        private Interceptor\Pipeline $pipeline,
     ) {
         parent::__construct($prototype, $context);
 
@@ -267,7 +266,12 @@ final class WorkflowInstance extends Instance implements WorkflowInstanceInterfa
         $this->signalQueue->clear();
         $this->signalHandlers = [];
         $this->queryHandlers = [];
-        unset($this->queryExecutor);
+        unset($this->queryExecutor, $this->prototype, $this->pipeline, $this->context);
+    }
+
+    public function getPrototype(): WorkflowPrototype
+    {
+        return $this->prototype;
     }
 
     /**

--- a/src/Internal/Declaration/WorkflowInstance.php
+++ b/src/Internal/Declaration/WorkflowInstance.php
@@ -97,8 +97,8 @@ final class WorkflowInstance extends Instance implements WorkflowInstanceInterfa
                 : null;
         }
 
-        foreach ($prototype->getQueryHandlers() as $name => $reflection) {
-            $fn = $this->createHandler($reflection);
+        foreach ($prototype->getQueryHandlers() as $name => $definition) {
+            $fn = $this->createHandler($definition->method);
             $this->queryHandlers[$name] = $this->pipeline->with(
                 function (QueryInput $input) use ($fn): mixed {
                     return ($this->queryExecutor)($input, $fn);

--- a/src/Internal/Declaration/WorkflowInstance.php
+++ b/src/Internal/Declaration/WorkflowInstance.php
@@ -31,7 +31,7 @@ use Temporal\Internal\Interceptor;
  * @psalm-type ValidateUpdateExecutor = \Closure(UpdateInput, callable(ValuesInterface): mixed): mixed
  * @psalm-type UpdateValidator = \Closure(UpdateInput, UpdateHandler): void
  */
-final class WorkflowInstance extends Instance implements WorkflowInstanceInterface, Destroyable
+final class WorkflowInstance extends Instance implements WorkflowInstanceInterface
 {
     /**
      * @var array<non-empty-string, QueryHandler>
@@ -266,7 +266,16 @@ final class WorkflowInstance extends Instance implements WorkflowInstanceInterfa
         $this->signalQueue->clear();
         $this->signalHandlers = [];
         $this->queryHandlers = [];
-        unset($this->queryExecutor, $this->prototype, $this->pipeline, $this->context);
+        $this->updateHandlers = [];
+        $this->validateUpdateHandlers = [];
+        unset(
+            $this->queryExecutor,
+            $this->updateExecutor,
+            $this->updateValidator,
+            $this->prototype,
+            $this->pipeline,
+        );
+        parent::destroy();
     }
 
     public function getPrototype(): WorkflowPrototype

--- a/src/Internal/Declaration/WorkflowInstance.php
+++ b/src/Internal/Declaration/WorkflowInstance.php
@@ -84,8 +84,8 @@ final class WorkflowInstance extends Instance implements WorkflowInstanceInterfa
         }
 
         $updateValidators = $prototype->getValidateUpdateHandlers();
-        foreach ($prototype->getUpdateHandlers() as $method => $reflection) {
-            $fn = $this->createHandler($reflection);
+        foreach ($prototype->getUpdateHandlers() as $method => $definition) {
+            $fn = $this->createHandler($definition->method);
             $this->updateHandlers[$method] = fn(UpdateInput $input, Deferred $deferred): mixed =>
                 ($this->updateExecutor)($input, $fn, $deferred);
             // Register validate update handlers

--- a/src/Internal/Declaration/WorkflowInstanceInterface.php
+++ b/src/Internal/Declaration/WorkflowInstanceInterface.php
@@ -16,6 +16,7 @@ use React\Promise\PromiseInterface;
 use Temporal\DataConverter\ValuesInterface;
 use Temporal\Interceptor\WorkflowInbound\QueryInput;
 use Temporal\Interceptor\WorkflowInbound\UpdateInput;
+use Temporal\Internal\Declaration\Prototype\WorkflowPrototype;
 
 interface WorkflowInstanceInterface extends InstanceInterface
 {
@@ -61,4 +62,6 @@ interface WorkflowInstanceInterface extends InstanceInterface
     public function addSignalHandler(string $name, callable $handler): void;
 
     public function clearSignalQueue(): void;
+
+    public function getPrototype(): WorkflowPrototype;
 }

--- a/src/Internal/Transport/Router/GetWorkerInfo.php
+++ b/src/Internal/Transport/Router/GetWorkerInfo.php
@@ -66,8 +66,8 @@ final class GetWorkerInfo extends Route
         $workflowMap = function (WorkflowPrototype $workflow) {
             return [
                 'Name'    => $workflow->getID(),
-                'Queries' => $this->keys($workflow->getQueryHandlers()),
-                'Signals' => $this->keys($workflow->getSignalHandlers()),
+                'Queries' => \array_keys($workflow->getQueryHandlers()),
+                'Signals' => \array_keys($workflow->getSignalHandlers()),
                 // 'Updates' => $this->keys($workflow->getUpdateHandlers()),
             ];
         };
@@ -98,21 +98,6 @@ final class GetWorkerInfo extends Route
 
         foreach ($items as $key => $value) {
             $result[] = $map($value, $key);
-        }
-
-        return $result;
-    }
-
-    /**
-     * @param iterable $items
-     * @return array
-     */
-    private function keys(iterable $items): array
-    {
-        $result = [];
-
-        foreach ($items as $key => $_) {
-            $result[] = $key;
         }
 
         return $result;

--- a/src/Internal/Workflow/ChildWorkflowProxy.php
+++ b/src/Internal/Workflow/ChildWorkflowProxy.php
@@ -86,9 +86,9 @@ final class ChildWorkflowProxy extends Proxy
         }
 
         // Otherwise, we try to find a suitable workflow "signal" method.
-        foreach ($this->workflow->getSignalHandlers() as $name => $signal) {
-            if ($signal->getName() === $method) {
-                $args = Reflection::orderArguments($signal, $args);
+        foreach ($this->workflow->getSignalHandlers() as $name => $definition) {
+            if ($definition->method->getName() === $method) {
+                $args = Reflection::orderArguments($definition->method, $args);
 
                 return $this->stub->signal($name, $args);
             }

--- a/src/Internal/Workflow/ChildWorkflowProxy.php
+++ b/src/Internal/Workflow/ChildWorkflowProxy.php
@@ -95,12 +95,10 @@ final class ChildWorkflowProxy extends Proxy
         }
 
         // Otherwise, we try to find a suitable workflow "query" method.
-        foreach ($this->workflow->getQueryHandlers() as $name => $query) {
-            if ($query->getName() === $method) {
-                throw new \BadMethodCallException(
-                    \sprintf(self::ERROR_UNSUPPORTED_METHOD, $method, $name)
-                );
-            }
+        foreach ($this->workflow->getQueryHandlers() as $name => $definition) {
+            $definition->method->getName() === $method and throw new \BadMethodCallException(
+                \sprintf(self::ERROR_UNSUPPORTED_METHOD, $method, $name)
+            );
         }
 
         throw new \BadMethodCallException(

--- a/src/Internal/Workflow/ExternalWorkflowProxy.php
+++ b/src/Internal/Workflow/ExternalWorkflowProxy.php
@@ -60,9 +60,9 @@ class ExternalWorkflowProxy extends Proxy
      */
     public function __call(string $method, array $args): PromiseInterface
     {
-        foreach ($this->workflow->getSignalHandlers() as $name => $reflection) {
-            if ($method === $reflection->getName()) {
-                $args = Reflection::orderArguments($reflection, $args);
+        foreach ($this->workflow->getSignalHandlers() as $name => $definition) {
+            if ($method === $definition->method->getName()) {
+                $args = Reflection::orderArguments($definition->method, $args);
 
                 return $this->stub->signal($name, $args);
             }

--- a/src/Internal/Workflow/Process/HandlerState.php
+++ b/src/Internal/Workflow/Process/HandlerState.php
@@ -9,6 +9,33 @@ namespace Temporal\Internal\Workflow\Process;
  */
 final class HandlerState
 {
-    public int $updates = 0;
-    public int $signals = 0;
+    private int $updates = 0;
+    private int $signals = 0;
+
+    public function hasRunningHandlers(): bool
+    {
+        return $this->updates > 0 || $this->signals > 0;
+    }
+
+    public function addUpdate($name): int
+    {
+        ++$this->updates;
+        return 0;
+    }
+
+    public function removeUpdate(int $updateId): void
+    {
+        --$this->updates;
+    }
+
+    public function addSignal($name): int
+    {
+        ++$this->signals;
+        return 0;
+    }
+
+    public function removeSignal(int $signalId): void
+    {
+        --$this->signals;
+    }
 }

--- a/src/Internal/Workflow/Process/HandlerState.php
+++ b/src/Internal/Workflow/Process/HandlerState.php
@@ -9,7 +9,10 @@ namespace Temporal\Internal\Workflow\Process;
  */
 final class HandlerState
 {
+    /** @var array<int, array{id: non-empty-string, name: non-empty-string}> */
     private array $updates = [];
+
+    /** @var array<int, non-empty-string> */
     private array $signals = [];
 
     public function hasRunningHandlers(): bool
@@ -17,41 +20,48 @@ final class HandlerState
         return \count($this->updates) > 0 || \count($this->signals) > 0;
     }
 
-    public function addUpdate($name): int
+    /**
+     * @param non-empty-string $id
+     * @param non-empty-string $name
+     */
+    public function addUpdate(string $id, string $name): int
     {
-        $this->updates[] = $name;
+        $this->updates[] = ['id' => $id, 'name' => $name];
         return \array_key_last($this->updates);
     }
 
-    public function removeUpdate(int $updateId): void
+    public function removeUpdate(int $recordId): void
     {
-        unset($this->updates[$updateId]);
+        unset($this->updates[$recordId]);
     }
 
-    public function addSignal($name): int
+    /**
+     * @param non-empty-string $name
+     */
+    public function addSignal(string $name): int
     {
         $this->signals[] = $name;
         return \array_key_last($this->signals);
     }
 
-    public function removeSignal(int $signalId): void
+    public function removeSignal(int $recordId): void
     {
-        unset($this->signals[$signalId]);
+        unset($this->signals[$recordId]);
     }
 
     /**
-     * @return list<non-empty-string> List of signal names
+     * @return array<non-empty-string, int<1, max>> Signal name => count
      */
     public function getRunningSignals(): array
     {
-        return \array_unique($this->signals);
+        return \array_count_values($this->signals);
     }
 
     /**
-     * @return list<non-empty-string> List of update names
+     * @return array<int, array{id: non-empty-string, name: non-empty-string}>
      */
     public function getRunningUpdates(): array
     {
-        return \array_unique($this->updates);
+        return $this->updates;
     }
 }

--- a/src/Internal/Workflow/Process/HandlerState.php
+++ b/src/Internal/Workflow/Process/HandlerState.php
@@ -9,33 +9,49 @@ namespace Temporal\Internal\Workflow\Process;
  */
 final class HandlerState
 {
-    private int $updates = 0;
-    private int $signals = 0;
+    private array $updates = [];
+    private array $signals = [];
 
     public function hasRunningHandlers(): bool
     {
-        return $this->updates > 0 || $this->signals > 0;
+        return \count($this->updates) > 0 || \count($this->signals) > 0;
     }
 
     public function addUpdate($name): int
     {
-        ++$this->updates;
-        return 0;
+        $this->updates[] = $name;
+        return \array_key_last($this->updates);
     }
 
     public function removeUpdate(int $updateId): void
     {
-        --$this->updates;
+        unset($this->updates[$updateId]);
     }
 
     public function addSignal($name): int
     {
-        ++$this->signals;
-        return 0;
+        $this->signals[] = $name;
+        return \array_key_last($this->signals);
     }
 
     public function removeSignal(int $signalId): void
     {
-        --$this->signals;
+        unset($this->signals[$signalId]);
+    }
+
+    /**
+     * @return list<non-empty-string> List of signal names
+     */
+    public function getRunningSignals(): array
+    {
+        return \array_unique($this->signals);
+    }
+
+    /**
+     * @return list<non-empty-string> List of update names
+     */
+    public function getRunningUpdates(): array
+    {
+        return \array_unique($this->updates);
     }
 }

--- a/src/Internal/Workflow/Process/Process.php
+++ b/src/Internal/Workflow/Process/Process.php
@@ -44,7 +44,7 @@ class Process extends Scope implements ProcessInterface
     public function __construct(
         ServiceContainer $services,
         WorkflowContext $ctx,
-        private string $runId,
+        private readonly string $runId,
     ) {
         parent::__construct($services, $ctx);
 
@@ -115,6 +115,7 @@ class Process extends Scope implements ProcessInterface
                     },
                     $input->arguments,
                     $resolver,
+                    $input->updateName,
                 );
 
                 return $scope->promise();
@@ -146,7 +147,8 @@ class Process extends Scope implements ProcessInterface
                             }
                         )->startSignal(
                             $handler,
-                            $input->arguments
+                            $input->arguments,
+                            $input->signalName,
                         );
                     },
                     /** @see WorkflowInboundCallsInterceptor::handleSignal() */

--- a/src/Internal/Workflow/Process/Scope.php
+++ b/src/Internal/Workflow/Process/Scope.php
@@ -19,6 +19,7 @@ use Temporal\Exception\DestructMemorizedInstanceException;
 use Temporal\Exception\Failure\CanceledFailure;
 use Temporal\Exception\Failure\TemporalFailure;
 use Temporal\Exception\InvalidArgumentException;
+use Temporal\Interceptor\WorkflowInbound\UpdateInput;
 use Temporal\Internal\Declaration\Destroyable;
 use Temporal\Internal\ServiceContainer;
 use Temporal\Internal\Transport\Request\Cancel;
@@ -150,10 +151,10 @@ class Scope implements CancellationScopeInterface, Destroyable
      * @param callable(ValuesInterface): mixed $handler Update method handler.
      * @param Deferred $resolver Update method promise resolver.
      */
-    public function startUpdate(callable $handler, ValuesInterface $values, Deferred $resolver, string $name): void
+    public function startUpdate(callable $handler, UpdateInput $input, Deferred $resolver): void
     {
         // Update handler counter
-        $id = $this->context->getHandlerState()->addUpdate($name);
+        $id = $this->context->getHandlerState()->addUpdate($input->updateId, $input->updateName);
         $this->then(
             fn() => $this->context->getHandlerState()->removeUpdate($id),
             fn() => $this->context->getHandlerState()->removeUpdate($id),
@@ -169,7 +170,7 @@ class Scope implements CancellationScopeInterface, Destroyable
         );
 
         // Create a coroutine generator
-        $this->coroutine = $this->callSignalOrUpdateHandler($handler, $values);
+        $this->coroutine = $this->callSignalOrUpdateHandler($handler, $input->arguments);
         $this->next();
     }
 

--- a/src/Internal/Workflow/Process/Scope.php
+++ b/src/Internal/Workflow/Process/Scope.php
@@ -68,22 +68,7 @@ class Scope implements CancellationScopeInterface, Destroyable
     protected DeferredGenerator $coroutine;
 
     /**
-     * Due nature of PHP generators the result of coroutine can be available before all child coroutines complete.
-     * This property will hold this result until all the inner coroutines resolve.
-     *
-     * @var mixed
-     */
-    private mixed $result;
-
-    /**
-     * When scope completes with exception.
-     *
-     * @var \Throwable|null
-     */
-    private ?\Throwable $exception = null;
-
-    /**
-     * Every coroutine runs on it's own loop layer.
+     * Every coroutine runs on its own loop layer.
      *
      * @var non-empty-string
      */
@@ -100,7 +85,7 @@ class Scope implements CancellationScopeInterface, Destroyable
     private array $onCancel = [];
 
     /**
-     * @var array<callable>
+     * @var array<callable(mixed): mixed>
      */
     private array $onClose = [];
 
@@ -165,13 +150,13 @@ class Scope implements CancellationScopeInterface, Destroyable
      * @param callable(ValuesInterface): mixed $handler Update method handler.
      * @param Deferred $resolver Update method promise resolver.
      */
-    public function startUpdate(callable $handler, ValuesInterface $values, Deferred $resolver): void
+    public function startUpdate(callable $handler, ValuesInterface $values, Deferred $resolver, string $name): void
     {
         // Update handler counter
-        ++$this->context->getHandlerState()->updates;
+        $id = $this->context->getHandlerState()->addUpdate($name);
         $this->then(
-            fn() => --$this->context->getHandlerState()->updates,
-            fn() => --$this->context->getHandlerState()->updates,
+            fn() => $this->context->getHandlerState()->removeUpdate($id),
+            fn() => $this->context->getHandlerState()->removeUpdate($id),
         );
 
         $this->then(
@@ -191,13 +176,13 @@ class Scope implements CancellationScopeInterface, Destroyable
     /**
      * @param callable $handler
      */
-    public function startSignal(callable $handler, ValuesInterface $values): void
+    public function startSignal(callable $handler, ValuesInterface $values, string $name): void
     {
         // Update handler counter
-        ++$this->context->getHandlerState()->signals;
+        $id = $this->context->getHandlerState()->addSignal($name);
         $this->then(
-            fn() => --$this->context->getHandlerState()->signals,
-            fn() => --$this->context->getHandlerState()->signals,
+            fn() => $this->context->getHandlerState()->removeSignal($id),
+            fn() => $this->context->getHandlerState()->removeSignal($id),
         );
 
         // Create a coroutine generator
@@ -223,7 +208,7 @@ class Scope implements CancellationScopeInterface, Destroyable
     }
 
     /**
-     * @param callable $then An exception instance is passed in case of error.
+     * @param callable(mixed): mixed $then An exception instance is passed in case of error.
      * @return $this
      */
     public function onClose(callable $then): self
@@ -531,14 +516,13 @@ class Scope implements CancellationScopeInterface, Destroyable
      */
     private function onException(\Throwable $e): void
     {
-        $this->exception = $e;
         $this->deferred->reject($e);
 
         $this->makeCurrent();
         $this->context->resolveConditions();
 
         foreach ($this->onClose as $close) {
-            $close($this->exception);
+            $close($e);
         }
     }
 
@@ -547,14 +531,13 @@ class Scope implements CancellationScopeInterface, Destroyable
      */
     private function onResult(mixed $result): void
     {
-        $this->result = $result;
         $this->deferred->resolve($result);
 
         $this->makeCurrent();
         $this->context->resolveConditions();
 
         foreach ($this->onClose as $close) {
-            $close($this->result);
+            $close($result);
         }
     }
 

--- a/src/Internal/Workflow/Process/Scope.php
+++ b/src/Internal/Workflow/Process/Scope.php
@@ -176,6 +176,7 @@ class Scope implements CancellationScopeInterface, Destroyable
 
     /**
      * @param callable $handler
+     * @param non-empty-string $name
      */
     public function startSignal(callable $handler, ValuesInterface $values, string $name): void
     {

--- a/src/Internal/Workflow/WorkflowContext.php
+++ b/src/Internal/Workflow/WorkflowContext.php
@@ -524,7 +524,7 @@ class WorkflowContext implements WorkflowContextInterface, HeaderCarrier, Destro
      */
     public function allHandlersFinished(): bool
     {
-        return $this->handlers->signals === 0 && $this->handlers->updates === 0;
+        return !$this->handlers->hasRunningHandlers();
     }
 
     /**

--- a/src/Workflow/HandlerUnfinishedPolicy.php
+++ b/src/Workflow/HandlerUnfinishedPolicy.php
@@ -15,7 +15,7 @@ enum HandlerUnfinishedPolicy
     /**
      * Issue a warning in addition to abandoning.
      */
-    case WARN_AND_ABANDON;
+    case WarnAndAbandon;
 
     /**
      * Abandon the handler.
@@ -23,5 +23,5 @@ enum HandlerUnfinishedPolicy
      * In the case of an update handler, this means that the client will receive an error rather than
      * the update result.
      */
-    case ABANDON;
+    case Abandon;
 }

--- a/src/Workflow/QueryMethod.php
+++ b/src/Workflow/QueryMethod.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace Temporal\Workflow;
 
 use Doctrine\Common\Annotations\Annotation\Target;
-use JetBrains\PhpStorm\Immutable;
 use Spiral\Attributes\NamedArgumentConstructor;
 
 /**
@@ -31,22 +30,9 @@ use Spiral\Attributes\NamedArgumentConstructor;
 final class QueryMethod
 {
     /**
-     * Name of the query type. Default is method name.
-     *
-     * Be careful about names that contain special characters. These names can
-     * be used as metric tags. And systems like prometheus ignore metrics which
-     * have tags with unsupported characters.
-     *
-     * @var string|null
+     * @param non-empty-string|null $name
      */
-    #[Immutable]
-    public ?string $name = null;
-
-    /**
-     * @param string|null $name
-     */
-    public function __construct(string $name = null)
-    {
-        $this->name = $name;
-    }
+    public function __construct(
+        public readonly ?string $name = null,
+    ) {}
 }

--- a/src/Workflow/ReturnType.php
+++ b/src/Workflow/ReturnType.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace Temporal\Workflow;
 
 use JetBrains\PhpStorm\ExpectedValues;
-use JetBrains\PhpStorm\Immutable;
 use Spiral\Attributes\NamedArgumentConstructor;
 use Temporal\DataConverter\Type;
 
@@ -24,34 +23,22 @@ use Temporal\DataConverter\Type;
 #[\Attribute(\Attribute::TARGET_METHOD), NamedArgumentConstructor]
 final class ReturnType
 {
-    public const TYPE_ANY    = Type::TYPE_ANY;
+    public const TYPE_ANY = Type::TYPE_ANY;
     public const TYPE_STRING = Type::TYPE_STRING;
-    public const TYPE_BOOL   = Type::TYPE_BOOL;
-    public const TYPE_INT    = Type::TYPE_INT;
-    public const TYPE_FLOAT  = Type::TYPE_FLOAT;
+    public const TYPE_BOOL = Type::TYPE_BOOL;
+    public const TYPE_INT = Type::TYPE_INT;
+    public const TYPE_FLOAT = Type::TYPE_FLOAT;
+
+    public readonly bool $nullable;
 
     /**
-     * @var string
-     */
-    #[Immutable]
-    public string $name;
-
-    /**
-     * @var bool
-     */
-    #[Immutable]
-    public bool $nullable;
-
-    /**
-     * @param string $name
-     * @param bool $nullable
+     * @param non-empty-string $name
      */
     public function __construct(
         #[ExpectedValues(valuesFromClass: Type::class)]
-        string $name,
-        bool $nullable = false
+        public readonly string $name,
+        bool $nullable = false,
     ) {
-        $this->name = $name;
         $this->nullable = $nullable || (new Type($name))->allowsNull();
     }
 }

--- a/src/Workflow/SignalMethod.php
+++ b/src/Workflow/SignalMethod.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace Temporal\Workflow;
 
 use Doctrine\Common\Annotations\Annotation\Target;
-use JetBrains\PhpStorm\Immutable;
 use Spiral\Attributes\NamedArgumentConstructor;
 
 /**
@@ -27,23 +26,14 @@ use Spiral\Attributes\NamedArgumentConstructor;
 #[\Attribute(\Attribute::TARGET_METHOD), NamedArgumentConstructor]
 final class SignalMethod
 {
-    /**
-     * Name of the signal type. Default is method name.
-     *
-     * Be careful about names that contain special characters. These names can
-     * be used as metric tags. And systems like prometheus ignore metrics which
-     * have tags with unsupported characters.
-     *
-     * @var string|null
-     */
-    #[Immutable]
-    public ?string $name = null;
 
     /**
-     * @param string|null $name
+     * @param non-empty-string|null $name Signal name.
+     * @param HandlerUnfinishedPolicy $unfinishedPolicy Actions taken if a workflow exits with
+     *         a running instance of this handler.
      */
-    public function __construct(string $name = null)
-    {
-        $this->name = $name;
-    }
+    public function __construct(
+        public readonly ?string $name = null,
+        public readonly HandlerUnfinishedPolicy $unfinishedPolicy = HandlerUnfinishedPolicy::WarnAndAbandon,
+    ) {}
 }

--- a/src/Workflow/UpdateMethod.php
+++ b/src/Workflow/UpdateMethod.php
@@ -33,8 +33,7 @@ final class UpdateMethod
      *        a running instance of this handler.
      */
     public function __construct(
-        public ?string $name = null,
+        public readonly ?string $name = null,
         public readonly HandlerUnfinishedPolicy $unfinishedPolicy = HandlerUnfinishedPolicy::WarnAndAbandon,
-    ) {
-    }
+    ) {}
 }

--- a/src/Workflow/UpdateMethod.php
+++ b/src/Workflow/UpdateMethod.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace Temporal\Workflow;
 
 use Doctrine\Common\Annotations\Annotation\Target;
-use JetBrains\PhpStorm\Immutable;
 use Spiral\Attributes\NamedArgumentConstructor;
 
 /**
@@ -30,10 +29,12 @@ final class UpdateMethod
      * @param non-empty-string|null $name Name of the update handler. Default is method name.
      *        Be careful about names that contain special characters. These names can be used as metric tags.
      *        And systems like prometheus ignore metrics which have tags with unsupported characters.
+     * @param HandlerUnfinishedPolicy $unfinishedPolicy Actions taken if a workflow exits with
+     *        a running instance of this handler.
      */
     public function __construct(
-        #[Immutable]
         public ?string $name = null,
+        public readonly HandlerUnfinishedPolicy $unfinishedPolicy = HandlerUnfinishedPolicy::WarnAndAbandon,
     ) {
     }
 }

--- a/src/Workflow/UpdateValidatorMethod.php
+++ b/src/Workflow/UpdateValidatorMethod.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace Temporal\Workflow;
 
 use Doctrine\Common\Annotations\Annotation\Target;
-use JetBrains\PhpStorm\Immutable;
 use Spiral\Attributes\NamedArgumentConstructor;
 
 /**
@@ -33,8 +32,6 @@ final class UpdateValidatorMethod
      *        And systems like prometheus ignore metrics which have tags with unsupported characters.
      */
     public function __construct(
-        #[Immutable]
-        public string $forUpdate,
-    ) {
-    }
+        public readonly string $forUpdate,
+    ) {}
 }

--- a/tests/Acceptance/App/Runtime/RRStarter.php
+++ b/tests/Acceptance/App/Runtime/RRStarter.php
@@ -15,7 +15,7 @@ final class RRStarter
         private State $runtime,
     ) {
         $this->environment = Environment::create();
-        \register_shutdown_function(fn() => $this->stop());
+        // \register_shutdown_function(fn() => $this->stop());
     }
 
     public function start(): void

--- a/tests/Acceptance/App/Runtime/TemporalStarter.php
+++ b/tests/Acceptance/App/Runtime/TemporalStarter.php
@@ -14,7 +14,7 @@ final class TemporalStarter
     public function __construct()
     {
         $this->environment = Environment::create();
-        \register_shutdown_function(fn() => $this->stop());
+        // \register_shutdown_function(fn() => $this->stop());
     }
 
     public function start(): void

--- a/tests/Acceptance/App/RuntimeBuilder.php
+++ b/tests/Acceptance/App/RuntimeBuilder.php
@@ -69,6 +69,7 @@ final class RuntimeBuilder
     public static function init(): void
     {
         \ini_set('display_errors', 'stderr');
+        // Feature flags
         FeatureFlags::$workflowDeferredHandlerStart = true;
     }
 

--- a/tests/Acceptance/Extra/Workflow/AllHandlersFinishedTest.php
+++ b/tests/Acceptance/Extra/Workflow/AllHandlersFinishedTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Acceptance\Extra\Workflow\AllHandlersFinished;
 
+use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\Attributes\Test;
 use React\Promise\PromiseInterface;
 use Temporal\Client\WorkflowStubInterface;
@@ -14,6 +15,7 @@ use Temporal\Workflow;
 use Temporal\Workflow\WorkflowInterface;
 use Temporal\Workflow\WorkflowMethod;
 
+#[CoversFunction('Temporal\Internal\Workflow\Process\Process::logRunningHandlers')]
 class AllHandlersFinishedTest extends TestCase
 {
     #[Test]
@@ -136,12 +138,14 @@ class AllHandlersFinishedTest extends TestCase
     ): void {
         $this->markTestSkipped("Can't check the log yet");
 
+        /** @see TestWorkflow::resolveFromSignal() */
+        $stub->signal('resolve', 'foo', 42);
+        $stub->signal('resolve', 'bar', 42);
+
         for ($i = 0; $i < 8; $i++) {
             /** @see TestWorkflow::addFromSignal() */
             $stub->signal('await', "key-$i");
         }
-        /** @see TestWorkflow::resolveFromSignal() */
-        $stub->signal('resolve', 'foo');
 
         // Finish the workflow
         $stub->signal('exit');
@@ -161,7 +165,7 @@ class AllHandlersFinishedTest extends TestCase
             $stub->startUpdate('await', "key-$i");
         }
         /** @see TestWorkflow::resolveFromUpdate() */
-        $stub->startUpdate('resolve', 'foo');
+        $stub->startUpdate('resolve', 'foo', 42);
 
         // Finish the workflow
         $stub->signal('exit');

--- a/tests/Functional/WorkflowTestCase.php
+++ b/tests/Functional/WorkflowTestCase.php
@@ -230,17 +230,6 @@ class WorkflowTestCase extends AbstractFunctional
         $worker->run($this, Splitter::create('Test_RuntimeSignal.log')->getQueue());
     }
 
-    public function testUnfinishedHandlerWarn(): void
-    {
-        $this->markTestSkipped("Can't check the log yet");
-
-        $worker = WorkerMock::createMock();
-
-        $worker->run($this, Splitter::create('Test_RuntimeSignal.log')->getQueue());
-
-        // todo check logs
-    }
-
     public function testSignalStepsAndRuntimeQuery(): void
     {
         $worker = WorkerMock::createMock();

--- a/tests/Functional/WorkflowTestCase.php
+++ b/tests/Functional/WorkflowTestCase.php
@@ -296,7 +296,7 @@ class WorkflowTestCase extends AbstractFunctional
                 LOG;
 
             $worker->run($this, Splitter::createFromString($log)->getQueue());
-            $before ??= \memory_get_usage();
+            $i === 3 and $before = \memory_get_usage();
         }
         $after = \memory_get_usage();
 

--- a/tests/Functional/WorkflowTestCase.php
+++ b/tests/Functional/WorkflowTestCase.php
@@ -230,6 +230,17 @@ class WorkflowTestCase extends AbstractFunctional
         $worker->run($this, Splitter::create('Test_RuntimeSignal.log')->getQueue());
     }
 
+    public function testUnfinishedHandlerWarn(): void
+    {
+        $this->markTestSkipped("Can't check the log yet");
+
+        $worker = WorkerMock::createMock();
+
+        $worker->run($this, Splitter::create('Test_RuntimeSignal.log')->getQueue());
+
+        // todo check logs
+    }
+
     public function testSignalStepsAndRuntimeQuery(): void
     {
         $worker = WorkerMock::createMock();
@@ -333,7 +344,7 @@ class WorkflowTestCase extends AbstractFunctional
                 LOG;
 
             $worker->run($this, Splitter::createFromString($log)->getQueue());
-            $before ??= \memory_get_usage();
+            $i === 3 and $before = \memory_get_usage();
         }
         $after = \memory_get_usage();
 
@@ -364,7 +375,7 @@ class WorkflowTestCase extends AbstractFunctional
                 LOG;
 
             $worker->run($this, Splitter::createFromString($log)->getQueue());
-            $before ??= \memory_get_usage();
+            $i === 3 and $before = \memory_get_usage();
         }
         $after = \memory_get_usage();
 

--- a/tests/Functional/bootstrap.php
+++ b/tests/Functional/bootstrap.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Temporal\FeatureFlags;
 use Temporal\Testing\Environment;
 use Temporal\Tests\SearchAttributeTestInvoker;
 
@@ -13,3 +14,6 @@ $environment->startTemporalTestServer();
 (new SearchAttributeTestInvoker)();
 $environment->startRoadRunner('./rr serve -c .rr.silent.yaml -w tests/Functional');
 register_shutdown_function(fn() => $environment->stop());
+
+// Default feature flags
+FeatureFlags::$warnOnWorkflowUnfinishedHandlers = false;

--- a/tests/Functional/worker.php
+++ b/tests/Functional/worker.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Temporal\FeatureFlags;
 use Temporal\Testing\WorkerFactory;
 use Temporal\Tests\Fixtures\PipelineProvider;
 use Temporal\Tests\Interceptor\HeaderChanger;
@@ -10,6 +11,9 @@ use Temporal\Worker\WorkerInterface;
 
 require __DIR__ . '/../../vendor/autoload.php';
 chdir(__DIR__ . '/../../');
+
+// Default feature flags
+FeatureFlags::$warnOnWorkflowUnfinishedHandlers = false;
 
 /**
  * @param non-empty-string $dir


### PR DESCRIPTION
## What was changed

Added logging of unfinished Signal and Update handlers when a Workflow finishes.

> [!WARNING]
> Warn will happen in cases of Workflow **success**, **cancel**, **continue-as-new**, **fail** with retryable, **fail** with non-retryable.

If there are unfinished handlers of both types, two warnings will be sent.

To disable such warnings a new feature flag `$warnOnWorkflowUnfinishedHandlers` has been added:
```php
\Temporal\FeatureFlags::$warnOnWorkflowUnfinishedHandlers = false;
```


Examples:

> Workflow `Extra_Workflow_AllHandlersFinished` cancelled while update handlers are still running. This may have interrupted work that the update handler was doing, and the client that sent the update will receive a 'workflow execution already completed' RPCError instead of the update result. You can wait for all update and signal handlers to complete by using `yield Workflow::await(Workflow::allHandlersFinished(...));`. Alternatively, if both you and the clients sending the update are okay with interrupting running handlers when the workflow finishes, and causing clients to receive errors, then you can disable this warning via the update handler attribute: `#[UpdateMethod(unfinishedPolicy: HandlerUnfinishedPolicy::Abandon)]`. The following updates were unfinished (and warnings were not disabled for their handler): `await` id:5e51ad4d-041c-4604-8b0a-cda641169da6, `await` id:1ea22590-aafa-4d27-aea4-9f0b7122b33d, `await` id:12059abd-2097-452b-b4de-36978c1c45da, `await` id:ca26f433-0974-4332-bc01-91c32e97dcc0, `await` id:ec827b4a-801c-453f-864c-b042bbcda3ea, `await` id:4b4dcf64-043c-4de2-b1fa-7431aedabf4c, `await` id:57839a31-34db-4560-b10a-4afc083133cc, `await` id:14158ca5-2d65-47f4-824c-7e15705219b5

> Workflow `Extra_Workflow_AllHandlersFinished` finished while signal handlers are still running. This may have interrupted work that the signal handler was doing. You can wait for all update and signal handlers to complete by using `yield Workflow::await(Workflow::allHandlersFinished(...));`. Alternatively, if both you and the clients sending the signal are okay with interrupting running handlers when the workflow finishes, and causing clients to receive errors, then you can disable this warning via the signal handler attribute: `#SignalMethod(unfinishedPolicy: HandlerUnfinishedPolicy::Abandon)]`. The following signals were unfinished (and warnings were not disabled for their handler): `resolve` x2, `await` x8


## Checklist

1. Closes #446
2. How was this tested: manually
3. Any docs updates needed?
