### PR TITLE
Add WorkflowUpdateRPCTimeoutOrCanceledException

### DIFF
--- a/src/Client/GRPC/BaseClient.php
+++ b/src/Client/GRPC/BaseClient.php
@@ -24,6 +24,7 @@ use Temporal\Client\Common\RpcRetryOptions;
 use Temporal\Client\Common\ServerCapabilities;
 use Temporal\Client\GRPC\Connection\Connection;
 use Temporal\Client\GRPC\Connection\ConnectionInterface;
+use Temporal\Exception\Client\CanceledException;
 use Temporal\Exception\Client\ServiceClientException;
 use Temporal\Exception\Client\TimeoutException;
 use Temporal\Interceptor\GrpcClientInterceptor;
@@ -300,6 +301,10 @@ abstract class BaseClient implements ServiceClientInterface
                 if (!\in_array($e->getCode(), self::RETRYABLE_ERRORS, true)) {
                     if ($e->getCode() === StatusCode::DEADLINE_EXCEEDED) {
                         throw new TimeoutException($e->getMessage(), $e->getCode(), $e);
+                    }
+
+                    if ($e->getCode() === StatusCode::CANCELLED) {
+                        throw new CanceledException($e->getMessage(), $e->getCode(), $e);
                     }
 
                     // non retryable

--- a/src/Client/Update/UpdateHandle.php
+++ b/src/Client/Update/UpdateHandle.php
@@ -10,6 +10,7 @@ use Temporal\Client\GRPC\ServiceClientInterface;
 use Temporal\DataConverter\DataConverterInterface;
 use Temporal\DataConverter\EncodedValues;
 use Temporal\DataConverter\ValuesInterface;
+use Temporal\Exception\Client\CanceledException;
 use Temporal\Exception\Client\TimeoutException;
 use Temporal\Exception\Client\WorkflowUpdateException;
 use Temporal\Exception\Client\WorkflowUpdateRPCTimeoutOrCanceledException;
@@ -122,8 +123,8 @@ final class UpdateHandle
                 $request,
                 $timeout === null ? null : $this->client->getContext()->withTimeout($timeout),
             );
-        } catch (TimeoutException $e) {
-            throw WorkflowUpdateRPCTimeoutOrCanceledException::fromTimeoutException($e);
+        } catch (TimeoutException|CanceledException $e) {
+            throw WorkflowUpdateRPCTimeoutOrCanceledException::fromTimeoutOrCanceledException($e);
         }
 
         // Workflow Uprate accepted

--- a/src/Client/WorkflowStubInterface.php
+++ b/src/Client/WorkflowStubInterface.php
@@ -15,6 +15,8 @@ use Temporal\Client\Update\UpdateHandle;
 use Temporal\Client\Update\UpdateOptions;
 use Temporal\DataConverter\Type;
 use Temporal\DataConverter\ValuesInterface;
+use Temporal\Exception\Client\WorkflowUpdateException;
+use Temporal\Exception\Client\WorkflowUpdateRPCTimeoutOrCanceledException;
 use Temporal\Exception\IllegalStateException;
 use Temporal\Workflow\CancellationScopeInterface;
 use Temporal\Workflow\QueryMethod;
@@ -91,6 +93,8 @@ interface WorkflowStubInterface extends WorkflowRunInterface
      * @param non-empty-string $name Name of the update handler.
      * @param mixed ...$args Arguments to pass to the update handler.
      * @return ValuesInterface|null
+     * @throws WorkflowUpdateException
+     * @throws WorkflowUpdateRPCTimeoutOrCanceledException
      */
     public function update(string $name, ...$args): ?ValuesInterface;
 
@@ -107,7 +111,7 @@ interface WorkflowStubInterface extends WorkflowRunInterface
      *
      * @param non-empty-string|UpdateOptions $nameOrOptions Name of the update handler or update options.
      * @param mixed ...$args Arguments to pass to the update handler.
-     * @return UpdateHandle
+     * @throws WorkflowUpdateRPCTimeoutOrCanceledException
      */
     public function startUpdate(string|UpdateOptions $nameOrOptions, ...$args): UpdateHandle;
 

--- a/src/Exception/Client/CanceledException.php
+++ b/src/Exception/Client/CanceledException.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Exception\Client;
+
+use Temporal\Exception\TemporalException;
+
+/**
+ * RPC call was canceled.
+ */
+class CanceledException extends TemporalException {}

--- a/src/Exception/Client/TimeoutException.php
+++ b/src/Exception/Client/TimeoutException.php
@@ -13,6 +13,7 @@ namespace Temporal\Exception\Client;
 
 use Temporal\Exception\TemporalException;
 
-class TimeoutException extends TemporalException
-{
-}
+/**
+ * RPC timeout or cancellation.
+ */
+class TimeoutException extends TemporalException {}

--- a/src/Exception/Client/WorkflowUpdateException.php
+++ b/src/Exception/Client/WorkflowUpdateException.php
@@ -13,7 +13,7 @@ namespace Temporal\Exception\Client;
 
 use Temporal\Workflow\WorkflowExecution;
 
-final class WorkflowUpdateException extends WorkflowException
+class WorkflowUpdateException extends WorkflowException
 {
     public function __construct(
         ?string $message,

--- a/src/Exception/Client/WorkflowUpdateRPCTimeoutOrCanceledException.php
+++ b/src/Exception/Client/WorkflowUpdateRPCTimeoutOrCanceledException.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Exception\Client;
+
+/**
+ * Occurs when an update call times out or is cancelled.
+ *
+ * @note this is not related to any general concept of timing out or cancelling a running update,
+ *       this is only related to the client call itself.
+ */
+class WorkflowUpdateRPCTimeoutOrCanceledException extends TimeoutException {
+    public static function fromTimeoutException(TimeoutException $exception): self
+    {
+        return new self(
+            $exception->getMessage(),
+            $exception->getCode(),
+            $exception->getPrevious(),
+        );
+    }
+}

--- a/src/Exception/Client/WorkflowUpdateRPCTimeoutOrCanceledException.php
+++ b/src/Exception/Client/WorkflowUpdateRPCTimeoutOrCanceledException.php
@@ -18,12 +18,15 @@ namespace Temporal\Exception\Client;
  *       this is only related to the client call itself.
  */
 class WorkflowUpdateRPCTimeoutOrCanceledException extends TimeoutException {
-    public static function fromTimeoutException(TimeoutException $exception): self
+    private function __construct(string $message = '', int $code = 0, ?\Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+
+    public static function fromTimeoutOrCanceledException(TimeoutException|CanceledException $exception): self
     {
         return new self(
-            $exception->getMessage(),
-            $exception->getCode(),
-            $exception->getPrevious(),
+            previous: $exception->getPrevious(),
         );
     }
 }

--- a/src/Internal/Client/WorkflowStub.php
+++ b/src/Internal/Client/WorkflowStub.php
@@ -51,6 +51,7 @@ use Temporal\Exception\Client\WorkflowQueryException;
 use Temporal\Exception\Client\WorkflowQueryRejectedException;
 use Temporal\Exception\Client\WorkflowServiceException;
 use Temporal\Exception\Client\WorkflowUpdateException;
+use Temporal\Exception\Client\WorkflowUpdateRPCTimeoutOrCanceledException;
 use Temporal\Exception\Failure\CanceledFailure;
 use Temporal\Exception\Failure\FailureConverter;
 use Temporal\Exception\Failure\TerminatedFailure;
@@ -332,6 +333,8 @@ final class WorkflowStub implements WorkflowStubInterface, HeaderCarrier
                     }
 
                     throw WorkflowServiceException::withoutMessage($input->workflowExecution, $input->workflowType, $e);
+                } catch (TimeoutException $e) {
+                    throw WorkflowUpdateRPCTimeoutOrCanceledException::fromTimeoutException($e);
                 } catch (\Throwable $e) {
                     throw new WorkflowServiceException(null, $input->workflowExecution, $input->workflowType, $e);
                 }

--- a/src/Internal/Client/WorkflowStub.php
+++ b/src/Internal/Client/WorkflowStub.php
@@ -334,7 +334,7 @@ final class WorkflowStub implements WorkflowStubInterface, HeaderCarrier
 
                     throw WorkflowServiceException::withoutMessage($input->workflowExecution, $input->workflowType, $e);
                 } catch (TimeoutException $e) {
-                    throw WorkflowUpdateRPCTimeoutOrCanceledException::fromTimeoutException($e);
+                    throw WorkflowUpdateRPCTimeoutOrCanceledException::fromTimeoutOrCanceledException($e);
                 } catch (\Throwable $e) {
                     throw new WorkflowServiceException(null, $input->workflowExecution, $input->workflowType, $e);
                 }

--- a/tests/Acceptance/App/Attribute/Client.php
+++ b/tests/Acceptance/App/Attribute/Client.php
@@ -13,7 +13,7 @@ namespace Temporal\Tests\Acceptance\App\Attribute;
 final class Client
 {
     public function __construct(
-        public int|string|null $timeout = null,
+        public float|null $timeout = null,
         public \Closure|array|string|null $pipelineProvider = null,
         public array $payloadConverters = [],
     ) {

--- a/tests/Acceptance/Extra/Update/TimeoutTest.php
+++ b/tests/Acceptance/Extra/Update/TimeoutTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Acceptance\Extra\Update\TimeoutTest;
+
+use PHPUnit\Framework\Attributes\Test;
+use Temporal\Client\WorkflowClientInterface;
+use Temporal\Client\WorkflowOptions;
+use Temporal\Client\WorkflowStubInterface;
+use Temporal\Exception\Client\WorkflowUpdateRPCTimeoutOrCanceledException;
+use Temporal\Tests\Acceptance\App\Attribute\Client;
+use Temporal\Tests\Acceptance\App\Attribute\Stub;
+use Temporal\Tests\Acceptance\App\TestCase;
+use Temporal\Workflow;
+use Temporal\Workflow\WorkflowInterface;
+use Temporal\Workflow\WorkflowMethod;
+
+class TimeoutTest extends TestCase
+{
+    #[Test]
+    public function getUpdateResultFromHandler(
+        #[Stub('Extra_Timeout_WorkflowUpdate')]
+        WorkflowStubInterface $stub,
+    ): void {
+        /** @see TestWorkflow::sleep */
+        $handle = $stub->startUpdate('sleep', '1 second');
+
+        $this->expectException(WorkflowUpdateRPCTimeoutOrCanceledException::class);
+
+        $handle->getResult(0.2);
+    }
+
+    #[Test]
+    public function doUpdateWithTimeout(
+        #[Stub('Extra_Timeout_WorkflowUpdate')]
+        #[Client(timeout: 1.2)]
+        WorkflowStubInterface $stub,
+    ): void {
+        $this->expectException(WorkflowUpdateRPCTimeoutOrCanceledException::class);
+
+        /** @see TestWorkflow::sleep */
+        $stub->update('sleep', '2 second');
+    }
+
+    #[Test]
+    public function withoutRunningWorker(WorkflowClientInterface $client): void
+    {
+        $client = $client->withTimeout(1.2);
+        $wf = $client->newUntypedWorkflowStub('Extra_Timeout_WorkflowUpdate', WorkflowOptions::new()
+            ->withTaskQueue('not-existing-task-queue'));
+        $client->start($wf);
+
+        $this->expectException(WorkflowUpdateRPCTimeoutOrCanceledException::class);
+
+        /** @see TestWorkflow::sleep */
+        $wf->update('sleep', '2 second');
+    }
+}
+
+#[WorkflowInterface]
+class TestWorkflow
+{
+    #[WorkflowMethod(name: "Extra_Timeout_WorkflowUpdate")]
+    public function handle()
+    {
+        yield Workflow::await(static fn() => false);
+    }
+
+    #[Workflow\UpdateMethod(name: 'sleep')]
+    public function sleep(string $sleep): mixed
+    {
+        yield Workflow::timer(\DateInterval::createFromDateString($sleep));
+    }
+}


### PR DESCRIPTION
## What was changed

Added `WorkflowUpdateRPCTimeoutOrCanceledException` that will be thrown instead of `TimeoutException` in Update cases.
I haven't added the new `RPCTimeoutOrCanceledException` because we already have a similar RPC specific timeout exception (`\Temporal\Exception\Client\TimeoutException`)

Added `\Temporal\Exception\Client\CanceledException` for client canceled calls

## Checklist
<!--- add/delete as needed --->

1. Closes #436
2. How was this tested: added auto-tests
