### PR TITLE
Change return type of WorkerInterface::getWorkflows() and WorkerInterface::getActivities()

### DIFF
--- a/src/Worker/Worker.php
+++ b/src/Worker/Worker.php
@@ -26,7 +26,7 @@ use Temporal\Worker\Transport\RPCConnectionInterface;
  * Worker manages the execution of workflows and activities within the single TaskQueue. Activity and Workflow processing
  * will be launched using separate processes.
  */
-class Worker implements WorkerInterface, EventListenerInterface, DispatcherInterface
+class Worker implements WorkerWithRepositoriesInterface, EventListenerInterface, DispatcherInterface
 {
     use EventEmitterTrait;
 

--- a/src/Worker/WorkerWithRepositoriesInterface.php
+++ b/src/Worker/WorkerWithRepositoriesInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Temporal\Worker;
+
+use Temporal\Internal\Declaration\Prototype\ActivityPrototype;
+use Temporal\Internal\Declaration\Prototype\WorkflowPrototype;
+use Temporal\Internal\Repository\RepositoryInterface;
+
+/**
+ * This interface will be merged into WorkerInterface in version 3.0.
+ */
+interface WorkerWithRepositoriesInterface extends WorkerInterface
+{
+    /**
+     * @return RepositoryInterface<WorkflowPrototype>
+     */
+    public function getWorkflows(): RepositoryInterface;
+
+    /**
+     * @return RepositoryInterface<ActivityPrototype>
+     */
+    public function getActivities(): RepositoryInterface;
+}


### PR DESCRIPTION
I would like to change the return type of `WorkerInterface::getWorkflows()` and `WorkerInterface::getActivities()`. They were both introduced in https://github.com/temporalio/sdk-php/pull/14 and as far as I can see it was not publicly discussed if it should be `iterable` or `RepositoryInterface`. 

## What was changed
To change the return type is a hard BC break which we want to avoid. That is why this PR introduce a new interface which is is compatible with `WorkerInterface` and will narrow down the return type. This interface will of course be removed before we release next major version. 

As you can see, the `Worker` is already compatible with this change. 

## Why?
If one would like to add activities to the worker one currently have limited options. There is no way to "standardize" activity behaviour for your application. 

In my case, I want to automatically add `MethodRetry` to each activity in my application with some "my app"-specific standards. 

My current workaround is of course not to use `WorkerInterface` and just type hint to `Worker`. 


