### PR TITLE
Add getter for ActivityPrototype::$factory

### DIFF
--- a/src/Internal/Declaration/Prototype/ActivityPrototype.php
+++ b/src/Internal/Declaration/Prototype/ActivityPrototype.php
@@ -112,4 +112,9 @@ final class ActivityPrototype extends Prototype
     {
         return $this->isLocalActivity;
     }
+
+    public function getFactory(): ?Closure
+    {
+        return $this->factory;
+    }
 }

--- a/tests/Unit/Activity/ActivityPrototypeTestCase.php
+++ b/tests/Unit/Activity/ActivityPrototypeTestCase.php
@@ -111,4 +111,13 @@ final class ActivityPrototypeTestCase extends AbstractUnit
         $this->assertEquals($protoWithFactory->getInstance()->getContext(), $protoWithFactory->getInstance()->getContext());
         $this->assertNotSame($protoWithFactory->getInstance()->getContext(), $protoWithFactory->getInstance()->getContext());
     }
+
+    public function testGetFactory(): void
+    {
+        $proto = $this->activityReader->fromClass(DummyActivity::class)[0];
+        $protoWithFactory = $proto->withFactory(fn (\ReflectionClass $reflectionClass) => $reflectionClass->newInstance());
+
+        $this->assertNull($proto->getFactory());
+        $this->assertNotNull($protoWithFactory->getFactory());
+    }
 }


### PR DESCRIPTION


## What was changed
Adding a getter for ActivityPrototype::$factory

## Why?

Whenever I start my workers, I replace all `ActivityPrototype` with a decorated version of my activities. I do this to add support for EventDispatcher. Ie I dispatch event before and after an activity is executed. 

So I need to rebuild the `ActivityPrototype`. 

## Checklist


2. How was this tested:
Unit tests

3. Any docs updates needed?
Nope