### PR TITLE
Remove unused and invalid use statement

### DIFF
--- a/src/Promise.php
+++ b/src/Promise.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace Temporal;
 
 use React\Promise\Exception\LengthException;
-use React\Promise\Internal\RejectedPromise;
 use React\Promise\PromiseInterface;
 use Temporal\Internal\Promise\CancellationQueue;
 


### PR DESCRIPTION
## What was changed
One less use statement

## Why?
It was not used nor is it valid (ie class does not exist)

