### PR TITLE
Make sure we run php-cs-fixer as part of our CI

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -44,7 +44,7 @@ jobs:
 
   php-cs-fixer:
     name: PHP-CS-Fixer
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
@@ -56,6 +56,9 @@ jobs:
           php-version: 8.1
           coverage: none
           tools: cs2pr
+
+      - name: Download dependencies
+        uses: ramsey/composer-install@v3
 
       - name: Display PHP-CS-Fixer version
         run: php-cs-fixer --version

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -21,26 +21,12 @@ jobs:
 
       - name: Check Out Code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
 
-      - name: Get Composer Cache Directory
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Cache Dependencies
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: php-${{ matrix.php }}-${{ runner.os }}-composer-
-
-      - name: Install Composer Dependencies
-        run: composer install --prefer-dist --no-interaction
+      - name: Download dependencies
+        uses: ramsey/composer-install@v3
 
       - name: Run Tests
         run: vendor/bin/psalm --output-format=github
-
 
   php-cs-fixer:
     name: PHP-CS-Fixer

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -39,4 +39,26 @@ jobs:
         run: composer install --prefer-dist --no-interaction
 
       - name: Run Tests
-        run: vendor/bin/psalm
+        run: vendor/bin/psalm --output-format=github
+
+
+  php-cs-fixer:
+    name: PHP-CS-Fixer
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.1
+          coverage: none
+          tools: cs2pr
+
+      - name: Display PHP-CS-Fixer version
+        run: php-cs-fixer --version
+
+      - name: PHP-CS-Fixer
+        run: php-cs-fixer fix --dry-run --format=checkstyle | cs2pr

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ composer.phar
 Thumbs.db
 
 # Cache
-.php_cs.cache
+.php-cs-fixer.cache
 
 # Other
 /.rr.yaml

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -11,8 +11,8 @@ file that was distributed with this source code.
 EOF;
 
 $finder = Finder::create()
-    ->exclude('tests')
     ->in(__DIR__ . '/src')
+    ->exclude('tests')
 ;
 
 return (new Config())
@@ -31,7 +31,8 @@ return (new Config())
         'unary_operator_spaces'             => true,
         'no_useless_else'                   => true,
         'no_useless_return'                 => true,
-        'trailing_comma_in_multiline_array' => true,
+        'trailing_comma_in_multiline'       => true,
     ])
     ->setFinder($finder)
 ;
+

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -22,9 +22,11 @@ return (new Config())
         '@PHP80Migration:risky'             => true,
         'list_syntax'                       => ['syntax' => 'short'],
         'no_unused_imports'                 => true,
-        'declare_strict_types'              => true,
+        // TODO change to true
+        'declare_strict_types'              => false,
         'void_return'                       => true,
-        'ordered_class_elements'            => true,
+        // TODO change this to true
+        'ordered_class_elements'            => false,
         'linebreak_after_opening_tag'       => true,
         'single_quote'                      => true,
         'no_blank_lines_after_phpdoc'       => true,
@@ -32,6 +34,10 @@ return (new Config())
         'no_useless_else'                   => true,
         'no_useless_return'                 => true,
         'trailing_comma_in_multiline'       => true,
+        // TODO remove the remaining rules
+        'blank_line_after_opening_tag'      => false,
+        'braces_position'                   => false,
+
     ])
     ->setFinder($finder)
 ;

--- a/src/Activity/ActivityOptionsInterface.php
+++ b/src/Activity/ActivityOptionsInterface.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-
 namespace Temporal\Activity;
 
 use Temporal\Common\MethodRetry;

--- a/src/Client/Common/BackoffThrottler.php
+++ b/src/Client/Common/BackoffThrottler.php
@@ -79,7 +79,7 @@ final class BackoffThrottler
         // Choose a random number in the range -maxJitterCoefficient ... +maxJitterCoefficient
         $jitter = \random_int(-1000, 1000) * $this->maxJitterCoefficient / 1000;
         $sleepTime = \min(
-            \pow($this->backoffCoefficient, $failureCount - 1) * $initialInterval * (1.0 + $jitter),
+            $this->backoffCoefficient ** ($failureCount - 1) * $initialInterval * (1.0 + $jitter),
             $this->maxInterval,
         );
 

--- a/src/Client/Common/ClientContextInterface.php
+++ b/src/Client/Common/ClientContextInterface.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Temporal\Client\Common;
 
-use Temporal\Common\RetryOptions;
-
 interface ClientContextInterface
 {
     /**

--- a/src/Client/Common/ClientContextTrait.php
+++ b/src/Client/Common/ClientContextTrait.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Temporal\Client\Common;
 
 use Temporal\Client\GRPC\ServiceClientInterface;
-use Temporal\Common\RetryOptions;
 use Temporal\Internal\Support\DateInterval;
 
 /**

--- a/src/Client/Common/RpcRetryOptions.php
+++ b/src/Client/Common/RpcRetryOptions.php
@@ -36,7 +36,7 @@ final class RpcRetryOptions extends RetryOptions
      */
     public static function fromRetryOptions(RetryOptions $options): self
     {
-        return $options instanceof self ? $options :  (new self())
+        return $options instanceof self ? $options : (new self())
             ->withInitialInterval($options->initialInterval)
             ->withBackoffCoefficient($options->backoffCoefficient)
             ->withMaximumInterval($options->maximumInterval)

--- a/src/Client/GRPC/BaseClient.php
+++ b/src/Client/GRPC/BaseClient.php
@@ -59,7 +59,7 @@ abstract class BaseClient implements ServiceClientInterface
                 'Creating a ServiceClient instance via constructor is deprecated. Use static factory methods instead.',
                 \E_USER_DEPRECATED,
             );
-            $workflowService = static fn(): WorkflowServiceClient => $workflowService;
+            $workflowService = static fn (): WorkflowServiceClient => $workflowService;
         }
 
         $this->connection = new Connection($workflowService);
@@ -112,7 +112,7 @@ abstract class BaseClient implements ServiceClientInterface
             throw new \RuntimeException('The gRPC extension is required to use Temporal Client.');
         }
 
-        return new static(static fn(): WorkflowServiceClient => new WorkflowServiceClient(
+        return new static(static fn (): WorkflowServiceClient => new WorkflowServiceClient(
             $address,
             ['credentials' => \Grpc\ChannelCredentials::createInsecure()]
         ));
@@ -156,7 +156,7 @@ abstract class BaseClient implements ServiceClientInterface
                 $loadCert($crt),
                 $loadCert($clientKey),
                 $loadCert($clientPem),
-            )
+            ),
         ];
 
         if ($overrideServerName !== null) {
@@ -164,7 +164,7 @@ abstract class BaseClient implements ServiceClientInterface
             $options['grpc.ssl_target_name_override'] = $overrideServerName;
         }
 
-        return new static(static fn(): WorkflowServiceClient => new WorkflowServiceClient($address, $options));
+        return new static(static fn (): WorkflowServiceClient => new WorkflowServiceClient($address, $options));
     }
 
     /**

--- a/src/Client/GRPC/ServiceClient.php
+++ b/src/Client/GRPC/ServiceClient.php
@@ -6,7 +6,6 @@
  * file that was distributed with this source code.
  */
 
-
 namespace Temporal\Client\GRPC;
 
 use Temporal\Api\Workflowservice\V1;
@@ -31,9 +30,9 @@ class ServiceClient extends BaseClient
      * @return V1\RegisterNamespaceResponse
      * @throws ServiceClientException
      */
-    public function RegisterNamespace(V1\RegisterNamespaceRequest $arg, ContextInterface $ctx = null) : V1\RegisterNamespaceResponse
+    public function RegisterNamespace(V1\RegisterNamespaceRequest $arg, ContextInterface $ctx = null): V1\RegisterNamespaceResponse
     {
-        return $this->invoke("RegisterNamespace", $arg, $ctx);
+        return $this->invoke('RegisterNamespace', $arg, $ctx);
     }
 
     /**
@@ -45,9 +44,9 @@ class ServiceClient extends BaseClient
      * @return V1\DescribeNamespaceResponse
      * @throws ServiceClientException
      */
-    public function DescribeNamespace(V1\DescribeNamespaceRequest $arg, ContextInterface $ctx = null) : V1\DescribeNamespaceResponse
+    public function DescribeNamespace(V1\DescribeNamespaceRequest $arg, ContextInterface $ctx = null): V1\DescribeNamespaceResponse
     {
-        return $this->invoke("DescribeNamespace", $arg, $ctx);
+        return $this->invoke('DescribeNamespace', $arg, $ctx);
     }
 
     /**
@@ -58,9 +57,9 @@ class ServiceClient extends BaseClient
      * @return V1\ListNamespacesResponse
      * @throws ServiceClientException
      */
-    public function ListNamespaces(V1\ListNamespacesRequest $arg, ContextInterface $ctx = null) : V1\ListNamespacesResponse
+    public function ListNamespaces(V1\ListNamespacesRequest $arg, ContextInterface $ctx = null): V1\ListNamespacesResponse
     {
-        return $this->invoke("ListNamespaces", $arg, $ctx);
+        return $this->invoke('ListNamespaces', $arg, $ctx);
     }
 
     /**
@@ -73,9 +72,9 @@ class ServiceClient extends BaseClient
      * @return V1\UpdateNamespaceResponse
      * @throws ServiceClientException
      */
-    public function UpdateNamespace(V1\UpdateNamespaceRequest $arg, ContextInterface $ctx = null) : V1\UpdateNamespaceResponse
+    public function UpdateNamespace(V1\UpdateNamespaceRequest $arg, ContextInterface $ctx = null): V1\UpdateNamespaceResponse
     {
-        return $this->invoke("UpdateNamespace", $arg, $ctx);
+        return $this->invoke('UpdateNamespace', $arg, $ctx);
     }
 
     /**
@@ -95,9 +94,9 @@ class ServiceClient extends BaseClient
      * @return V1\DeprecateNamespaceResponse
      * @throws ServiceClientException
      */
-    public function DeprecateNamespace(V1\DeprecateNamespaceRequest $arg, ContextInterface $ctx = null) : V1\DeprecateNamespaceResponse
+    public function DeprecateNamespace(V1\DeprecateNamespaceRequest $arg, ContextInterface $ctx = null): V1\DeprecateNamespaceResponse
     {
-        return $this->invoke("DeprecateNamespace", $arg, $ctx);
+        return $this->invoke('DeprecateNamespace', $arg, $ctx);
     }
 
     /**
@@ -114,9 +113,9 @@ class ServiceClient extends BaseClient
      * @return V1\StartWorkflowExecutionResponse
      * @throws ServiceClientException
      */
-    public function StartWorkflowExecution(V1\StartWorkflowExecutionRequest $arg, ContextInterface $ctx = null) : V1\StartWorkflowExecutionResponse
+    public function StartWorkflowExecution(V1\StartWorkflowExecutionRequest $arg, ContextInterface $ctx = null): V1\StartWorkflowExecutionResponse
     {
-        return $this->invoke("StartWorkflowExecution", $arg, $ctx);
+        return $this->invoke('StartWorkflowExecution', $arg, $ctx);
     }
 
     /**
@@ -129,9 +128,9 @@ class ServiceClient extends BaseClient
      * @return V1\GetWorkflowExecutionHistoryResponse
      * @throws ServiceClientException
      */
-    public function GetWorkflowExecutionHistory(V1\GetWorkflowExecutionHistoryRequest $arg, ContextInterface $ctx = null) : V1\GetWorkflowExecutionHistoryResponse
+    public function GetWorkflowExecutionHistory(V1\GetWorkflowExecutionHistoryRequest $arg, ContextInterface $ctx = null): V1\GetWorkflowExecutionHistoryResponse
     {
-        return $this->invoke("GetWorkflowExecutionHistory", $arg, $ctx);
+        return $this->invoke('GetWorkflowExecutionHistory', $arg, $ctx);
     }
 
     /**
@@ -146,9 +145,9 @@ class ServiceClient extends BaseClient
      * @return V1\GetWorkflowExecutionHistoryReverseResponse
      * @throws ServiceClientException
      */
-    public function GetWorkflowExecutionHistoryReverse(V1\GetWorkflowExecutionHistoryReverseRequest $arg, ContextInterface $ctx = null) : V1\GetWorkflowExecutionHistoryReverseResponse
+    public function GetWorkflowExecutionHistoryReverse(V1\GetWorkflowExecutionHistoryReverseRequest $arg, ContextInterface $ctx = null): V1\GetWorkflowExecutionHistoryReverseResponse
     {
-        return $this->invoke("GetWorkflowExecutionHistoryReverse", $arg, $ctx);
+        return $this->invoke('GetWorkflowExecutionHistoryReverse', $arg, $ctx);
     }
 
     /**
@@ -170,9 +169,9 @@ class ServiceClient extends BaseClient
      * @return V1\PollWorkflowTaskQueueResponse
      * @throws ServiceClientException
      */
-    public function PollWorkflowTaskQueue(V1\PollWorkflowTaskQueueRequest $arg, ContextInterface $ctx = null) : V1\PollWorkflowTaskQueueResponse
+    public function PollWorkflowTaskQueue(V1\PollWorkflowTaskQueueRequest $arg, ContextInterface $ctx = null): V1\PollWorkflowTaskQueueResponse
     {
-        return $this->invoke("PollWorkflowTaskQueue", $arg, $ctx);
+        return $this->invoke('PollWorkflowTaskQueue', $arg, $ctx);
     }
 
     /**
@@ -194,9 +193,9 @@ class ServiceClient extends BaseClient
      * @return V1\RespondWorkflowTaskCompletedResponse
      * @throws ServiceClientException
      */
-    public function RespondWorkflowTaskCompleted(V1\RespondWorkflowTaskCompletedRequest $arg, ContextInterface $ctx = null) : V1\RespondWorkflowTaskCompletedResponse
+    public function RespondWorkflowTaskCompleted(V1\RespondWorkflowTaskCompletedRequest $arg, ContextInterface $ctx = null): V1\RespondWorkflowTaskCompletedResponse
     {
-        return $this->invoke("RespondWorkflowTaskCompleted", $arg, $ctx);
+        return $this->invoke('RespondWorkflowTaskCompleted', $arg, $ctx);
     }
 
     /**
@@ -222,9 +221,9 @@ class ServiceClient extends BaseClient
      * @return V1\RespondWorkflowTaskFailedResponse
      * @throws ServiceClientException
      */
-    public function RespondWorkflowTaskFailed(V1\RespondWorkflowTaskFailedRequest $arg, ContextInterface $ctx = null) : V1\RespondWorkflowTaskFailedResponse
+    public function RespondWorkflowTaskFailed(V1\RespondWorkflowTaskFailedRequest $arg, ContextInterface $ctx = null): V1\RespondWorkflowTaskFailedResponse
     {
-        return $this->invoke("RespondWorkflowTaskFailed", $arg, $ctx);
+        return $this->invoke('RespondWorkflowTaskFailed', $arg, $ctx);
     }
 
     /**
@@ -256,9 +255,9 @@ class ServiceClient extends BaseClient
      * @return V1\PollActivityTaskQueueResponse
      * @throws ServiceClientException
      */
-    public function PollActivityTaskQueue(V1\PollActivityTaskQueueRequest $arg, ContextInterface $ctx = null) : V1\PollActivityTaskQueueResponse
+    public function PollActivityTaskQueue(V1\PollActivityTaskQueueRequest $arg, ContextInterface $ctx = null): V1\PollActivityTaskQueueResponse
     {
-        return $this->invoke("PollActivityTaskQueue", $arg, $ctx);
+        return $this->invoke('PollActivityTaskQueue', $arg, $ctx);
     }
 
     /**
@@ -279,9 +278,9 @@ class ServiceClient extends BaseClient
      * @return V1\RecordActivityTaskHeartbeatResponse
      * @throws ServiceClientException
      */
-    public function RecordActivityTaskHeartbeat(V1\RecordActivityTaskHeartbeatRequest $arg, ContextInterface $ctx = null) : V1\RecordActivityTaskHeartbeatResponse
+    public function RecordActivityTaskHeartbeat(V1\RecordActivityTaskHeartbeatRequest $arg, ContextInterface $ctx = null): V1\RecordActivityTaskHeartbeatResponse
     {
-        return $this->invoke("RecordActivityTaskHeartbeat", $arg, $ctx);
+        return $this->invoke('RecordActivityTaskHeartbeat', $arg, $ctx);
     }
 
     /**
@@ -297,9 +296,9 @@ class ServiceClient extends BaseClient
      * @return V1\RecordActivityTaskHeartbeatByIdResponse
      * @throws ServiceClientException
      */
-    public function RecordActivityTaskHeartbeatById(V1\RecordActivityTaskHeartbeatByIdRequest $arg, ContextInterface $ctx = null) : V1\RecordActivityTaskHeartbeatByIdResponse
+    public function RecordActivityTaskHeartbeatById(V1\RecordActivityTaskHeartbeatByIdRequest $arg, ContextInterface $ctx = null): V1\RecordActivityTaskHeartbeatByIdResponse
     {
-        return $this->invoke("RecordActivityTaskHeartbeatById", $arg, $ctx);
+        return $this->invoke('RecordActivityTaskHeartbeatById', $arg, $ctx);
     }
 
     /**
@@ -319,9 +318,9 @@ class ServiceClient extends BaseClient
      * @return V1\RespondActivityTaskCompletedResponse
      * @throws ServiceClientException
      */
-    public function RespondActivityTaskCompleted(V1\RespondActivityTaskCompletedRequest $arg, ContextInterface $ctx = null) : V1\RespondActivityTaskCompletedResponse
+    public function RespondActivityTaskCompleted(V1\RespondActivityTaskCompletedRequest $arg, ContextInterface $ctx = null): V1\RespondActivityTaskCompletedResponse
     {
-        return $this->invoke("RespondActivityTaskCompleted", $arg, $ctx);
+        return $this->invoke('RespondActivityTaskCompleted', $arg, $ctx);
     }
 
     /**
@@ -337,9 +336,9 @@ class ServiceClient extends BaseClient
      * @return V1\RespondActivityTaskCompletedByIdResponse
      * @throws ServiceClientException
      */
-    public function RespondActivityTaskCompletedById(V1\RespondActivityTaskCompletedByIdRequest $arg, ContextInterface $ctx = null) : V1\RespondActivityTaskCompletedByIdResponse
+    public function RespondActivityTaskCompletedById(V1\RespondActivityTaskCompletedByIdRequest $arg, ContextInterface $ctx = null): V1\RespondActivityTaskCompletedByIdResponse
     {
-        return $this->invoke("RespondActivityTaskCompletedById", $arg, $ctx);
+        return $this->invoke('RespondActivityTaskCompletedById', $arg, $ctx);
     }
 
     /**
@@ -358,9 +357,9 @@ class ServiceClient extends BaseClient
      * @return V1\RespondActivityTaskFailedResponse
      * @throws ServiceClientException
      */
-    public function RespondActivityTaskFailed(V1\RespondActivityTaskFailedRequest $arg, ContextInterface $ctx = null) : V1\RespondActivityTaskFailedResponse
+    public function RespondActivityTaskFailed(V1\RespondActivityTaskFailedRequest $arg, ContextInterface $ctx = null): V1\RespondActivityTaskFailedResponse
     {
-        return $this->invoke("RespondActivityTaskFailed", $arg, $ctx);
+        return $this->invoke('RespondActivityTaskFailed', $arg, $ctx);
     }
 
     /**
@@ -376,9 +375,9 @@ class ServiceClient extends BaseClient
      * @return V1\RespondActivityTaskFailedByIdResponse
      * @throws ServiceClientException
      */
-    public function RespondActivityTaskFailedById(V1\RespondActivityTaskFailedByIdRequest $arg, ContextInterface $ctx = null) : V1\RespondActivityTaskFailedByIdResponse
+    public function RespondActivityTaskFailedById(V1\RespondActivityTaskFailedByIdRequest $arg, ContextInterface $ctx = null): V1\RespondActivityTaskFailedByIdResponse
     {
-        return $this->invoke("RespondActivityTaskFailedById", $arg, $ctx);
+        return $this->invoke('RespondActivityTaskFailedById', $arg, $ctx);
     }
 
     /**
@@ -397,9 +396,9 @@ class ServiceClient extends BaseClient
      * @return V1\RespondActivityTaskCanceledResponse
      * @throws ServiceClientException
      */
-    public function RespondActivityTaskCanceled(V1\RespondActivityTaskCanceledRequest $arg, ContextInterface $ctx = null) : V1\RespondActivityTaskCanceledResponse
+    public function RespondActivityTaskCanceled(V1\RespondActivityTaskCanceledRequest $arg, ContextInterface $ctx = null): V1\RespondActivityTaskCanceledResponse
     {
-        return $this->invoke("RespondActivityTaskCanceled", $arg, $ctx);
+        return $this->invoke('RespondActivityTaskCanceled', $arg, $ctx);
     }
 
     /**
@@ -415,9 +414,9 @@ class ServiceClient extends BaseClient
      * @return V1\RespondActivityTaskCanceledByIdResponse
      * @throws ServiceClientException
      */
-    public function RespondActivityTaskCanceledById(V1\RespondActivityTaskCanceledByIdRequest $arg, ContextInterface $ctx = null) : V1\RespondActivityTaskCanceledByIdResponse
+    public function RespondActivityTaskCanceledById(V1\RespondActivityTaskCanceledByIdRequest $arg, ContextInterface $ctx = null): V1\RespondActivityTaskCanceledByIdResponse
     {
-        return $this->invoke("RespondActivityTaskCanceledById", $arg, $ctx);
+        return $this->invoke('RespondActivityTaskCanceledById', $arg, $ctx);
     }
 
     /**
@@ -437,9 +436,9 @@ class ServiceClient extends BaseClient
      * @return V1\RequestCancelWorkflowExecutionResponse
      * @throws ServiceClientException
      */
-    public function RequestCancelWorkflowExecution(V1\RequestCancelWorkflowExecutionRequest $arg, ContextInterface $ctx = null) : V1\RequestCancelWorkflowExecutionResponse
+    public function RequestCancelWorkflowExecution(V1\RequestCancelWorkflowExecutionRequest $arg, ContextInterface $ctx = null): V1\RequestCancelWorkflowExecutionResponse
     {
-        return $this->invoke("RequestCancelWorkflowExecution", $arg, $ctx);
+        return $this->invoke('RequestCancelWorkflowExecution', $arg, $ctx);
     }
 
     /**
@@ -455,9 +454,9 @@ class ServiceClient extends BaseClient
      * @return V1\SignalWorkflowExecutionResponse
      * @throws ServiceClientException
      */
-    public function SignalWorkflowExecution(V1\SignalWorkflowExecutionRequest $arg, ContextInterface $ctx = null) : V1\SignalWorkflowExecutionResponse
+    public function SignalWorkflowExecution(V1\SignalWorkflowExecutionRequest $arg, ContextInterface $ctx = null): V1\SignalWorkflowExecutionResponse
     {
-        return $this->invoke("SignalWorkflowExecution", $arg, $ctx);
+        return $this->invoke('SignalWorkflowExecution', $arg, $ctx);
     }
 
     /**
@@ -482,9 +481,9 @@ class ServiceClient extends BaseClient
      * @return V1\SignalWithStartWorkflowExecutionResponse
      * @throws ServiceClientException
      */
-    public function SignalWithStartWorkflowExecution(V1\SignalWithStartWorkflowExecutionRequest $arg, ContextInterface $ctx = null) : V1\SignalWithStartWorkflowExecutionResponse
+    public function SignalWithStartWorkflowExecution(V1\SignalWithStartWorkflowExecutionRequest $arg, ContextInterface $ctx = null): V1\SignalWithStartWorkflowExecutionResponse
     {
-        return $this->invoke("SignalWithStartWorkflowExecution", $arg, $ctx);
+        return $this->invoke('SignalWithStartWorkflowExecution', $arg, $ctx);
     }
 
     /**
@@ -500,9 +499,9 @@ class ServiceClient extends BaseClient
      * @return V1\ResetWorkflowExecutionResponse
      * @throws ServiceClientException
      */
-    public function ResetWorkflowExecution(V1\ResetWorkflowExecutionRequest $arg, ContextInterface $ctx = null) : V1\ResetWorkflowExecutionResponse
+    public function ResetWorkflowExecution(V1\ResetWorkflowExecutionRequest $arg, ContextInterface $ctx = null): V1\ResetWorkflowExecutionResponse
     {
-        return $this->invoke("ResetWorkflowExecution", $arg, $ctx);
+        return $this->invoke('ResetWorkflowExecution', $arg, $ctx);
     }
 
     /**
@@ -517,9 +516,9 @@ class ServiceClient extends BaseClient
      * @return V1\TerminateWorkflowExecutionResponse
      * @throws ServiceClientException
      */
-    public function TerminateWorkflowExecution(V1\TerminateWorkflowExecutionRequest $arg, ContextInterface $ctx = null) : V1\TerminateWorkflowExecutionResponse
+    public function TerminateWorkflowExecution(V1\TerminateWorkflowExecutionRequest $arg, ContextInterface $ctx = null): V1\TerminateWorkflowExecutionResponse
     {
-        return $this->invoke("TerminateWorkflowExecution", $arg, $ctx);
+        return $this->invoke('TerminateWorkflowExecution', $arg, $ctx);
     }
 
     /**
@@ -539,9 +538,9 @@ class ServiceClient extends BaseClient
      * @return V1\DeleteWorkflowExecutionResponse
      * @throws ServiceClientException
      */
-    public function DeleteWorkflowExecution(V1\DeleteWorkflowExecutionRequest $arg, ContextInterface $ctx = null) : V1\DeleteWorkflowExecutionResponse
+    public function DeleteWorkflowExecution(V1\DeleteWorkflowExecutionRequest $arg, ContextInterface $ctx = null): V1\DeleteWorkflowExecutionResponse
     {
-        return $this->invoke("DeleteWorkflowExecution", $arg, $ctx);
+        return $this->invoke('DeleteWorkflowExecution', $arg, $ctx);
     }
 
     /**
@@ -556,9 +555,9 @@ class ServiceClient extends BaseClient
      * @return V1\ListOpenWorkflowExecutionsResponse
      * @throws ServiceClientException
      */
-    public function ListOpenWorkflowExecutions(V1\ListOpenWorkflowExecutionsRequest $arg, ContextInterface $ctx = null) : V1\ListOpenWorkflowExecutionsResponse
+    public function ListOpenWorkflowExecutions(V1\ListOpenWorkflowExecutionsRequest $arg, ContextInterface $ctx = null): V1\ListOpenWorkflowExecutionsResponse
     {
-        return $this->invoke("ListOpenWorkflowExecutions", $arg, $ctx);
+        return $this->invoke('ListOpenWorkflowExecutions', $arg, $ctx);
     }
 
     /**
@@ -573,9 +572,9 @@ class ServiceClient extends BaseClient
      * @return V1\ListClosedWorkflowExecutionsResponse
      * @throws ServiceClientException
      */
-    public function ListClosedWorkflowExecutions(V1\ListClosedWorkflowExecutionsRequest $arg, ContextInterface $ctx = null) : V1\ListClosedWorkflowExecutionsResponse
+    public function ListClosedWorkflowExecutions(V1\ListClosedWorkflowExecutionsRequest $arg, ContextInterface $ctx = null): V1\ListClosedWorkflowExecutionsResponse
     {
-        return $this->invoke("ListClosedWorkflowExecutions", $arg, $ctx);
+        return $this->invoke('ListClosedWorkflowExecutions', $arg, $ctx);
     }
 
     /**
@@ -587,9 +586,9 @@ class ServiceClient extends BaseClient
      * @return V1\ListWorkflowExecutionsResponse
      * @throws ServiceClientException
      */
-    public function ListWorkflowExecutions(V1\ListWorkflowExecutionsRequest $arg, ContextInterface $ctx = null) : V1\ListWorkflowExecutionsResponse
+    public function ListWorkflowExecutions(V1\ListWorkflowExecutionsRequest $arg, ContextInterface $ctx = null): V1\ListWorkflowExecutionsResponse
     {
-        return $this->invoke("ListWorkflowExecutions", $arg, $ctx);
+        return $this->invoke('ListWorkflowExecutions', $arg, $ctx);
     }
 
     /**
@@ -601,9 +600,9 @@ class ServiceClient extends BaseClient
      * @return V1\ListArchivedWorkflowExecutionsResponse
      * @throws ServiceClientException
      */
-    public function ListArchivedWorkflowExecutions(V1\ListArchivedWorkflowExecutionsRequest $arg, ContextInterface $ctx = null) : V1\ListArchivedWorkflowExecutionsResponse
+    public function ListArchivedWorkflowExecutions(V1\ListArchivedWorkflowExecutionsRequest $arg, ContextInterface $ctx = null): V1\ListArchivedWorkflowExecutionsResponse
     {
-        return $this->invoke("ListArchivedWorkflowExecutions", $arg, $ctx);
+        return $this->invoke('ListArchivedWorkflowExecutions', $arg, $ctx);
     }
 
     /**
@@ -618,9 +617,9 @@ class ServiceClient extends BaseClient
      * @return V1\ScanWorkflowExecutionsResponse
      * @throws ServiceClientException
      */
-    public function ScanWorkflowExecutions(V1\ScanWorkflowExecutionsRequest $arg, ContextInterface $ctx = null) : V1\ScanWorkflowExecutionsResponse
+    public function ScanWorkflowExecutions(V1\ScanWorkflowExecutionsRequest $arg, ContextInterface $ctx = null): V1\ScanWorkflowExecutionsResponse
     {
-        return $this->invoke("ScanWorkflowExecutions", $arg, $ctx);
+        return $this->invoke('ScanWorkflowExecutions', $arg, $ctx);
     }
 
     /**
@@ -632,9 +631,9 @@ class ServiceClient extends BaseClient
      * @return V1\CountWorkflowExecutionsResponse
      * @throws ServiceClientException
      */
-    public function CountWorkflowExecutions(V1\CountWorkflowExecutionsRequest $arg, ContextInterface $ctx = null) : V1\CountWorkflowExecutionsResponse
+    public function CountWorkflowExecutions(V1\CountWorkflowExecutionsRequest $arg, ContextInterface $ctx = null): V1\CountWorkflowExecutionsResponse
     {
-        return $this->invoke("CountWorkflowExecutions", $arg, $ctx);
+        return $this->invoke('CountWorkflowExecutions', $arg, $ctx);
     }
 
     /**
@@ -650,9 +649,9 @@ class ServiceClient extends BaseClient
      * @return V1\GetSearchAttributesResponse
      * @throws ServiceClientException
      */
-    public function GetSearchAttributes(V1\GetSearchAttributesRequest $arg, ContextInterface $ctx = null) : V1\GetSearchAttributesResponse
+    public function GetSearchAttributes(V1\GetSearchAttributesRequest $arg, ContextInterface $ctx = null): V1\GetSearchAttributesResponse
     {
-        return $this->invoke("GetSearchAttributes", $arg, $ctx);
+        return $this->invoke('GetSearchAttributes', $arg, $ctx);
     }
 
     /**
@@ -672,9 +671,9 @@ class ServiceClient extends BaseClient
      * @return V1\RespondQueryTaskCompletedResponse
      * @throws ServiceClientException
      */
-    public function RespondQueryTaskCompleted(V1\RespondQueryTaskCompletedRequest $arg, ContextInterface $ctx = null) : V1\RespondQueryTaskCompletedResponse
+    public function RespondQueryTaskCompleted(V1\RespondQueryTaskCompletedRequest $arg, ContextInterface $ctx = null): V1\RespondQueryTaskCompletedResponse
     {
-        return $this->invoke("RespondQueryTaskCompleted", $arg, $ctx);
+        return $this->invoke('RespondQueryTaskCompleted', $arg, $ctx);
     }
 
     /**
@@ -696,9 +695,9 @@ class ServiceClient extends BaseClient
      * @return V1\ResetStickyTaskQueueResponse
      * @throws ServiceClientException
      */
-    public function ResetStickyTaskQueue(V1\ResetStickyTaskQueueRequest $arg, ContextInterface $ctx = null) : V1\ResetStickyTaskQueueResponse
+    public function ResetStickyTaskQueue(V1\ResetStickyTaskQueueRequest $arg, ContextInterface $ctx = null): V1\ResetStickyTaskQueueResponse
     {
-        return $this->invoke("ResetStickyTaskQueue", $arg, $ctx);
+        return $this->invoke('ResetStickyTaskQueue', $arg, $ctx);
     }
 
     /**
@@ -709,9 +708,9 @@ class ServiceClient extends BaseClient
      * @return V1\QueryWorkflowResponse
      * @throws ServiceClientException
      */
-    public function QueryWorkflow(V1\QueryWorkflowRequest $arg, ContextInterface $ctx = null) : V1\QueryWorkflowResponse
+    public function QueryWorkflow(V1\QueryWorkflowRequest $arg, ContextInterface $ctx = null): V1\QueryWorkflowResponse
     {
-        return $this->invoke("QueryWorkflow", $arg, $ctx);
+        return $this->invoke('QueryWorkflow', $arg, $ctx);
     }
 
     /**
@@ -723,9 +722,9 @@ class ServiceClient extends BaseClient
      * @return V1\DescribeWorkflowExecutionResponse
      * @throws ServiceClientException
      */
-    public function DescribeWorkflowExecution(V1\DescribeWorkflowExecutionRequest $arg, ContextInterface $ctx = null) : V1\DescribeWorkflowExecutionResponse
+    public function DescribeWorkflowExecution(V1\DescribeWorkflowExecutionRequest $arg, ContextInterface $ctx = null): V1\DescribeWorkflowExecutionResponse
     {
-        return $this->invoke("DescribeWorkflowExecution", $arg, $ctx);
+        return $this->invoke('DescribeWorkflowExecution', $arg, $ctx);
     }
 
     /**
@@ -740,9 +739,9 @@ class ServiceClient extends BaseClient
      * @return V1\DescribeTaskQueueResponse
      * @throws ServiceClientException
      */
-    public function DescribeTaskQueue(V1\DescribeTaskQueueRequest $arg, ContextInterface $ctx = null) : V1\DescribeTaskQueueResponse
+    public function DescribeTaskQueue(V1\DescribeTaskQueueRequest $arg, ContextInterface $ctx = null): V1\DescribeTaskQueueResponse
     {
-        return $this->invoke("DescribeTaskQueue", $arg, $ctx);
+        return $this->invoke('DescribeTaskQueue', $arg, $ctx);
     }
 
     /**
@@ -753,9 +752,9 @@ class ServiceClient extends BaseClient
      * @return V1\GetClusterInfoResponse
      * @throws ServiceClientException
      */
-    public function GetClusterInfo(V1\GetClusterInfoRequest $arg, ContextInterface $ctx = null) : V1\GetClusterInfoResponse
+    public function GetClusterInfo(V1\GetClusterInfoRequest $arg, ContextInterface $ctx = null): V1\GetClusterInfoResponse
     {
-        return $this->invoke("GetClusterInfo", $arg, $ctx);
+        return $this->invoke('GetClusterInfo', $arg, $ctx);
     }
 
     /**
@@ -766,9 +765,9 @@ class ServiceClient extends BaseClient
      * @return V1\GetSystemInfoResponse
      * @throws ServiceClientException
      */
-    public function GetSystemInfo(V1\GetSystemInfoRequest $arg, ContextInterface $ctx = null) : V1\GetSystemInfoResponse
+    public function GetSystemInfo(V1\GetSystemInfoRequest $arg, ContextInterface $ctx = null): V1\GetSystemInfoResponse
     {
-        return $this->invoke("GetSystemInfo", $arg, $ctx);
+        return $this->invoke('GetSystemInfo', $arg, $ctx);
     }
 
     /**
@@ -780,9 +779,9 @@ class ServiceClient extends BaseClient
      * @return V1\ListTaskQueuePartitionsResponse
      * @throws ServiceClientException
      */
-    public function ListTaskQueuePartitions(V1\ListTaskQueuePartitionsRequest $arg, ContextInterface $ctx = null) : V1\ListTaskQueuePartitionsResponse
+    public function ListTaskQueuePartitions(V1\ListTaskQueuePartitionsRequest $arg, ContextInterface $ctx = null): V1\ListTaskQueuePartitionsResponse
     {
-        return $this->invoke("ListTaskQueuePartitions", $arg, $ctx);
+        return $this->invoke('ListTaskQueuePartitions', $arg, $ctx);
     }
 
     /**
@@ -793,9 +792,9 @@ class ServiceClient extends BaseClient
      * @return V1\CreateScheduleResponse
      * @throws ServiceClientException
      */
-    public function CreateSchedule(V1\CreateScheduleRequest $arg, ContextInterface $ctx = null) : V1\CreateScheduleResponse
+    public function CreateSchedule(V1\CreateScheduleRequest $arg, ContextInterface $ctx = null): V1\CreateScheduleResponse
     {
-        return $this->invoke("CreateSchedule", $arg, $ctx);
+        return $this->invoke('CreateSchedule', $arg, $ctx);
     }
 
     /**
@@ -806,9 +805,9 @@ class ServiceClient extends BaseClient
      * @return V1\DescribeScheduleResponse
      * @throws ServiceClientException
      */
-    public function DescribeSchedule(V1\DescribeScheduleRequest $arg, ContextInterface $ctx = null) : V1\DescribeScheduleResponse
+    public function DescribeSchedule(V1\DescribeScheduleRequest $arg, ContextInterface $ctx = null): V1\DescribeScheduleResponse
     {
-        return $this->invoke("DescribeSchedule", $arg, $ctx);
+        return $this->invoke('DescribeSchedule', $arg, $ctx);
     }
 
     /**
@@ -819,9 +818,9 @@ class ServiceClient extends BaseClient
      * @return V1\UpdateScheduleResponse
      * @throws ServiceClientException
      */
-    public function UpdateSchedule(V1\UpdateScheduleRequest $arg, ContextInterface $ctx = null) : V1\UpdateScheduleResponse
+    public function UpdateSchedule(V1\UpdateScheduleRequest $arg, ContextInterface $ctx = null): V1\UpdateScheduleResponse
     {
-        return $this->invoke("UpdateSchedule", $arg, $ctx);
+        return $this->invoke('UpdateSchedule', $arg, $ctx);
     }
 
     /**
@@ -832,9 +831,9 @@ class ServiceClient extends BaseClient
      * @return V1\PatchScheduleResponse
      * @throws ServiceClientException
      */
-    public function PatchSchedule(V1\PatchScheduleRequest $arg, ContextInterface $ctx = null) : V1\PatchScheduleResponse
+    public function PatchSchedule(V1\PatchScheduleRequest $arg, ContextInterface $ctx = null): V1\PatchScheduleResponse
     {
-        return $this->invoke("PatchSchedule", $arg, $ctx);
+        return $this->invoke('PatchSchedule', $arg, $ctx);
     }
 
     /**
@@ -845,9 +844,9 @@ class ServiceClient extends BaseClient
      * @return V1\ListScheduleMatchingTimesResponse
      * @throws ServiceClientException
      */
-    public function ListScheduleMatchingTimes(V1\ListScheduleMatchingTimesRequest $arg, ContextInterface $ctx = null) : V1\ListScheduleMatchingTimesResponse
+    public function ListScheduleMatchingTimes(V1\ListScheduleMatchingTimesRequest $arg, ContextInterface $ctx = null): V1\ListScheduleMatchingTimesResponse
     {
-        return $this->invoke("ListScheduleMatchingTimes", $arg, $ctx);
+        return $this->invoke('ListScheduleMatchingTimes', $arg, $ctx);
     }
 
     /**
@@ -858,9 +857,9 @@ class ServiceClient extends BaseClient
      * @return V1\DeleteScheduleResponse
      * @throws ServiceClientException
      */
-    public function DeleteSchedule(V1\DeleteScheduleRequest $arg, ContextInterface $ctx = null) : V1\DeleteScheduleResponse
+    public function DeleteSchedule(V1\DeleteScheduleRequest $arg, ContextInterface $ctx = null): V1\DeleteScheduleResponse
     {
-        return $this->invoke("DeleteSchedule", $arg, $ctx);
+        return $this->invoke('DeleteSchedule', $arg, $ctx);
     }
 
     /**
@@ -871,9 +870,9 @@ class ServiceClient extends BaseClient
      * @return V1\ListSchedulesResponse
      * @throws ServiceClientException
      */
-    public function ListSchedules(V1\ListSchedulesRequest $arg, ContextInterface $ctx = null) : V1\ListSchedulesResponse
+    public function ListSchedules(V1\ListSchedulesRequest $arg, ContextInterface $ctx = null): V1\ListSchedulesResponse
     {
-        return $this->invoke("ListSchedules", $arg, $ctx);
+        return $this->invoke('ListSchedules', $arg, $ctx);
     }
 
     /**
@@ -906,9 +905,9 @@ class ServiceClient extends BaseClient
      * @return V1\UpdateWorkerBuildIdCompatibilityResponse
      * @throws ServiceClientException
      */
-    public function UpdateWorkerBuildIdCompatibility(V1\UpdateWorkerBuildIdCompatibilityRequest $arg, ContextInterface $ctx = null) : V1\UpdateWorkerBuildIdCompatibilityResponse
+    public function UpdateWorkerBuildIdCompatibility(V1\UpdateWorkerBuildIdCompatibilityRequest $arg, ContextInterface $ctx = null): V1\UpdateWorkerBuildIdCompatibilityResponse
     {
-        return $this->invoke("UpdateWorkerBuildIdCompatibility", $arg, $ctx);
+        return $this->invoke('UpdateWorkerBuildIdCompatibility', $arg, $ctx);
     }
 
     /**
@@ -920,9 +919,9 @@ class ServiceClient extends BaseClient
      * @return V1\GetWorkerBuildIdCompatibilityResponse
      * @throws ServiceClientException
      */
-    public function GetWorkerBuildIdCompatibility(V1\GetWorkerBuildIdCompatibilityRequest $arg, ContextInterface $ctx = null) : V1\GetWorkerBuildIdCompatibilityResponse
+    public function GetWorkerBuildIdCompatibility(V1\GetWorkerBuildIdCompatibilityRequest $arg, ContextInterface $ctx = null): V1\GetWorkerBuildIdCompatibilityResponse
     {
-        return $this->invoke("GetWorkerBuildIdCompatibility", $arg, $ctx);
+        return $this->invoke('GetWorkerBuildIdCompatibility', $arg, $ctx);
     }
 
     /**
@@ -938,9 +937,9 @@ class ServiceClient extends BaseClient
      * @return V1\UpdateWorkerVersioningRulesResponse
      * @throws ServiceClientException
      */
-    public function UpdateWorkerVersioningRules(V1\UpdateWorkerVersioningRulesRequest $arg, ContextInterface $ctx = null) : V1\UpdateWorkerVersioningRulesResponse
+    public function UpdateWorkerVersioningRules(V1\UpdateWorkerVersioningRulesRequest $arg, ContextInterface $ctx = null): V1\UpdateWorkerVersioningRulesResponse
     {
-        return $this->invoke("UpdateWorkerVersioningRules", $arg, $ctx);
+        return $this->invoke('UpdateWorkerVersioningRules', $arg, $ctx);
     }
 
     /**
@@ -953,9 +952,9 @@ class ServiceClient extends BaseClient
      * @return V1\GetWorkerVersioningRulesResponse
      * @throws ServiceClientException
      */
-    public function GetWorkerVersioningRules(V1\GetWorkerVersioningRulesRequest $arg, ContextInterface $ctx = null) : V1\GetWorkerVersioningRulesResponse
+    public function GetWorkerVersioningRules(V1\GetWorkerVersioningRulesRequest $arg, ContextInterface $ctx = null): V1\GetWorkerVersioningRulesResponse
     {
-        return $this->invoke("GetWorkerVersioningRules", $arg, $ctx);
+        return $this->invoke('GetWorkerVersioningRules', $arg, $ctx);
     }
 
     /**
@@ -986,9 +985,9 @@ class ServiceClient extends BaseClient
      * @return V1\GetWorkerTaskReachabilityResponse
      * @throws ServiceClientException
      */
-    public function GetWorkerTaskReachability(V1\GetWorkerTaskReachabilityRequest $arg, ContextInterface $ctx = null) : V1\GetWorkerTaskReachabilityResponse
+    public function GetWorkerTaskReachability(V1\GetWorkerTaskReachabilityRequest $arg, ContextInterface $ctx = null): V1\GetWorkerTaskReachabilityResponse
     {
-        return $this->invoke("GetWorkerTaskReachability", $arg, $ctx);
+        return $this->invoke('GetWorkerTaskReachability', $arg, $ctx);
     }
 
     /**
@@ -999,9 +998,9 @@ class ServiceClient extends BaseClient
      * @return V1\UpdateWorkflowExecutionResponse
      * @throws ServiceClientException
      */
-    public function UpdateWorkflowExecution(V1\UpdateWorkflowExecutionRequest $arg, ContextInterface $ctx = null) : V1\UpdateWorkflowExecutionResponse
+    public function UpdateWorkflowExecution(V1\UpdateWorkflowExecutionRequest $arg, ContextInterface $ctx = null): V1\UpdateWorkflowExecutionResponse
     {
-        return $this->invoke("UpdateWorkflowExecution", $arg, $ctx);
+        return $this->invoke('UpdateWorkflowExecution', $arg, $ctx);
     }
 
     /**
@@ -1019,9 +1018,9 @@ class ServiceClient extends BaseClient
      * @return V1\PollWorkflowExecutionUpdateResponse
      * @throws ServiceClientException
      */
-    public function PollWorkflowExecutionUpdate(V1\PollWorkflowExecutionUpdateRequest $arg, ContextInterface $ctx = null) : V1\PollWorkflowExecutionUpdateResponse
+    public function PollWorkflowExecutionUpdate(V1\PollWorkflowExecutionUpdateRequest $arg, ContextInterface $ctx = null): V1\PollWorkflowExecutionUpdateResponse
     {
-        return $this->invoke("PollWorkflowExecutionUpdate", $arg, $ctx);
+        return $this->invoke('PollWorkflowExecutionUpdate', $arg, $ctx);
     }
 
     /**
@@ -1032,9 +1031,9 @@ class ServiceClient extends BaseClient
      * @return V1\StartBatchOperationResponse
      * @throws ServiceClientException
      */
-    public function StartBatchOperation(V1\StartBatchOperationRequest $arg, ContextInterface $ctx = null) : V1\StartBatchOperationResponse
+    public function StartBatchOperation(V1\StartBatchOperationRequest $arg, ContextInterface $ctx = null): V1\StartBatchOperationResponse
     {
-        return $this->invoke("StartBatchOperation", $arg, $ctx);
+        return $this->invoke('StartBatchOperation', $arg, $ctx);
     }
 
     /**
@@ -1045,9 +1044,9 @@ class ServiceClient extends BaseClient
      * @return V1\StopBatchOperationResponse
      * @throws ServiceClientException
      */
-    public function StopBatchOperation(V1\StopBatchOperationRequest $arg, ContextInterface $ctx = null) : V1\StopBatchOperationResponse
+    public function StopBatchOperation(V1\StopBatchOperationRequest $arg, ContextInterface $ctx = null): V1\StopBatchOperationResponse
     {
-        return $this->invoke("StopBatchOperation", $arg, $ctx);
+        return $this->invoke('StopBatchOperation', $arg, $ctx);
     }
 
     /**
@@ -1058,9 +1057,9 @@ class ServiceClient extends BaseClient
      * @return V1\DescribeBatchOperationResponse
      * @throws ServiceClientException
      */
-    public function DescribeBatchOperation(V1\DescribeBatchOperationRequest $arg, ContextInterface $ctx = null) : V1\DescribeBatchOperationResponse
+    public function DescribeBatchOperation(V1\DescribeBatchOperationRequest $arg, ContextInterface $ctx = null): V1\DescribeBatchOperationResponse
     {
-        return $this->invoke("DescribeBatchOperation", $arg, $ctx);
+        return $this->invoke('DescribeBatchOperation', $arg, $ctx);
     }
 
     /**
@@ -1071,9 +1070,9 @@ class ServiceClient extends BaseClient
      * @return V1\ListBatchOperationsResponse
      * @throws ServiceClientException
      */
-    public function ListBatchOperations(V1\ListBatchOperationsRequest $arg, ContextInterface $ctx = null) : V1\ListBatchOperationsResponse
+    public function ListBatchOperations(V1\ListBatchOperationsRequest $arg, ContextInterface $ctx = null): V1\ListBatchOperationsResponse
     {
-        return $this->invoke("ListBatchOperations", $arg, $ctx);
+        return $this->invoke('ListBatchOperations', $arg, $ctx);
     }
 
     /**
@@ -1086,9 +1085,9 @@ class ServiceClient extends BaseClient
      * @return V1\PollNexusTaskQueueResponse
      * @throws ServiceClientException
      */
-    public function PollNexusTaskQueue(V1\PollNexusTaskQueueRequest $arg, ContextInterface $ctx = null) : V1\PollNexusTaskQueueResponse
+    public function PollNexusTaskQueue(V1\PollNexusTaskQueueRequest $arg, ContextInterface $ctx = null): V1\PollNexusTaskQueueResponse
     {
-        return $this->invoke("PollNexusTaskQueue", $arg, $ctx);
+        return $this->invoke('PollNexusTaskQueue', $arg, $ctx);
     }
 
     /**
@@ -1102,9 +1101,9 @@ class ServiceClient extends BaseClient
      * @return V1\RespondNexusTaskCompletedResponse
      * @throws ServiceClientException
      */
-    public function RespondNexusTaskCompleted(V1\RespondNexusTaskCompletedRequest $arg, ContextInterface $ctx = null) : V1\RespondNexusTaskCompletedResponse
+    public function RespondNexusTaskCompleted(V1\RespondNexusTaskCompletedRequest $arg, ContextInterface $ctx = null): V1\RespondNexusTaskCompletedResponse
     {
-        return $this->invoke("RespondNexusTaskCompleted", $arg, $ctx);
+        return $this->invoke('RespondNexusTaskCompleted', $arg, $ctx);
     }
 
     /**
@@ -1118,9 +1117,8 @@ class ServiceClient extends BaseClient
      * @return V1\RespondNexusTaskFailedResponse
      * @throws ServiceClientException
      */
-    public function RespondNexusTaskFailed(V1\RespondNexusTaskFailedRequest $arg, ContextInterface $ctx = null) : V1\RespondNexusTaskFailedResponse
+    public function RespondNexusTaskFailed(V1\RespondNexusTaskFailedRequest $arg, ContextInterface $ctx = null): V1\RespondNexusTaskFailedResponse
     {
-        return $this->invoke("RespondNexusTaskFailed", $arg, $ctx);
+        return $this->invoke('RespondNexusTaskFailed', $arg, $ctx);
     }
 }
-

--- a/src/Client/GRPC/ServiceClientInterface.php
+++ b/src/Client/GRPC/ServiceClientInterface.php
@@ -6,7 +6,6 @@
  * file that was distributed with this source code.
  */
 
-
 namespace Temporal\Client\GRPC;
 
 use Temporal\Api\Workflowservice\V1;
@@ -14,11 +13,11 @@ use Temporal\Exception\Client\ServiceClientException;
 
 interface ServiceClientInterface
 {
-    public function getContext() : ContextInterface;
-    public function withContext(ContextInterface $context) : static;
-    public function withAuthKey(\Stringable|string $key) : static;
-    public function getConnection() : \Temporal\Client\GRPC\Connection\ConnectionInterface;
-    public function getServerCapabilities() : ?\Temporal\Client\Common\ServerCapabilities;
+    public function getContext(): ContextInterface;
+    public function withContext(ContextInterface $context): static;
+    public function withAuthKey(\Stringable|string $key): static;
+    public function getConnection(): \Temporal\Client\GRPC\Connection\ConnectionInterface;
+    public function getServerCapabilities(): ?\Temporal\Client\Common\ServerCapabilities;
     /**
      * RegisterNamespace creates a new namespace which can be used as a container for
      * all resources.
@@ -36,7 +35,7 @@ interface ServiceClientInterface
      * @return V1\RegisterNamespaceResponse
      * @throws ServiceClientException
      */
-    public function RegisterNamespace(V1\RegisterNamespaceRequest $arg, ContextInterface $ctx = null) : V1\RegisterNamespaceResponse;
+    public function RegisterNamespace(V1\RegisterNamespaceRequest $arg, ContextInterface $ctx = null): V1\RegisterNamespaceResponse;
     /**
      * DescribeNamespace returns the information and configuration for a registered
      * namespace.
@@ -46,7 +45,7 @@ interface ServiceClientInterface
      * @return V1\DescribeNamespaceResponse
      * @throws ServiceClientException
      */
-    public function DescribeNamespace(V1\DescribeNamespaceRequest $arg, ContextInterface $ctx = null) : V1\DescribeNamespaceResponse;
+    public function DescribeNamespace(V1\DescribeNamespaceRequest $arg, ContextInterface $ctx = null): V1\DescribeNamespaceResponse;
     /**
      * ListNamespaces returns the information and configuration for all namespaces.
      *
@@ -55,7 +54,7 @@ interface ServiceClientInterface
      * @return V1\ListNamespacesResponse
      * @throws ServiceClientException
      */
-    public function ListNamespaces(V1\ListNamespacesRequest $arg, ContextInterface $ctx = null) : V1\ListNamespacesResponse;
+    public function ListNamespaces(V1\ListNamespacesRequest $arg, ContextInterface $ctx = null): V1\ListNamespacesResponse;
     /**
      * UpdateNamespace is used to update the information and configuration of a
      * registered
@@ -66,7 +65,7 @@ interface ServiceClientInterface
      * @return V1\UpdateNamespaceResponse
      * @throws ServiceClientException
      */
-    public function UpdateNamespace(V1\UpdateNamespaceRequest $arg, ContextInterface $ctx = null) : V1\UpdateNamespaceResponse;
+    public function UpdateNamespace(V1\UpdateNamespaceRequest $arg, ContextInterface $ctx = null): V1\UpdateNamespaceResponse;
     /**
      * DeprecateNamespace is used to update the state of a registered namespace to
      * DEPRECATED.
@@ -84,7 +83,7 @@ interface ServiceClientInterface
      * @return V1\DeprecateNamespaceResponse
      * @throws ServiceClientException
      */
-    public function DeprecateNamespace(V1\DeprecateNamespaceRequest $arg, ContextInterface $ctx = null) : V1\DeprecateNamespaceResponse;
+    public function DeprecateNamespace(V1\DeprecateNamespaceRequest $arg, ContextInterface $ctx = null): V1\DeprecateNamespaceResponse;
     /**
      * StartWorkflowExecution starts a new workflow execution.
      *
@@ -99,7 +98,7 @@ interface ServiceClientInterface
      * @return V1\StartWorkflowExecutionResponse
      * @throws ServiceClientException
      */
-    public function StartWorkflowExecution(V1\StartWorkflowExecutionRequest $arg, ContextInterface $ctx = null) : V1\StartWorkflowExecutionResponse;
+    public function StartWorkflowExecution(V1\StartWorkflowExecutionRequest $arg, ContextInterface $ctx = null): V1\StartWorkflowExecutionResponse;
     /**
      * GetWorkflowExecutionHistory returns the history of specified workflow execution.
      * Fails with
@@ -110,7 +109,7 @@ interface ServiceClientInterface
      * @return V1\GetWorkflowExecutionHistoryResponse
      * @throws ServiceClientException
      */
-    public function GetWorkflowExecutionHistory(V1\GetWorkflowExecutionHistoryRequest $arg, ContextInterface $ctx = null) : V1\GetWorkflowExecutionHistoryResponse;
+    public function GetWorkflowExecutionHistory(V1\GetWorkflowExecutionHistoryRequest $arg, ContextInterface $ctx = null): V1\GetWorkflowExecutionHistoryResponse;
     /**
      * GetWorkflowExecutionHistoryReverse returns the history of specified workflow
      * execution in reverse
@@ -123,7 +122,7 @@ interface ServiceClientInterface
      * @return V1\GetWorkflowExecutionHistoryReverseResponse
      * @throws ServiceClientException
      */
-    public function GetWorkflowExecutionHistoryReverse(V1\GetWorkflowExecutionHistoryReverseRequest $arg, ContextInterface $ctx = null) : V1\GetWorkflowExecutionHistoryReverseResponse;
+    public function GetWorkflowExecutionHistoryReverse(V1\GetWorkflowExecutionHistoryReverseRequest $arg, ContextInterface $ctx = null): V1\GetWorkflowExecutionHistoryReverseResponse;
     /**
      * PollWorkflowTaskQueue is called by workers to make progress on workflows.
      *
@@ -143,7 +142,7 @@ interface ServiceClientInterface
      * @return V1\PollWorkflowTaskQueueResponse
      * @throws ServiceClientException
      */
-    public function PollWorkflowTaskQueue(V1\PollWorkflowTaskQueueRequest $arg, ContextInterface $ctx = null) : V1\PollWorkflowTaskQueueResponse;
+    public function PollWorkflowTaskQueue(V1\PollWorkflowTaskQueueRequest $arg, ContextInterface $ctx = null): V1\PollWorkflowTaskQueueResponse;
     /**
      * RespondWorkflowTaskCompleted is called by workers to successfully complete
      * workflow tasks
@@ -163,7 +162,7 @@ interface ServiceClientInterface
      * @return V1\RespondWorkflowTaskCompletedResponse
      * @throws ServiceClientException
      */
-    public function RespondWorkflowTaskCompleted(V1\RespondWorkflowTaskCompletedRequest $arg, ContextInterface $ctx = null) : V1\RespondWorkflowTaskCompletedResponse;
+    public function RespondWorkflowTaskCompleted(V1\RespondWorkflowTaskCompletedRequest $arg, ContextInterface $ctx = null): V1\RespondWorkflowTaskCompletedResponse;
     /**
      * RespondWorkflowTaskFailed is called by workers to indicate the processing of a
      * workflow task
@@ -187,7 +186,7 @@ interface ServiceClientInterface
      * @return V1\RespondWorkflowTaskFailedResponse
      * @throws ServiceClientException
      */
-    public function RespondWorkflowTaskFailed(V1\RespondWorkflowTaskFailedRequest $arg, ContextInterface $ctx = null) : V1\RespondWorkflowTaskFailedResponse;
+    public function RespondWorkflowTaskFailed(V1\RespondWorkflowTaskFailedRequest $arg, ContextInterface $ctx = null): V1\RespondWorkflowTaskFailedResponse;
     /**
      * PollActivityTaskQueue is called by workers to process activity tasks from a
      * specific task
@@ -217,7 +216,7 @@ interface ServiceClientInterface
      * @return V1\PollActivityTaskQueueResponse
      * @throws ServiceClientException
      */
-    public function PollActivityTaskQueue(V1\PollActivityTaskQueueRequest $arg, ContextInterface $ctx = null) : V1\PollActivityTaskQueueResponse;
+    public function PollActivityTaskQueue(V1\PollActivityTaskQueueRequest $arg, ContextInterface $ctx = null): V1\PollActivityTaskQueueResponse;
     /**
      * RecordActivityTaskHeartbeat is optionally called by workers while they execute
      * activities.
@@ -236,7 +235,7 @@ interface ServiceClientInterface
      * @return V1\RecordActivityTaskHeartbeatResponse
      * @throws ServiceClientException
      */
-    public function RecordActivityTaskHeartbeat(V1\RecordActivityTaskHeartbeatRequest $arg, ContextInterface $ctx = null) : V1\RecordActivityTaskHeartbeatResponse;
+    public function RecordActivityTaskHeartbeat(V1\RecordActivityTaskHeartbeatRequest $arg, ContextInterface $ctx = null): V1\RecordActivityTaskHeartbeatResponse;
     /**
      * See `RecordActivityTaskHeartbeat`. This version allows clients to record
      * heartbeats by
@@ -250,7 +249,7 @@ interface ServiceClientInterface
      * @return V1\RecordActivityTaskHeartbeatByIdResponse
      * @throws ServiceClientException
      */
-    public function RecordActivityTaskHeartbeatById(V1\RecordActivityTaskHeartbeatByIdRequest $arg, ContextInterface $ctx = null) : V1\RecordActivityTaskHeartbeatByIdResponse;
+    public function RecordActivityTaskHeartbeatById(V1\RecordActivityTaskHeartbeatByIdRequest $arg, ContextInterface $ctx = null): V1\RecordActivityTaskHeartbeatByIdResponse;
     /**
      * RespondActivityTaskCompleted is called by workers when they successfully
      * complete an activity
@@ -268,7 +267,7 @@ interface ServiceClientInterface
      * @return V1\RespondActivityTaskCompletedResponse
      * @throws ServiceClientException
      */
-    public function RespondActivityTaskCompleted(V1\RespondActivityTaskCompletedRequest $arg, ContextInterface $ctx = null) : V1\RespondActivityTaskCompletedResponse;
+    public function RespondActivityTaskCompleted(V1\RespondActivityTaskCompletedRequest $arg, ContextInterface $ctx = null): V1\RespondActivityTaskCompletedResponse;
     /**
      * See `RecordActivityTaskCompleted`. This version allows clients to record
      * completions by
@@ -282,7 +281,7 @@ interface ServiceClientInterface
      * @return V1\RespondActivityTaskCompletedByIdResponse
      * @throws ServiceClientException
      */
-    public function RespondActivityTaskCompletedById(V1\RespondActivityTaskCompletedByIdRequest $arg, ContextInterface $ctx = null) : V1\RespondActivityTaskCompletedByIdResponse;
+    public function RespondActivityTaskCompletedById(V1\RespondActivityTaskCompletedByIdRequest $arg, ContextInterface $ctx = null): V1\RespondActivityTaskCompletedByIdResponse;
     /**
      * RespondActivityTaskFailed is called by workers when processing an activity task
      * fails.
@@ -299,7 +298,7 @@ interface ServiceClientInterface
      * @return V1\RespondActivityTaskFailedResponse
      * @throws ServiceClientException
      */
-    public function RespondActivityTaskFailed(V1\RespondActivityTaskFailedRequest $arg, ContextInterface $ctx = null) : V1\RespondActivityTaskFailedResponse;
+    public function RespondActivityTaskFailed(V1\RespondActivityTaskFailedRequest $arg, ContextInterface $ctx = null): V1\RespondActivityTaskFailedResponse;
     /**
      * See `RecordActivityTaskFailed`. This version allows clients to record failures
      * by
@@ -313,7 +312,7 @@ interface ServiceClientInterface
      * @return V1\RespondActivityTaskFailedByIdResponse
      * @throws ServiceClientException
      */
-    public function RespondActivityTaskFailedById(V1\RespondActivityTaskFailedByIdRequest $arg, ContextInterface $ctx = null) : V1\RespondActivityTaskFailedByIdResponse;
+    public function RespondActivityTaskFailedById(V1\RespondActivityTaskFailedByIdRequest $arg, ContextInterface $ctx = null): V1\RespondActivityTaskFailedByIdResponse;
     /**
      * RespondActivityTaskFailed is called by workers when processing an activity task
      * fails.
@@ -330,7 +329,7 @@ interface ServiceClientInterface
      * @return V1\RespondActivityTaskCanceledResponse
      * @throws ServiceClientException
      */
-    public function RespondActivityTaskCanceled(V1\RespondActivityTaskCanceledRequest $arg, ContextInterface $ctx = null) : V1\RespondActivityTaskCanceledResponse;
+    public function RespondActivityTaskCanceled(V1\RespondActivityTaskCanceledRequest $arg, ContextInterface $ctx = null): V1\RespondActivityTaskCanceledResponse;
     /**
      * See `RecordActivityTaskCanceled`. This version allows clients to record failures
      * by
@@ -344,7 +343,7 @@ interface ServiceClientInterface
      * @return V1\RespondActivityTaskCanceledByIdResponse
      * @throws ServiceClientException
      */
-    public function RespondActivityTaskCanceledById(V1\RespondActivityTaskCanceledByIdRequest $arg, ContextInterface $ctx = null) : V1\RespondActivityTaskCanceledByIdResponse;
+    public function RespondActivityTaskCanceledById(V1\RespondActivityTaskCanceledByIdRequest $arg, ContextInterface $ctx = null): V1\RespondActivityTaskCanceledByIdResponse;
     /**
      * RequestCancelWorkflowExecution is called by workers when they want to request
      * cancellation of
@@ -362,7 +361,7 @@ interface ServiceClientInterface
      * @return V1\RequestCancelWorkflowExecutionResponse
      * @throws ServiceClientException
      */
-    public function RequestCancelWorkflowExecution(V1\RequestCancelWorkflowExecutionRequest $arg, ContextInterface $ctx = null) : V1\RequestCancelWorkflowExecutionResponse;
+    public function RequestCancelWorkflowExecution(V1\RequestCancelWorkflowExecutionRequest $arg, ContextInterface $ctx = null): V1\RequestCancelWorkflowExecutionResponse;
     /**
      * SignalWorkflowExecution is used to send a signal to a running workflow
      * execution.
@@ -376,7 +375,7 @@ interface ServiceClientInterface
      * @return V1\SignalWorkflowExecutionResponse
      * @throws ServiceClientException
      */
-    public function SignalWorkflowExecution(V1\SignalWorkflowExecutionRequest $arg, ContextInterface $ctx = null) : V1\SignalWorkflowExecutionResponse;
+    public function SignalWorkflowExecution(V1\SignalWorkflowExecutionRequest $arg, ContextInterface $ctx = null): V1\SignalWorkflowExecutionResponse;
     /**
      * SignalWithStartWorkflowExecution is used to ensure a signal is sent to a
      * workflow, even if
@@ -399,7 +398,7 @@ interface ServiceClientInterface
      * @return V1\SignalWithStartWorkflowExecutionResponse
      * @throws ServiceClientException
      */
-    public function SignalWithStartWorkflowExecution(V1\SignalWithStartWorkflowExecutionRequest $arg, ContextInterface $ctx = null) : V1\SignalWithStartWorkflowExecutionResponse;
+    public function SignalWithStartWorkflowExecution(V1\SignalWithStartWorkflowExecutionRequest $arg, ContextInterface $ctx = null): V1\SignalWithStartWorkflowExecutionResponse;
     /**
      * ResetWorkflowExecution will reset an existing workflow execution to a specified
      * `WORKFLOW_TASK_COMPLETED` event (exclusive). It will immediately terminate the
@@ -413,7 +412,7 @@ interface ServiceClientInterface
      * @return V1\ResetWorkflowExecutionResponse
      * @throws ServiceClientException
      */
-    public function ResetWorkflowExecution(V1\ResetWorkflowExecutionRequest $arg, ContextInterface $ctx = null) : V1\ResetWorkflowExecutionResponse;
+    public function ResetWorkflowExecution(V1\ResetWorkflowExecutionRequest $arg, ContextInterface $ctx = null): V1\ResetWorkflowExecutionResponse;
     /**
      * TerminateWorkflowExecution terminates an existing workflow execution by
      * recording a
@@ -426,7 +425,7 @@ interface ServiceClientInterface
      * @return V1\TerminateWorkflowExecutionResponse
      * @throws ServiceClientException
      */
-    public function TerminateWorkflowExecution(V1\TerminateWorkflowExecutionRequest $arg, ContextInterface $ctx = null) : V1\TerminateWorkflowExecutionResponse;
+    public function TerminateWorkflowExecution(V1\TerminateWorkflowExecutionRequest $arg, ContextInterface $ctx = null): V1\TerminateWorkflowExecutionResponse;
     /**
      * DeleteWorkflowExecution asynchronously deletes a specific Workflow Execution
      * (when
@@ -444,7 +443,7 @@ interface ServiceClientInterface
      * @return V1\DeleteWorkflowExecutionResponse
      * @throws ServiceClientException
      */
-    public function DeleteWorkflowExecution(V1\DeleteWorkflowExecutionRequest $arg, ContextInterface $ctx = null) : V1\DeleteWorkflowExecutionResponse;
+    public function DeleteWorkflowExecution(V1\DeleteWorkflowExecutionRequest $arg, ContextInterface $ctx = null): V1\DeleteWorkflowExecutionResponse;
     /**
      * ListOpenWorkflowExecutions is a visibility API to list the open executions in a
      * specific namespace.
@@ -457,7 +456,7 @@ interface ServiceClientInterface
      * @return V1\ListOpenWorkflowExecutionsResponse
      * @throws ServiceClientException
      */
-    public function ListOpenWorkflowExecutions(V1\ListOpenWorkflowExecutionsRequest $arg, ContextInterface $ctx = null) : V1\ListOpenWorkflowExecutionsResponse;
+    public function ListOpenWorkflowExecutions(V1\ListOpenWorkflowExecutionsRequest $arg, ContextInterface $ctx = null): V1\ListOpenWorkflowExecutionsResponse;
     /**
      * ListClosedWorkflowExecutions is a visibility API to list the closed executions
      * in a specific namespace.
@@ -470,7 +469,7 @@ interface ServiceClientInterface
      * @return V1\ListClosedWorkflowExecutionsResponse
      * @throws ServiceClientException
      */
-    public function ListClosedWorkflowExecutions(V1\ListClosedWorkflowExecutionsRequest $arg, ContextInterface $ctx = null) : V1\ListClosedWorkflowExecutionsResponse;
+    public function ListClosedWorkflowExecutions(V1\ListClosedWorkflowExecutionsRequest $arg, ContextInterface $ctx = null): V1\ListClosedWorkflowExecutionsResponse;
     /**
      * ListWorkflowExecutions is a visibility API to list workflow executions in a
      * specific namespace.
@@ -480,7 +479,7 @@ interface ServiceClientInterface
      * @return V1\ListWorkflowExecutionsResponse
      * @throws ServiceClientException
      */
-    public function ListWorkflowExecutions(V1\ListWorkflowExecutionsRequest $arg, ContextInterface $ctx = null) : V1\ListWorkflowExecutionsResponse;
+    public function ListWorkflowExecutions(V1\ListWorkflowExecutionsRequest $arg, ContextInterface $ctx = null): V1\ListWorkflowExecutionsResponse;
     /**
      * ListArchivedWorkflowExecutions is a visibility API to list archived workflow
      * executions in a specific namespace.
@@ -490,7 +489,7 @@ interface ServiceClientInterface
      * @return V1\ListArchivedWorkflowExecutionsResponse
      * @throws ServiceClientException
      */
-    public function ListArchivedWorkflowExecutions(V1\ListArchivedWorkflowExecutionsRequest $arg, ContextInterface $ctx = null) : V1\ListArchivedWorkflowExecutionsResponse;
+    public function ListArchivedWorkflowExecutions(V1\ListArchivedWorkflowExecutionsRequest $arg, ContextInterface $ctx = null): V1\ListArchivedWorkflowExecutionsResponse;
     /**
      * ScanWorkflowExecutions is a visibility API to list large amount of workflow
      * executions in a specific namespace without order.
@@ -503,7 +502,7 @@ interface ServiceClientInterface
      * @return V1\ScanWorkflowExecutionsResponse
      * @throws ServiceClientException
      */
-    public function ScanWorkflowExecutions(V1\ScanWorkflowExecutionsRequest $arg, ContextInterface $ctx = null) : V1\ScanWorkflowExecutionsResponse;
+    public function ScanWorkflowExecutions(V1\ScanWorkflowExecutionsRequest $arg, ContextInterface $ctx = null): V1\ScanWorkflowExecutionsResponse;
     /**
      * CountWorkflowExecutions is a visibility API to count of workflow executions in a
      * specific namespace.
@@ -513,7 +512,7 @@ interface ServiceClientInterface
      * @return V1\CountWorkflowExecutionsResponse
      * @throws ServiceClientException
      */
-    public function CountWorkflowExecutions(V1\CountWorkflowExecutionsRequest $arg, ContextInterface $ctx = null) : V1\CountWorkflowExecutionsResponse;
+    public function CountWorkflowExecutions(V1\CountWorkflowExecutionsRequest $arg, ContextInterface $ctx = null): V1\CountWorkflowExecutionsResponse;
     /**
      * GetSearchAttributes is a visibility API to get all legal keys that could be used
      * in list APIs
@@ -527,7 +526,7 @@ interface ServiceClientInterface
      * @return V1\GetSearchAttributesResponse
      * @throws ServiceClientException
      */
-    public function GetSearchAttributes(V1\GetSearchAttributesRequest $arg, ContextInterface $ctx = null) : V1\GetSearchAttributesResponse;
+    public function GetSearchAttributes(V1\GetSearchAttributesRequest $arg, ContextInterface $ctx = null): V1\GetSearchAttributesResponse;
     /**
      * RespondQueryTaskCompleted is called by workers to complete queries which were
      * delivered on
@@ -545,7 +544,7 @@ interface ServiceClientInterface
      * @return V1\RespondQueryTaskCompletedResponse
      * @throws ServiceClientException
      */
-    public function RespondQueryTaskCompleted(V1\RespondQueryTaskCompletedRequest $arg, ContextInterface $ctx = null) : V1\RespondQueryTaskCompletedResponse;
+    public function RespondQueryTaskCompleted(V1\RespondQueryTaskCompletedRequest $arg, ContextInterface $ctx = null): V1\RespondQueryTaskCompletedResponse;
     /**
      * ResetStickyTaskQueue resets the sticky task queue related information in the
      * mutable state of
@@ -565,7 +564,7 @@ interface ServiceClientInterface
      * @return V1\ResetStickyTaskQueueResponse
      * @throws ServiceClientException
      */
-    public function ResetStickyTaskQueue(V1\ResetStickyTaskQueueRequest $arg, ContextInterface $ctx = null) : V1\ResetStickyTaskQueueResponse;
+    public function ResetStickyTaskQueue(V1\ResetStickyTaskQueueRequest $arg, ContextInterface $ctx = null): V1\ResetStickyTaskQueueResponse;
     /**
      * QueryWorkflow requests a query be executed for a specified workflow execution.
      *
@@ -574,7 +573,7 @@ interface ServiceClientInterface
      * @return V1\QueryWorkflowResponse
      * @throws ServiceClientException
      */
-    public function QueryWorkflow(V1\QueryWorkflowRequest $arg, ContextInterface $ctx = null) : V1\QueryWorkflowResponse;
+    public function QueryWorkflow(V1\QueryWorkflowRequest $arg, ContextInterface $ctx = null): V1\QueryWorkflowResponse;
     /**
      * DescribeWorkflowExecution returns information about the specified workflow
      * execution.
@@ -584,7 +583,7 @@ interface ServiceClientInterface
      * @return V1\DescribeWorkflowExecutionResponse
      * @throws ServiceClientException
      */
-    public function DescribeWorkflowExecution(V1\DescribeWorkflowExecutionRequest $arg, ContextInterface $ctx = null) : V1\DescribeWorkflowExecutionResponse;
+    public function DescribeWorkflowExecution(V1\DescribeWorkflowExecutionRequest $arg, ContextInterface $ctx = null): V1\DescribeWorkflowExecutionResponse;
     /**
      * DescribeTaskQueue returns the following information about the target task queue,
      * broken down by Build ID:
@@ -597,7 +596,7 @@ interface ServiceClientInterface
      * @return V1\DescribeTaskQueueResponse
      * @throws ServiceClientException
      */
-    public function DescribeTaskQueue(V1\DescribeTaskQueueRequest $arg, ContextInterface $ctx = null) : V1\DescribeTaskQueueResponse;
+    public function DescribeTaskQueue(V1\DescribeTaskQueueRequest $arg, ContextInterface $ctx = null): V1\DescribeTaskQueueResponse;
     /**
      * GetClusterInfo returns information about temporal cluster
      *
@@ -606,7 +605,7 @@ interface ServiceClientInterface
      * @return V1\GetClusterInfoResponse
      * @throws ServiceClientException
      */
-    public function GetClusterInfo(V1\GetClusterInfoRequest $arg, ContextInterface $ctx = null) : V1\GetClusterInfoResponse;
+    public function GetClusterInfo(V1\GetClusterInfoRequest $arg, ContextInterface $ctx = null): V1\GetClusterInfoResponse;
     /**
      * GetSystemInfo returns information about the system.
      *
@@ -615,7 +614,7 @@ interface ServiceClientInterface
      * @return V1\GetSystemInfoResponse
      * @throws ServiceClientException
      */
-    public function GetSystemInfo(V1\GetSystemInfoRequest $arg, ContextInterface $ctx = null) : V1\GetSystemInfoResponse;
+    public function GetSystemInfo(V1\GetSystemInfoRequest $arg, ContextInterface $ctx = null): V1\GetSystemInfoResponse;
     /**
      * (-- api-linter: core::0127::http-annotation=disabled
      * aip.dev/not-precedent: We do not expose this low-level API to HTTP. --)
@@ -625,7 +624,7 @@ interface ServiceClientInterface
      * @return V1\ListTaskQueuePartitionsResponse
      * @throws ServiceClientException
      */
-    public function ListTaskQueuePartitions(V1\ListTaskQueuePartitionsRequest $arg, ContextInterface $ctx = null) : V1\ListTaskQueuePartitionsResponse;
+    public function ListTaskQueuePartitions(V1\ListTaskQueuePartitionsRequest $arg, ContextInterface $ctx = null): V1\ListTaskQueuePartitionsResponse;
     /**
      * Creates a new schedule.
      *
@@ -634,7 +633,7 @@ interface ServiceClientInterface
      * @return V1\CreateScheduleResponse
      * @throws ServiceClientException
      */
-    public function CreateSchedule(V1\CreateScheduleRequest $arg, ContextInterface $ctx = null) : V1\CreateScheduleResponse;
+    public function CreateSchedule(V1\CreateScheduleRequest $arg, ContextInterface $ctx = null): V1\CreateScheduleResponse;
     /**
      * Returns the schedule description and current state of an existing schedule.
      *
@@ -643,7 +642,7 @@ interface ServiceClientInterface
      * @return V1\DescribeScheduleResponse
      * @throws ServiceClientException
      */
-    public function DescribeSchedule(V1\DescribeScheduleRequest $arg, ContextInterface $ctx = null) : V1\DescribeScheduleResponse;
+    public function DescribeSchedule(V1\DescribeScheduleRequest $arg, ContextInterface $ctx = null): V1\DescribeScheduleResponse;
     /**
      * Changes the configuration or state of an existing schedule.
      *
@@ -652,7 +651,7 @@ interface ServiceClientInterface
      * @return V1\UpdateScheduleResponse
      * @throws ServiceClientException
      */
-    public function UpdateSchedule(V1\UpdateScheduleRequest $arg, ContextInterface $ctx = null) : V1\UpdateScheduleResponse;
+    public function UpdateSchedule(V1\UpdateScheduleRequest $arg, ContextInterface $ctx = null): V1\UpdateScheduleResponse;
     /**
      * Makes a specific change to a schedule or triggers an immediate action.
      *
@@ -661,7 +660,7 @@ interface ServiceClientInterface
      * @return V1\PatchScheduleResponse
      * @throws ServiceClientException
      */
-    public function PatchSchedule(V1\PatchScheduleRequest $arg, ContextInterface $ctx = null) : V1\PatchScheduleResponse;
+    public function PatchSchedule(V1\PatchScheduleRequest $arg, ContextInterface $ctx = null): V1\PatchScheduleResponse;
     /**
      * Lists matching times within a range.
      *
@@ -670,7 +669,7 @@ interface ServiceClientInterface
      * @return V1\ListScheduleMatchingTimesResponse
      * @throws ServiceClientException
      */
-    public function ListScheduleMatchingTimes(V1\ListScheduleMatchingTimesRequest $arg, ContextInterface $ctx = null) : V1\ListScheduleMatchingTimesResponse;
+    public function ListScheduleMatchingTimes(V1\ListScheduleMatchingTimesRequest $arg, ContextInterface $ctx = null): V1\ListScheduleMatchingTimesResponse;
     /**
      * Deletes a schedule, removing it from the system.
      *
@@ -679,7 +678,7 @@ interface ServiceClientInterface
      * @return V1\DeleteScheduleResponse
      * @throws ServiceClientException
      */
-    public function DeleteSchedule(V1\DeleteScheduleRequest $arg, ContextInterface $ctx = null) : V1\DeleteScheduleResponse;
+    public function DeleteSchedule(V1\DeleteScheduleRequest $arg, ContextInterface $ctx = null): V1\DeleteScheduleResponse;
     /**
      * List all schedules in a namespace.
      *
@@ -688,7 +687,7 @@ interface ServiceClientInterface
      * @return V1\ListSchedulesResponse
      * @throws ServiceClientException
      */
-    public function ListSchedules(V1\ListSchedulesRequest $arg, ContextInterface $ctx = null) : V1\ListSchedulesResponse;
+    public function ListSchedules(V1\ListSchedulesRequest $arg, ContextInterface $ctx = null): V1\ListSchedulesResponse;
     /**
      * Deprecated. Use `UpdateWorkerVersioningRules`.
      *
@@ -719,7 +718,7 @@ interface ServiceClientInterface
      * @return V1\UpdateWorkerBuildIdCompatibilityResponse
      * @throws ServiceClientException
      */
-    public function UpdateWorkerBuildIdCompatibility(V1\UpdateWorkerBuildIdCompatibilityRequest $arg, ContextInterface $ctx = null) : V1\UpdateWorkerBuildIdCompatibilityResponse;
+    public function UpdateWorkerBuildIdCompatibility(V1\UpdateWorkerBuildIdCompatibilityRequest $arg, ContextInterface $ctx = null): V1\UpdateWorkerBuildIdCompatibilityResponse;
     /**
      * Deprecated. Use `GetWorkerVersioningRules`.
      * Fetches the worker build id versioning sets for a task queue.
@@ -729,7 +728,7 @@ interface ServiceClientInterface
      * @return V1\GetWorkerBuildIdCompatibilityResponse
      * @throws ServiceClientException
      */
-    public function GetWorkerBuildIdCompatibility(V1\GetWorkerBuildIdCompatibilityRequest $arg, ContextInterface $ctx = null) : V1\GetWorkerBuildIdCompatibilityResponse;
+    public function GetWorkerBuildIdCompatibility(V1\GetWorkerBuildIdCompatibilityRequest $arg, ContextInterface $ctx = null): V1\GetWorkerBuildIdCompatibilityResponse;
     /**
      * Allows updating the Build ID assignment and redirect rules for a given Task
      * Queue.
@@ -743,7 +742,7 @@ interface ServiceClientInterface
      * @return V1\UpdateWorkerVersioningRulesResponse
      * @throws ServiceClientException
      */
-    public function UpdateWorkerVersioningRules(V1\UpdateWorkerVersioningRulesRequest $arg, ContextInterface $ctx = null) : V1\UpdateWorkerVersioningRulesResponse;
+    public function UpdateWorkerVersioningRules(V1\UpdateWorkerVersioningRulesRequest $arg, ContextInterface $ctx = null): V1\UpdateWorkerVersioningRulesResponse;
     /**
      * Fetches the Build ID assignment and redirect rules for a Task Queue.
      * WARNING: Worker Versioning is not yet stable and the API and behavior may change
@@ -754,7 +753,7 @@ interface ServiceClientInterface
      * @return V1\GetWorkerVersioningRulesResponse
      * @throws ServiceClientException
      */
-    public function GetWorkerVersioningRules(V1\GetWorkerVersioningRulesRequest $arg, ContextInterface $ctx = null) : V1\GetWorkerVersioningRulesResponse;
+    public function GetWorkerVersioningRules(V1\GetWorkerVersioningRulesRequest $arg, ContextInterface $ctx = null): V1\GetWorkerVersioningRulesResponse;
     /**
      * Deprecated. Use `DescribeTaskQueue`.
      *
@@ -783,7 +782,7 @@ interface ServiceClientInterface
      * @return V1\GetWorkerTaskReachabilityResponse
      * @throws ServiceClientException
      */
-    public function GetWorkerTaskReachability(V1\GetWorkerTaskReachabilityRequest $arg, ContextInterface $ctx = null) : V1\GetWorkerTaskReachabilityResponse;
+    public function GetWorkerTaskReachability(V1\GetWorkerTaskReachabilityRequest $arg, ContextInterface $ctx = null): V1\GetWorkerTaskReachabilityResponse;
     /**
      * Invokes the specified update function on user workflow code.
      *
@@ -792,7 +791,7 @@ interface ServiceClientInterface
      * @return V1\UpdateWorkflowExecutionResponse
      * @throws ServiceClientException
      */
-    public function UpdateWorkflowExecution(V1\UpdateWorkflowExecutionRequest $arg, ContextInterface $ctx = null) : V1\UpdateWorkflowExecutionResponse;
+    public function UpdateWorkflowExecution(V1\UpdateWorkflowExecutionRequest $arg, ContextInterface $ctx = null): V1\UpdateWorkflowExecutionResponse;
     /**
      * Polls a workflow execution for the outcome of a workflow execution update
      * previously issued through the UpdateWorkflowExecution RPC. The effective
@@ -808,7 +807,7 @@ interface ServiceClientInterface
      * @return V1\PollWorkflowExecutionUpdateResponse
      * @throws ServiceClientException
      */
-    public function PollWorkflowExecutionUpdate(V1\PollWorkflowExecutionUpdateRequest $arg, ContextInterface $ctx = null) : V1\PollWorkflowExecutionUpdateResponse;
+    public function PollWorkflowExecutionUpdate(V1\PollWorkflowExecutionUpdateRequest $arg, ContextInterface $ctx = null): V1\PollWorkflowExecutionUpdateResponse;
     /**
      * StartBatchOperation starts a new batch operation
      *
@@ -817,7 +816,7 @@ interface ServiceClientInterface
      * @return V1\StartBatchOperationResponse
      * @throws ServiceClientException
      */
-    public function StartBatchOperation(V1\StartBatchOperationRequest $arg, ContextInterface $ctx = null) : V1\StartBatchOperationResponse;
+    public function StartBatchOperation(V1\StartBatchOperationRequest $arg, ContextInterface $ctx = null): V1\StartBatchOperationResponse;
     /**
      * StopBatchOperation stops a batch operation
      *
@@ -826,7 +825,7 @@ interface ServiceClientInterface
      * @return V1\StopBatchOperationResponse
      * @throws ServiceClientException
      */
-    public function StopBatchOperation(V1\StopBatchOperationRequest $arg, ContextInterface $ctx = null) : V1\StopBatchOperationResponse;
+    public function StopBatchOperation(V1\StopBatchOperationRequest $arg, ContextInterface $ctx = null): V1\StopBatchOperationResponse;
     /**
      * DescribeBatchOperation returns the information about a batch operation
      *
@@ -835,7 +834,7 @@ interface ServiceClientInterface
      * @return V1\DescribeBatchOperationResponse
      * @throws ServiceClientException
      */
-    public function DescribeBatchOperation(V1\DescribeBatchOperationRequest $arg, ContextInterface $ctx = null) : V1\DescribeBatchOperationResponse;
+    public function DescribeBatchOperation(V1\DescribeBatchOperationRequest $arg, ContextInterface $ctx = null): V1\DescribeBatchOperationResponse;
     /**
      * ListBatchOperations returns a list of batch operations
      *
@@ -844,7 +843,7 @@ interface ServiceClientInterface
      * @return V1\ListBatchOperationsResponse
      * @throws ServiceClientException
      */
-    public function ListBatchOperations(V1\ListBatchOperationsRequest $arg, ContextInterface $ctx = null) : V1\ListBatchOperationsResponse;
+    public function ListBatchOperations(V1\ListBatchOperationsRequest $arg, ContextInterface $ctx = null): V1\ListBatchOperationsResponse;
     /**
      * PollNexusTaskQueue is a long poll call used by workers to receive Nexus tasks.
      * (-- api-linter: core::0127::http-annotation=disabled
@@ -855,7 +854,7 @@ interface ServiceClientInterface
      * @return V1\PollNexusTaskQueueResponse
      * @throws ServiceClientException
      */
-    public function PollNexusTaskQueue(V1\PollNexusTaskQueueRequest $arg, ContextInterface $ctx = null) : V1\PollNexusTaskQueueResponse;
+    public function PollNexusTaskQueue(V1\PollNexusTaskQueueRequest $arg, ContextInterface $ctx = null): V1\PollNexusTaskQueueResponse;
     /**
      * RespondNexusTaskCompleted is called by workers to respond to Nexus tasks
      * received via PollNexusTaskQueue.
@@ -867,7 +866,7 @@ interface ServiceClientInterface
      * @return V1\RespondNexusTaskCompletedResponse
      * @throws ServiceClientException
      */
-    public function RespondNexusTaskCompleted(V1\RespondNexusTaskCompletedRequest $arg, ContextInterface $ctx = null) : V1\RespondNexusTaskCompletedResponse;
+    public function RespondNexusTaskCompleted(V1\RespondNexusTaskCompletedRequest $arg, ContextInterface $ctx = null): V1\RespondNexusTaskCompletedResponse;
     /**
      * RespondNexusTaskFailed is called by workers to fail Nexus tasks received via
      * PollNexusTaskQueue.
@@ -879,10 +878,9 @@ interface ServiceClientInterface
      * @return V1\RespondNexusTaskFailedResponse
      * @throws ServiceClientException
      */
-    public function RespondNexusTaskFailed(V1\RespondNexusTaskFailedRequest $arg, ContextInterface $ctx = null) : V1\RespondNexusTaskFailedResponse;
+    public function RespondNexusTaskFailed(V1\RespondNexusTaskFailedRequest $arg, ContextInterface $ctx = null): V1\RespondNexusTaskFailedResponse;
     /**
      * Close the communication channel associated with this stub.
      */
-    public function close() : void;
+    public function close(): void;
 }
-

--- a/src/Client/Schedule/Spec/IntervalSpec.php
+++ b/src/Client/Schedule/Spec/IntervalSpec.php
@@ -30,7 +30,6 @@ final class IntervalSpec
     private function __construct(
         #[Marshal(name: 'interval', of: Duration::class)]
         public readonly \DateInterval $interval,
-
         #[Marshal(name: 'phase', of: Duration::class)]
         public readonly \DateInterval $phase,
     ) {

--- a/src/Client/Schedule/Spec/ScheduleSpec.php
+++ b/src/Client/Schedule/Spec/ScheduleSpec.php
@@ -165,7 +165,7 @@ final class ScheduleSpec
     public function withCronStringList(\Stringable|string ...$cron): self
     {
         /** @see self::$cronStringList */
-        return $this->with('cronStringList', \array_map(static fn($item) => (string)$item, $cron));
+        return $this->with('cronStringList', \array_map(static fn ($item) => (string)$item, $cron));
     }
 
     /**

--- a/src/Client/ScheduleClientInterface.php
+++ b/src/Client/ScheduleClientInterface.php
@@ -49,5 +49,5 @@ interface ScheduleClientInterface extends ClientContextInterface
      *
      * @return Paginator<ScheduleListEntry>
      */
-    public function listSchedules(?string $namespace = null, int $pageSize = 0,): Paginator;
+    public function listSchedules(?string $namespace = null, int $pageSize = 0): Paginator;
 }

--- a/src/Client/Update/WaitPolicy.php
+++ b/src/Client/Update/WaitPolicy.php
@@ -20,7 +20,7 @@ final class WaitPolicy
     /**
      * Indicates the update lifecycle stage that the gRPC call should wait for before returning.
      */
-    #[Marshal(name: "lifecycle_stage")]
+    #[Marshal(name: 'lifecycle_stage')]
     public readonly LifecycleStage $lifecycleStage;
 
     private function __construct()

--- a/src/Client/WorkflowClient.php
+++ b/src/Client/WorkflowClient.php
@@ -338,7 +338,7 @@ class WorkflowClient implements WorkflowClientInterface
                 $request->setNextPageToken($nextPageToken);
             } while ($nextPageToken !== '');
         };
-        $counter = fn(): int => $this->countWorkflowExecutions($query, $namespace)->count;
+        $counter = fn (): int => $this->countWorkflowExecutions($query, $namespace)->count;
 
         return Paginator::createFromGenerator($loader($request), $counter);
     }
@@ -380,7 +380,8 @@ class WorkflowClient implements WorkflowClientInterface
             ->setHistoryEventFilterType($historyEventFilterType)
             ->setSkipArchival($skipArchival)
             ->setMaximumPageSize($pageSize)
-            ->setExecution((new \Temporal\Api\Common\V1\WorkflowExecution())
+            ->setExecution(
+                (new \Temporal\Api\Common\V1\WorkflowExecution())
                 ->setWorkflowId($execution->getID())
                 ->setRunId(
                     $execution->getRunID() ?? throw new InvalidArgumentException('Execution Run ID is required.'),

--- a/src/Client/WorkflowOptions.php
+++ b/src/Client/WorkflowOptions.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace Temporal\Client;
 
 use Carbon\CarbonInterval;
-use JetBrains\PhpStorm\ExpectedValues;
 use JetBrains\PhpStorm\Pure;
 use Temporal\Api\Common\V1\Memo;
 use Temporal\Api\Common\V1\SearchAttributes;

--- a/src/DataConverter/ProtoConverter.php
+++ b/src/DataConverter/ProtoConverter.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 
 namespace Temporal\DataConverter;
 
-use Google\Protobuf\DescriptorPool;
 use Google\Protobuf\Internal\Message;
 use Temporal\Api\Common\V1\Payload;
 use Temporal\Exception\DataConverterException;

--- a/src/DataConverter/ProtoJsonConverter.php
+++ b/src/DataConverter/ProtoJsonConverter.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 
 namespace Temporal\DataConverter;
 
-use Google\Protobuf\DescriptorPool;
 use Google\Protobuf\Internal\Message;
 use Temporal\Api\Common\V1\Payload;
 use Temporal\Exception\DataConverterException;

--- a/src/Exception/Client/CanceledException.php
+++ b/src/Exception/Client/CanceledException.php
@@ -16,4 +16,5 @@ use Temporal\Exception\TemporalException;
 /**
  * RPC call was canceled.
  */
-class CanceledException extends TemporalException {}
+class CanceledException extends TemporalException
+{}

--- a/src/Exception/Client/TimeoutException.php
+++ b/src/Exception/Client/TimeoutException.php
@@ -16,4 +16,5 @@ use Temporal\Exception\TemporalException;
 /**
  * RPC timeout or cancellation.
  */
-class TimeoutException extends TemporalException {}
+class TimeoutException extends TemporalException
+{}

--- a/src/Exception/Client/WorkflowUpdateRPCTimeoutOrCanceledException.php
+++ b/src/Exception/Client/WorkflowUpdateRPCTimeoutOrCanceledException.php
@@ -17,7 +17,8 @@ namespace Temporal\Exception\Client;
  * @note this is not related to any general concept of timing out or cancelling a running update,
  *       this is only related to the client call itself.
  */
-class WorkflowUpdateRPCTimeoutOrCanceledException extends TimeoutException {
+class WorkflowUpdateRPCTimeoutOrCanceledException extends TimeoutException
+{
     private function __construct(string $message = '', int $code = 0, ?\Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);

--- a/src/Exception/Failure/FailureConverter.php
+++ b/src/Exception/Failure/FailureConverter.php
@@ -126,7 +126,7 @@ final class FailureConverter
                 $info
                     ->setActivityId($e->getActivityId())
                     ->setActivityType(new ActivityType([
-                        'name' => $e->getActivityType()
+                        'name' => $e->getActivityType(),
                     ]))
                     ->setIdentity($e->getIdentity())
                     ->setRetryState($e->getRetryState())
@@ -144,7 +144,7 @@ final class FailureConverter
                     ->setNamespace($e->getNamespace())
                     ->setRetryState($e->getRetryState())
                     ->setWorkflowType(new WorkflowType([
-                        'name' => $e->getWorkflowType()
+                        'name' => $e->getWorkflowType(),
                     ]))
                     ->setWorkflowExecution(new WorkflowExecution([
                         'workflow_id' => $e->getExecution()->getID(),
@@ -308,7 +308,7 @@ final class FailureConverter
                 continue;
             }
 
-            $renderer = static fn(): string => \sprintf(
+            $renderer = static fn (): string => \sprintf(
                 "%s%s%s\n%s%s%s%s(%s)",
                 \str_pad("#$i", $numPad, ' '),
                 $frame['file'] ?? '[internal function]',
@@ -337,7 +337,7 @@ final class FailureConverter
                     \count($internals),
                 );
             } else {
-                $result = [...$result, ...\array_map(static fn(callable $renderer) => $renderer(), $internals)];
+                $result = [...$result, ...\array_map(static fn (callable $renderer) => $renderer(), $internals)];
             }
 
             $internals = [];
@@ -364,11 +364,12 @@ final class FailureConverter
                 $arg === false => 'false',
                 $arg === null => 'null',
                 \is_array($arg) => 'array(' . count($arg) . ')',
-                \is_object($arg) => \get_class($arg),
+                \is_object($arg) => $arg::class,
                 \is_string($arg) => (string)\json_encode(
                     \strlen($arg) > 50
                         ? \substr($arg, 0, 50) . '...'
-                        : $arg, JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE
+                        : $arg,
+                    JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE
                 ),
                 \is_scalar($arg) => (string)$arg,
                 default => \get_debug_type($arg),

--- a/src/Interceptor/SimplePipelineProvider.php
+++ b/src/Interceptor/SimplePipelineProvider.php
@@ -31,9 +31,11 @@ class SimplePipelineProvider implements PipelineProvider
      */
     public function getPipeline(string $interceptorClass): Pipeline
     {
-        return $this->cache[$interceptorClass] ??= Pipeline::prepare(\array_filter(
-            $this->interceptors,
-            static fn(Interceptor $i): bool => $i instanceof $interceptorClass)
+        return $this->cache[$interceptorClass] ??= Pipeline::prepare(
+            \array_filter(
+                $this->interceptors,
+                static fn (Interceptor $i): bool => $i instanceof $interceptorClass
+            )
         );
     }
 }

--- a/src/Interceptor/WorkflowClient/DescribeInput.php
+++ b/src/Interceptor/WorkflowClient/DescribeInput.php
@@ -32,7 +32,7 @@ class DescribeInput
     ): self {
         return new self(
             $workflowExecution ?? $this->workflowExecution,
-                $namespace ?? $this->namespace,
+            $namespace ?? $this->namespace,
         );
     }
 }

--- a/src/Internal/Client/WorkflowStarter.php
+++ b/src/Internal/Client/WorkflowStarter.php
@@ -137,7 +137,8 @@ final class WorkflowStarter
      * @throws ServiceClientException
      * @throws WorkflowExecutionAlreadyStartedException
      */
-    private function executeRequest(StartWorkflowExecutionRequest|SignalWithStartWorkflowExecutionRequest $request,
+    private function executeRequest(
+        StartWorkflowExecutionRequest|SignalWithStartWorkflowExecutionRequest $request,
     ): WorkflowExecution {
         try {
             $response = $request instanceof StartWorkflowExecutionRequest

--- a/src/Internal/Declaration/Reader/WorkflowReader.php
+++ b/src/Internal/Declaration/Reader/WorkflowReader.php
@@ -94,7 +94,7 @@ class WorkflowReader extends Reader
 
     public function fromObject(object $object): WorkflowPrototype
     {
-        return $this->fromClass(get_class($object));
+        return $this->fromClass($object::class);
     }
 
     /**

--- a/src/Internal/Declaration/WorkflowInstance.php
+++ b/src/Internal/Declaration/WorkflowInstance.php
@@ -86,11 +86,11 @@ final class WorkflowInstance extends Instance implements WorkflowInstanceInterfa
         $updateValidators = $prototype->getValidateUpdateHandlers();
         foreach ($prototype->getUpdateHandlers() as $method => $reflection) {
             $fn = $this->createHandler($reflection);
-            $this->updateHandlers[$method] = fn(UpdateInput $input, Deferred $deferred): mixed =>
+            $this->updateHandlers[$method] = fn (UpdateInput $input, Deferred $deferred): mixed =>
                 ($this->updateExecutor)($input, $fn, $deferred);
             // Register validate update handlers
             $this->validateUpdateHandlers[$method] = \array_key_exists($method, $updateValidators)
-                ? fn(UpdateInput $input): mixed => ($this->updateValidator)(
+                ? fn (UpdateInput $input): mixed => ($this->updateValidator)(
                     $input,
                     $this->createHandler($updateValidators[$method]),
                 )
@@ -100,9 +100,7 @@ final class WorkflowInstance extends Instance implements WorkflowInstanceInterfa
         foreach ($prototype->getQueryHandlers() as $method => $reflection) {
             $fn = $this->createHandler($reflection);
             $this->queryHandlers[$method] = $this->pipeline->with(
-                function (QueryInput $input) use ($fn): mixed {
-                    return ($this->queryExecutor)($input, $fn);
-                },
+                fn (QueryInput $input): mixed => ($this->queryExecutor)($input, $fn),
                 /** @see WorkflowInboundCallsInterceptor::handleQuery() */
                 'handleQuery',
             )(...);
@@ -199,9 +197,7 @@ final class WorkflowInstance extends Instance implements WorkflowInstanceInterfa
         $fn = $this->createCallableHandler($handler);
 
         $this->queryHandlers[$name] = $this->pipeline->with(
-            function (QueryInput $input) use ($fn) {
-                return ($this->queryExecutor)($input, $fn);
-            },
+            fn (QueryInput $input) => ($this->queryExecutor)($input, $fn),
             /** @see WorkflowInboundCallsInterceptor::handleQuery() */
             'handleQuery',
         )(...);
@@ -217,9 +213,7 @@ final class WorkflowInstance extends Instance implements WorkflowInstanceInterfa
         $fn = $this->createCallableHandler($handler);
 
         $this->updateHandlers[$name] = $this->pipeline->with(
-            function (UpdateInput $input, Deferred $deferred) use ($fn) {
-                return ($this->updateExecutor)($input, $fn, $deferred);
-            },
+            fn (UpdateInput $input, Deferred $deferred) => ($this->updateExecutor)($input, $fn, $deferred),
             /** @see WorkflowInboundCallsInterceptor::handleUpdate() */
             'handleUpdate',
         )(...);

--- a/src/Internal/Mapper/ScheduleMapper.php
+++ b/src/Internal/Mapper/ScheduleMapper.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Temporal\Internal\Mapper;
 
 use Temporal\Api\Common\V1\Payloads;
-use Temporal\Api\Common\V1\RetryPolicy;
 use Temporal\Api\Common\V1\WorkflowType;
 use Temporal\Api\Schedule\V1\CalendarSpec;
 use Temporal\Api\Schedule\V1\IntervalSpec;
@@ -85,17 +84,17 @@ final class ScheduleMapper
         $result['structured_calendar'] = $this->prepareStructuredCalendar($result['structured_calendar'] ?? []);
 
         $result['calendar'] = \array_map(
-            static fn(array $item): CalendarSpec => new CalendarSpec($item),
+            static fn (array $item): CalendarSpec => new CalendarSpec($item),
             $result['calendar'] ?? [],
         );
 
         $result['exclude_calendar'] = \array_map(
-            static fn(array $item): CalendarSpec => new CalendarSpec($item),
+            static fn (array $item): CalendarSpec => new CalendarSpec($item),
             $result['exclude_calendar'] ?? [],
         );
 
         $result['interval'] = \array_map(
-            static fn(array $item): IntervalSpec => new IntervalSpec($item),
+            static fn (array $item): IntervalSpec => new IntervalSpec($item),
             $result['interval'] ?? [],
         );
 
@@ -112,7 +111,7 @@ final class ScheduleMapper
             // Convert Range fields
             foreach (['second', 'minute', 'hour', 'day_of_month', 'month', 'year', 'day_of_week'] as $key) {
                 $calendar[$key] = \array_map(
-                    static fn(array $item): Range => new Range($item),
+                    static fn (array $item): Range => new Range($item),
                     $calendar[$key] ?? [],
                 );
             }

--- a/src/Internal/Marshaller/Marshaller.php
+++ b/src/Internal/Marshaller/Marshaller.php
@@ -53,7 +53,7 @@ class Marshaller implements MarshallerInterface
      */
     public function marshal(object $from): array
     {
-        $mapper = $this->getMapper(\get_class($from));
+        $mapper = $this->getMapper($from::class);
 
         $result = [];
 

--- a/src/Internal/Marshaller/Meta/Marshal.php
+++ b/src/Internal/Marshaller/Meta/Marshal.php
@@ -13,7 +13,6 @@ namespace Temporal\Internal\Marshaller\Meta;
 
 use Spiral\Attributes\NamedArgumentConstructor;
 use Temporal\Internal\Marshaller\MarshallingRule;
-use Temporal\Internal\Marshaller\Type\NullableType;
 
 /**
  * You may use this annotation multiple times to specify multiple marshalling rules for a single property. It may be

--- a/src/Internal/Marshaller/Meta/Scope.php
+++ b/src/Internal/Marshaller/Meta/Scope.php
@@ -43,8 +43,8 @@ class Scope
      * @var int
      */
     public const VISIBILITY_ALL = self::VISIBILITY_PRIVATE
-                                | self::VISIBILITY_PROTECTED
-                                | self::VISIBILITY_PUBLIC;
+        | self::VISIBILITY_PROTECTED
+        | self::VISIBILITY_PUBLIC;
 
     /**
      * @var ExportScope

--- a/src/Internal/Marshaller/ProtoToArrayConverter.php
+++ b/src/Internal/Marshaller/ProtoToArrayConverter.php
@@ -48,7 +48,7 @@ final class ProtoToArrayConverter
     private function getMapper(Message $message): ?\Closure
     {
         $mapper = match ($message::class) {
-            Timestamp::class => static fn(Timestamp $input): DateTimeImmutable => DateTimeImmutable::createFromFormat(
+            Timestamp::class => static fn (Timestamp $input): DateTimeImmutable => DateTimeImmutable::createFromFormat(
                 'U.u',
                 \sprintf('%d.%d', $input->getSeconds(), $input->getNanos() / 1000),
             ),
@@ -60,21 +60,21 @@ final class ProtoToArrayConverter
                     )
                 );
             },
-            SearchAttributes::class => fn(SearchAttributes $input): EncodedCollection =>
+            SearchAttributes::class => fn (SearchAttributes $input): EncodedCollection =>
                 EncodedCollection::fromPayloadCollection(
                     $input->getIndexedFields(),
                     $this->converter,
                 ),
-            Memo::class => fn(Memo $input): EncodedCollection => EncodedCollection::fromPayloadCollection(
+            Memo::class => fn (Memo $input): EncodedCollection => EncodedCollection::fromPayloadCollection(
                 $input->getFields(),
                 $this->converter,
             ),
-            Payloads::class => fn(Payloads $input): ValuesInterface =>
+            Payloads::class => fn (Payloads $input): ValuesInterface =>
                 EncodedValues::fromPayloadCollection($input->getPayloads(), $this->converter),
-            Header::class => fn(Header $input): HeaderInterface =>
+            Header::class => fn (Header $input): HeaderInterface =>
                 \Temporal\Interceptor\Header::fromPayloadCollection($input->getFields(), $this->converter),
 
-            ScheduleAction::class => fn(ScheduleAction $scheduleAction): array => [
+            ScheduleAction::class => fn (ScheduleAction $scheduleAction): array => [
                 'action' => $this->convert(
                     // Use getter for `oneOf` field
                     $scheduleAction->{'get' . \str_replace('_', '', \ucwords($scheduleAction->getAction(), '_'))}()

--- a/src/Internal/Marshaller/Type/EnumType.php
+++ b/src/Internal/Marshaller/Type/EnumType.php
@@ -70,7 +70,7 @@ class EnumType extends Type implements RuleFactoryInterface
         }
 
         if (\is_array($value)) {
-           // Process the `value` key
+            // Process the `value` key
             if (\array_key_exists('value', $value)) {
                 return $this->classFQCN::from($value['value']);
             }

--- a/src/Internal/Promise/CancellationQueue.php
+++ b/src/Internal/Promise/CancellationQueue.php
@@ -13,7 +13,7 @@ class CancellationQueue
     private bool $started = false;
     private array $queue = [];
 
-    public function __invoke()
+    public function __invoke(): void
     {
         if ($this->started) {
             return;

--- a/src/Internal/Transport/Router/DestroyWorkflow.php
+++ b/src/Internal/Transport/Router/DestroyWorkflow.php
@@ -60,7 +60,7 @@ class DestroyWorkflow extends WorkflowProcessAwareRoute
         $process->cancel(new DestructMemorizedInstanceException());
         $this->loop->once(
             LoopInterface::ON_FINALLY,
-            function () use ($process) {
+            function () use ($process): void {
                 $process->destroy();
 
                 // Collect garbage if needed

--- a/src/Internal/Transport/Server.php
+++ b/src/Internal/Transport/Server.php
@@ -69,7 +69,8 @@ final class Server implements ServerInterface
 
         $result instanceof PromiseInterface or throw new \BadMethodCallException(\sprintf(
             self::ERROR_INVALID_RETURN_TYPE,
-            PromiseInterface::class, \get_debug_type($result),
+            PromiseInterface::class,
+            \get_debug_type($result),
         ));
 
         $result->then($this->onFulfilled($request), $this->onRejected($request));

--- a/src/Internal/Workflow/ActivityProxy.php
+++ b/src/Internal/Workflow/ActivityProxy.php
@@ -86,7 +86,7 @@ final class ActivityProxy extends Proxy
         return $handler->isLocalActivity()
             // Run local activity through an interceptor pipeline
             ? $this->callsInterceptor->with(
-                fn(ExecuteLocalActivityInput $input): PromiseInterface => $this->ctx
+                fn (ExecuteLocalActivityInput $input): PromiseInterface => $this->ctx
                     ->newUntypedActivityStub($input->options)
                     ->execute($input->type, $input->args, $input->returnType, true),
                 /** @see WorkflowOutboundCallsInterceptor::executeLocalActivity() */
@@ -103,7 +103,7 @@ final class ActivityProxy extends Proxy
 
             // Run activity through an interceptor pipeline
             : $this->callsInterceptor->with(
-                fn(ExecuteActivityInput $input): PromiseInterface => $this->ctx
+                fn (ExecuteActivityInput $input): PromiseInterface => $this->ctx
                     ->newUntypedActivityStub($input->options)
                     ->execute($input->type, $input->args, $input->returnType),
                 /** @see WorkflowOutboundCallsInterceptor::executeActivity() */

--- a/src/Internal/Workflow/ChildWorkflowProxy.php
+++ b/src/Internal/Workflow/ChildWorkflowProxy.php
@@ -13,7 +13,6 @@ namespace Temporal\Internal\Workflow;
 
 use React\Promise\PromiseInterface;
 use Temporal\DataConverter\Type;
-use Temporal\Internal\Client\WorkflowProxy;
 use Temporal\Internal\Declaration\Prototype\WorkflowPrototype;
 use Temporal\Internal\Support\Reflection;
 use Temporal\Internal\Transport\CompletableResultInterface;

--- a/src/Internal/Workflow/ChildWorkflowStub.php
+++ b/src/Internal/Workflow/ChildWorkflowStub.php
@@ -66,7 +66,7 @@ final class ChildWorkflowStub implements ChildWorkflowStubInterface
         return $this->execution->promise();
     }
 
-    public function start(... $args): PromiseInterface
+    public function start(...$args): PromiseInterface
     {
         if ($this->request !== null) {
             throw new \LogicException('Child workflow already has been executed');
@@ -104,7 +104,7 @@ final class ChildWorkflowStub implements ChildWorkflowStubInterface
      */
     public function execute(array $args = [], $returnType = null): PromiseInterface
     {
-        return $this->start(...$args)->then(fn() => $this->getResult($returnType));
+        return $this->start(...$args)->then(fn () => $this->getResult($returnType));
     }
 
     /**

--- a/src/Internal/Workflow/ExternalWorkflowStub.php
+++ b/src/Internal/Workflow/ExternalWorkflowStub.php
@@ -50,7 +50,7 @@ final class ExternalWorkflowStub implements ExternalWorkflowStubInterface
     public function signal(string $name, array $args = []): PromiseInterface
     {
         return $this->callsInterceptor->with(
-            fn(SignalExternalWorkflowInput $input): PromiseInterface => $this
+            fn (SignalExternalWorkflowInput $input): PromiseInterface => $this
                 ->request(
                     new SignalExternalWorkflow(
                         $input->namespace,
@@ -78,7 +78,7 @@ final class ExternalWorkflowStub implements ExternalWorkflowStubInterface
     public function cancel(): PromiseInterface
     {
         return $this->callsInterceptor->with(
-            fn(CancelExternalWorkflowInput $input): PromiseInterface => $this
+            fn (CancelExternalWorkflowInput $input): PromiseInterface => $this
                 ->request(new CancelExternalWorkflow($input->namespace, $input->workflowId, $input->runId)),
             /** @see WorkflowOutboundCallsInterceptor::cancelExternalWorkflow() */
             'cancelExternalWorkflow',

--- a/src/Internal/Workflow/Process/Process.php
+++ b/src/Internal/Workflow/Process/Process.php
@@ -108,7 +108,7 @@ class Process extends Scope implements ProcessInterface
                 $scope->startUpdate(
                     function () use ($handler, $inboundPipeline, $input): mixed {
                         return $inboundPipeline->with(
-                            static fn(UpdateInput $input): mixed => $handler($input->arguments),
+                            static fn (UpdateInput $input): mixed => $handler($input->arguments),
                             /** @see WorkflowInboundCallsInterceptor::handleUpdate() */
                             'handleUpdate',
                         )($input);
@@ -130,7 +130,7 @@ class Process extends Scope implements ProcessInterface
                 Workflow::setCurrentContext($this->scopeContext);
 
                 $inboundPipeline->with(
-                    function (SignalInput $input) use ($handler) {
+                    function (SignalInput $input) use ($handler): void {
                         $this->createScope(
                             true,
                             LoopInterface::ON_SIGNAL,

--- a/src/Internal/Workflow/Process/Scope.php
+++ b/src/Internal/Workflow/Process/Scope.php
@@ -170,8 +170,8 @@ class Scope implements CancellationScopeInterface, Destroyable
         // Update handler counter
         ++$this->context->getHandlerState()->updates;
         $this->then(
-            fn() => --$this->context->getHandlerState()->updates,
-            fn() => --$this->context->getHandlerState()->updates,
+            fn () => --$this->context->getHandlerState()->updates,
+            fn () => --$this->context->getHandlerState()->updates,
         );
 
         $this->then(
@@ -196,8 +196,8 @@ class Scope implements CancellationScopeInterface, Destroyable
         // Update handler counter
         ++$this->context->getHandlerState()->signals;
         $this->then(
-            fn() => --$this->context->getHandlerState()->signals,
-            fn() => --$this->context->getHandlerState()->signals,
+            fn () => --$this->context->getHandlerState()->signals,
+            fn () => --$this->context->getHandlerState()->signals,
         );
 
         // Create a coroutine generator

--- a/src/Internal/Workflow/WorkflowContext.php
+++ b/src/Internal/Workflow/WorkflowContext.php
@@ -218,7 +218,7 @@ class WorkflowContext implements WorkflowContextInterface, HeaderCarrier, Destro
     public function getVersion(string $changeId, int $minSupported, int $maxSupported): PromiseInterface
     {
         return $this->callsInterceptor->with(
-            fn(GetVersionInput $input): PromiseInterface => EncodedValues::decodePromise(
+            fn (GetVersionInput $input): PromiseInterface => EncodedValues::decodePromise(
                 $this->request(new GetVersion($input->changeId, $input->minSupported, $input->maxSupported)),
                 Type::TYPE_ANY,
             ),
@@ -254,7 +254,7 @@ class WorkflowContext implements WorkflowContextInterface, HeaderCarrier, Destro
         } catch (\Throwable) {
         }
 
-        $last = fn(): PromiseInterface => EncodedValues::decodePromise(
+        $last = fn (): PromiseInterface => EncodedValues::decodePromise(
             $this->request(new SideEffect(EncodedValues::fromValues([$value]))),
             $returnType,
         );
@@ -297,7 +297,7 @@ class WorkflowContext implements WorkflowContextInterface, HeaderCarrier, Destro
     public function panic(\Throwable $failure = null): PromiseInterface
     {
         return $this->callsInterceptor->with(
-            fn(PanicInput $failure): PromiseInterface => $this->request(new Panic($failure->failure), false),
+            fn (PanicInput $failure): PromiseInterface => $this->request(new Panic($failure->failure), false),
             /** @see WorkflowOutboundCallsInterceptor::panic() */
             'panic',
         )(new PanicInput($failure));
@@ -360,7 +360,7 @@ class WorkflowContext implements WorkflowContextInterface, HeaderCarrier, Destro
         mixed $returnType = null,
     ): PromiseInterface {
         return $this->callsInterceptor->with(
-            fn(ExecuteChildWorkflowInput $input): PromiseInterface => $this
+            fn (ExecuteChildWorkflowInput $input): PromiseInterface => $this
                 ->newUntypedChildWorkflowStub($input->type, $input->options)
                 ->execute($input->args, $input->returnType),
             /** @see WorkflowOutboundCallsInterceptor::executeChildWorkflow() */
@@ -432,14 +432,14 @@ class WorkflowContext implements WorkflowContextInterface, HeaderCarrier, Destro
 
         return $isLocal
             ? $this->callsInterceptor->with(
-                fn(ExecuteLocalActivityInput $input): PromiseInterface => $this
+                fn (ExecuteLocalActivityInput $input): PromiseInterface => $this
                     ->newUntypedActivityStub($input->options)
                     ->execute($input->type, $input->args, $input->returnType, true),
                 /** @see WorkflowOutboundCallsInterceptor::executeLocalActivity() */
                 'executeLocalActivity',
             )(new ExecuteLocalActivityInput($type, $args, $options, $returnType))
             : $this->callsInterceptor->with(
-                fn(ExecuteActivityInput $input): PromiseInterface => $this
+                fn (ExecuteActivityInput $input): PromiseInterface => $this
                     ->newUntypedActivityStub($input->options)
                     ->execute($input->type, $input->args, $input->returnType),
                 /** @see WorkflowOutboundCallsInterceptor::executeActivity() */
@@ -468,7 +468,7 @@ class WorkflowContext implements WorkflowContextInterface, HeaderCarrier, Destro
         $activities = $this->services->activitiesReader->fromClass($class);
 
         if (isset($activities[0]) && $activities[0]->isLocalActivity() && !$options instanceof LocalActivityOptions) {
-            throw new RuntimeException("Local activity can be used only with LocalActivityOptions");
+            throw new RuntimeException('Local activity can be used only with LocalActivityOptions');
         }
 
         return new ActivityProxy(
@@ -488,7 +488,7 @@ class WorkflowContext implements WorkflowContextInterface, HeaderCarrier, Destro
         $dateInterval = DateInterval::parse($interval, DateInterval::FORMAT_SECONDS);
 
         return $this->callsInterceptor->with(
-            fn(TimerInput $input): PromiseInterface => $this->request(new NewTimer($input->interval)),
+            fn (TimerInput $input): PromiseInterface => $this->request(new NewTimer($input->interval)),
             /** @see WorkflowOutboundCallsInterceptor::timer() */
             'timer',
         )(new TimerInput($dateInterval));
@@ -503,9 +503,7 @@ class WorkflowContext implements WorkflowContextInterface, HeaderCarrier, Destro
 
         // Intercept workflow outbound calls
         return $this->requestInterceptor->with(
-            function (RequestInterface $request): PromiseInterface {
-                return $this->client->request($request, $this);
-            },
+            fn (RequestInterface $request): PromiseInterface => $this->client->request($request, $this),
             /** @see WorkflowOutboundRequestInterceptor::handleOutboundRequest() */
             'handleOutboundRequest',
         )($request);
@@ -533,7 +531,7 @@ class WorkflowContext implements WorkflowContextInterface, HeaderCarrier, Destro
     public function upsertSearchAttributes(array $searchAttributes): void
     {
         $this->callsInterceptor->with(
-            fn(UpsertSearchAttributesInput $input): PromiseInterface
+            fn (UpsertSearchAttributesInput $input): PromiseInterface
                 => $this->request(new UpsertSearchAttributes($input->searchAttributes)),
             /** @see WorkflowOutboundCallsInterceptor::upsertSearchAttributes() */
             'upsertSearchAttributes',
@@ -546,7 +544,7 @@ class WorkflowContext implements WorkflowContextInterface, HeaderCarrier, Destro
     public function await(...$conditions): PromiseInterface
     {
         return $this->callsInterceptor->with(
-            fn(AwaitInput $input): PromiseInterface => $this->awaitRequest(...$input->conditions),
+            fn (AwaitInput $input): PromiseInterface => $this->awaitRequest(...$input->conditions),
             /** @see WorkflowOutboundCallsInterceptor::await() */
             'await',
         )(new AwaitInput($conditions));
@@ -613,7 +611,7 @@ class WorkflowContext implements WorkflowContextInterface, HeaderCarrier, Destro
      */
     public function uuid(): PromiseInterface
     {
-        return $this->sideEffect(static fn(): UuidInterface => \Ramsey\Uuid\Uuid::uuid4());
+        return $this->sideEffect(static fn (): UuidInterface => \Ramsey\Uuid\Uuid::uuid4());
     }
 
     /**
@@ -621,7 +619,7 @@ class WorkflowContext implements WorkflowContextInterface, HeaderCarrier, Destro
      */
     public function uuid4(): PromiseInterface
     {
-        return $this->sideEffect(static fn(): UuidInterface => \Ramsey\Uuid\Uuid::uuid4());
+        return $this->sideEffect(static fn (): UuidInterface => \Ramsey\Uuid\Uuid::uuid4());
     }
 
     /**
@@ -629,7 +627,7 @@ class WorkflowContext implements WorkflowContextInterface, HeaderCarrier, Destro
      */
     public function uuid7(?DateTimeInterface $dateTime = null): PromiseInterface
     {
-        return $this->sideEffect(static fn(): UuidInterface => \Ramsey\Uuid\Uuid::uuid7($dateTime));
+        return $this->sideEffect(static fn (): UuidInterface => \Ramsey\Uuid\Uuid::uuid7($dateTime));
     }
 
     /**
@@ -686,7 +684,7 @@ class WorkflowContext implements WorkflowContextInterface, HeaderCarrier, Destro
                 $this->resolveConditionGroup($conditionGroupId);
                 return $result;
             },
-            function ($reason) use ($conditionGroupId) {
+            function ($reason) use ($conditionGroupId): void {
                 $this->rejectConditionGroup($conditionGroupId);
                 // Throw the first reason
                 // It need to avoid memory leak when the related workflow is destroyed

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace Temporal;
 
 use React\Promise\Exception\LengthException;
-use React\Promise\Internal\RejectedPromise;
 use React\Promise\PromiseInterface;
 use Temporal\Internal\Promise\CancellationQueue;
 
@@ -39,7 +38,7 @@ final class Promise
      */
     public static function all(iterable $promises): PromiseInterface
     {
-        return self::map($promises, static fn($val): mixed => $val);
+        return self::map($promises, static fn ($val): mixed => $val);
     }
 
     /**
@@ -58,7 +57,7 @@ final class Promise
     public static function any(iterable $promises): PromiseInterface
     {
         return self::some([...$promises], 1)
-            ->then(static fn(array $values): mixed => \array_shift($values));
+            ->then(static fn (array $values): mixed => \array_shift($values));
     }
 
     /**
@@ -142,8 +141,11 @@ final class Promise
 
                             resolve($promiseOrValue)->then($fulfiller, $rejecter);
                         }
-                    }, $reject);
-            }, $cancellationQueue
+                    },
+                    $reject
+                );
+            },
+            $cancellationQueue
         );
     }
 
@@ -196,7 +198,8 @@ final class Promise
                                 );
                         }
                     }, $reject);
-            }, $cancellationQueue
+            },
+            $cancellationQueue
         );
     }
 
@@ -262,7 +265,8 @@ final class Promise
                         },
                         $reject,
                     );
-            }, $cancellationQueue
+            },
+            $cancellationQueue
         );
     }
 

--- a/src/Worker/ActivityInvocationCache/ActivityInvocationFailure.php
+++ b/src/Worker/ActivityInvocationCache/ActivityInvocationFailure.php
@@ -19,7 +19,7 @@ final class ActivityInvocationFailure
 
     public static function fromThrowable(Throwable $error): self
     {
-        return new self(get_class($error), $error->getMessage());
+        return new self($error::class, $error->getMessage());
     }
 
     public function toThrowable(): Throwable

--- a/src/Worker/ActivityInvocationCache/InMemoryActivityInvocationCache.php
+++ b/src/Worker/ActivityInvocationCache/InMemoryActivityInvocationCache.php
@@ -5,14 +5,9 @@ declare(strict_types=1);
 namespace Temporal\Worker\ActivityInvocationCache;
 
 use React\Promise\PromiseInterface;
-use Spiral\Goridge\RPC\RPC;
-use Spiral\RoadRunner\KeyValue\Factory;
-use Spiral\RoadRunner\KeyValue\StorageInterface;
 use Temporal\DataConverter\DataConverter;
 use Temporal\DataConverter\DataConverterInterface;
-use Temporal\DataConverter\EncodedValues;
 use Temporal\Exception\InvalidArgumentException;
-use Temporal\Worker\Transport\Command\RequestInterface;
 use Temporal\Worker\Transport\Command\ServerRequestInterface;
 use Throwable;
 

--- a/src/Worker/ActivityInvocationCache/RoadRunnerActivityInvocationCache.php
+++ b/src/Worker/ActivityInvocationCache/RoadRunnerActivityInvocationCache.php
@@ -13,6 +13,7 @@ use Temporal\DataConverter\DataConverterInterface;
 use Temporal\Exception\InvalidArgumentException;
 use Temporal\Worker\Transport\Command\ServerRequestInterface;
 use Throwable;
+
 use function React\Promise\reject;
 use function React\Promise\resolve;
 

--- a/src/Worker/Transport/Codec/JsonCodec/Encoder.php
+++ b/src/Worker/Transport/Codec/JsonCodec/Encoder.php
@@ -78,7 +78,7 @@ class Encoder
                 return $result;
 
             default:
-                throw new \InvalidArgumentException(\sprintf(self::ERROR_INVALID_COMMAND, \get_class($cmd)));
+                throw new \InvalidArgumentException(\sprintf(self::ERROR_INVALID_COMMAND, $cmd::class));
         }
     }
 }

--- a/src/Worker/Transport/Codec/ProtoCodec/Encoder.php
+++ b/src/Worker/Transport/Codec/ProtoCodec/Encoder.php
@@ -90,7 +90,7 @@ class Encoder
                 return $msg;
 
             default:
-                throw new \InvalidArgumentException(\sprintf(self::ERROR_INVALID_COMMAND, \get_class($cmd)));
+                throw new \InvalidArgumentException(\sprintf(self::ERROR_INVALID_COMMAND, $cmd::class));
         }
     }
 }

--- a/src/Worker/Transport/Command/RequestInterface.php
+++ b/src/Worker/Transport/Command/RequestInterface.php
@@ -13,7 +13,6 @@ namespace Temporal\Worker\Transport\Command;
 
 use Temporal\DataConverter\ValuesInterface;
 use Temporal\Interceptor\HeaderInterface;
-use Temporal\Internal\Interceptor\HeaderCarrier;
 
 /**
  * @psalm-type RequestOptions = array<non-empty-string, mixed>

--- a/src/Worker/Worker.php
+++ b/src/Worker/Worker.php
@@ -126,7 +126,7 @@ class Worker implements WorkerInterface, EventListenerInterface, DispatcherInter
     public function registerActivityImplementations(object ...$activity): WorkerInterface
     {
         foreach ($activity as $act) {
-            $this->registerActivity(\get_class($act), fn() => $act);
+            $this->registerActivity($act::class, fn () => $act);
         }
 
         return $this;

--- a/src/Workflow/ExternalWorkflowStubInterface.php
+++ b/src/Workflow/ExternalWorkflowStubInterface.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace Temporal\Workflow;
 
 use React\Promise\PromiseInterface;
-use Temporal\Internal\Transport\CompletableResultInterface;
 
 interface ExternalWorkflowStubInterface
 {

--- a/src/Workflow/WorkflowContextInterface.php
+++ b/src/Workflow/WorkflowContextInterface.php
@@ -275,7 +275,8 @@ interface WorkflowContextInterface extends EnvironmentInterface
      *
      * @return T
      */
-    public function newActivityStub(string $class,
+    public function newActivityStub(
+        string $class,
         ActivityOptionsInterface $options = null,
     ): object;
 


### PR DESCRIPTION
## What was changed
I see that we have php-cs-fixer config and library installed, but we dont run it as part of the CI. 

## Why?
Code style rules should be forced and handled automatically. This should not take up time for the reviewer or the contributors. 

## Checklist

Please review this PR by first looking at my manual changes in f45a9e2cd613619587a3cce93df4c7b435c5777b, then looking at the automatic changes in 85e48c3534d96176d896e20754a9464cecb47047.