### PR TITLE
Register Update handler dynamically

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -575,10 +575,6 @@
     <MissingClosureReturnType>
       <code><![CDATA[function (QueryInput $input) use ($fn) {]]></code>
     </MissingClosureReturnType>
-    <MoreSpecificImplementedParamType>
-      <code><![CDATA[$handler]]></code>
-      <code><![CDATA[$handler]]></code>
-    </MoreSpecificImplementedParamType>
     <PropertyNotSetInConstructor>
       <code><![CDATA[$queryExecutor]]></code>
       <code><![CDATA[$updateExecutor]]></code>

--- a/src/Internal/Declaration/WorkflowInstance.php
+++ b/src/Internal/Declaration/WorkflowInstance.php
@@ -190,7 +190,7 @@ final class WorkflowInstance extends Instance implements WorkflowInstanceInterfa
 
     /**
      * @param string $name
-     * @param callable(ValuesInterface):mixed $handler
+     * @param callable $handler
      * @throws \ReflectionException
      */
     public function addQueryHandler(string $name, callable $handler): void
@@ -208,7 +208,7 @@ final class WorkflowInstance extends Instance implements WorkflowInstanceInterfa
 
     /**
      * @param non-empty-string $name
-     * @param callable(ValuesInterface):mixed $handler
+     * @param callable $handler
      * @throws \ReflectionException
      */
     public function addUpdateHandler(string $name, callable $handler): void
@@ -222,6 +222,17 @@ final class WorkflowInstance extends Instance implements WorkflowInstanceInterfa
             /** @see WorkflowInboundCallsInterceptor::handleUpdate() */
             'handleUpdate',
         )(...);
+    }
+
+    /**
+     * @param non-empty-string $name
+     * @param callable $handler
+     * @throws \ReflectionException
+     */
+    public function addValidateUpdateHandler(string $name, callable $handler): void
+    {
+        $fn = $this->createCallableHandler($handler);
+        $this->validateUpdateHandlers[$name] = fn(UpdateInput $input): mixed => ($this->updateValidator)($input, $fn);
     }
 
     /**

--- a/src/Internal/Declaration/WorkflowInstanceInterface.php
+++ b/src/Internal/Declaration/WorkflowInstanceInterface.php
@@ -45,6 +45,12 @@ interface WorkflowInstanceInterface extends InstanceInterface
 
     /**
      * @param non-empty-string $name
+     * @param callable $handler
+     */
+    public function addValidateUpdateHandler(string $name, callable $handler): void;
+
+    /**
+     * @param non-empty-string $name
      * @return \Closure(ValuesInterface): void
      */
     public function getSignalHandler(string $name): \Closure;

--- a/src/Internal/Workflow/WorkflowContext.php
+++ b/src/Internal/Workflow/WorkflowContext.php
@@ -215,6 +215,17 @@ class WorkflowContext implements WorkflowContextInterface, HeaderCarrier, Destro
     /**
      * {@inheritDoc}
      */
+    public function registerUpdate(string $name, callable $handler, ?callable $validator): WorkflowContextInterface
+    {
+        $this->getWorkflowInstance()->addUpdateHandler($name, $handler);
+        $this->getWorkflowInstance()->addValidateUpdateHandler($name, $validator ?? fn() => null);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getVersion(string $changeId, int $minSupported, int $maxSupported): PromiseInterface
     {
         return $this->callsInterceptor->with(

--- a/src/Internal/Workflow/WorkflowContext.php
+++ b/src/Internal/Workflow/WorkflowContext.php
@@ -215,7 +215,7 @@ class WorkflowContext implements WorkflowContextInterface, HeaderCarrier, Destro
     /**
      * {@inheritDoc}
      */
-    public function registerUpdate(string $name, callable $handler, ?callable $validator): WorkflowContextInterface
+    public function registerUpdate(string $name, callable $handler, ?callable $validator): static
     {
         $this->getWorkflowInstance()->addUpdateHandler($name, $handler);
         $this->getWorkflowInstance()->addValidateUpdateHandler($name, $validator ?? fn() => null);

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -388,6 +388,17 @@ final class Workflow extends Facade
     }
 
     /**
+     * Registers an Update handler.
+     */
+    public static function registerUpdate(
+        string $name,
+        callable $handler,
+        ?callable $validator = null,
+    ): ScopedContextInterface {
+        return self::getCurrentContext()->registerUpdate($name, $handler, $validator);
+    }
+
+    /**
      * Updates the behavior of an existing workflow to resolve inconsistency errors during replay.
      *
      * The method is used to update the behavior (code) of an existing workflow

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -395,10 +395,13 @@ final class Workflow extends Facade
      * );
      * ```
      *
-     * Note that the validator must have the same signature as the Update method:
-     *
      * @param non-empty-string $name
+     * @param callable $handler Handler function to execute the update.
+     * @param callable|null $validator Validator function to check the input. It should throw an exception
+     *        if the input is invalid.
+     *        Note that the validator must have the same parameters as the handler.
      * @throws OutOfContextException in the absence of the workflow execution context.
+     * @since 2.11.0
      */
     public static function registerUpdate(
         string $name,

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -332,17 +332,12 @@ final class Workflow extends Facade
     }
 
     /**
-     * A method that allows you to dynamically register additional query
-     * handler in a workflow during the execution of a workflow.
+     * Register a Query handler in the Workflow.
      *
      * ```php
-     *  #[WorkflowMethod]
-     *  public function handler()
-     *  {
-     *      Workflow::registerQuery('query', function(string $argument) {
-     *          echo sprintf('Executed query "query" with argument "%s"', $argument);
-     *      });
-     *  }
+     * Workflow::registerQuery('query', function(string $argument) {
+     *     echo sprintf('Executed query "query" with argument "%s"', $argument);
+     * });
      * ```
      *
      * The same method ({@see WorkflowStubInterface::query()}) should be used
@@ -359,19 +354,12 @@ final class Workflow extends Facade
     }
 
     /**
-     * Registers a query with an additional signal handler.
-     *
-     * The method is similar to the {@see Workflow::registerQuery()}, but it
-     * registers an additional signal handler.
+     * Registers a Signal handler in the Workflow.
      *
      * ```php
-     *  #[WorkflowMethod]
-     *  public function handler()
-     *  {
-     *      Workflow::registerSignal('signal', function(string $argument) {
-     *          echo sprintf('Executed signal "signal" with argument "%s"', $argument);
-     *      });
-     *  }
+     * Workflow::registerSignal('signal', function(string $argument) {
+     *     echo sprintf('Executed signal "signal" with argument "%s"', $argument);
+     * });
      * ```
      *
      * The same method ({@see WorkflowStubInterface::signal()}) should be used
@@ -391,33 +379,26 @@ final class Workflow extends Facade
      * Registers an Update method in the Workflow.
      *
      * ```php
-     *  #[WorkflowMethod]
-     *  public function handler()
-     *  {
-     *      Workflow::registerUpdate(
-     *          'my-update',
-     *          fn(Task $task) => $this->queue->push($task),
-     *      );
-     *  }
+     * Workflow::registerUpdate(
+     *     'pushTask',
+     *     fn(Task $task) => $this->queue->push($task),
+     * );
      * ```
      *
      * Register an Update method with a validator:
      *
      * ```php
-     * #[WorkflowMethod]
-     * public function handler()
-     * {
-     *    Workflow::registerUpdate(
-     *       'my-update',
-     *       fn(Task $task) => $this->queue->push($task),
-     *       fn(Task $task) => $this->isValidTask($task) or throw new \InvalidArgumentException('Invalid task'),
-     *    );
-     * }
+     * Workflow::registerUpdate(
+     *     'pushTask',
+     *     fn(Task $task) => $this->queue->push($task),
+     *     fn(Task $task) => $this->isValidTask($task) or throw new \InvalidArgumentException('Invalid task'),
+     * );
      * ```
      *
      * Note that the validator must have the same signature as the Update method:
      *
      * @param non-empty-string $name
+     * @throws OutOfContextException in the absence of the workflow execution context.
      */
     public static function registerUpdate(
         string $name,

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -388,7 +388,36 @@ final class Workflow extends Facade
     }
 
     /**
-     * Registers an Update handler.
+     * Registers an Update method in the Workflow.
+     *
+     * ```php
+     *  #[WorkflowMethod]
+     *  public function handler()
+     *  {
+     *      Workflow::registerUpdate(
+     *          'my-update',
+     *          fn(Task $task) => $this->queue->push($task),
+     *      );
+     *  }
+     * ```
+     *
+     * Register an Update method with a validator:
+     *
+     * ```php
+     * #[WorkflowMethod]
+     * public function handler()
+     * {
+     *    Workflow::registerUpdate(
+     *       'my-update',
+     *       fn(Task $task) => $this->queue->push($task),
+     *       fn(Task $task) => $this->isValidTask($task) or throw new \InvalidArgumentException('Invalid task'),
+     *    );
+     * }
+     * ```
+     *
+     * Note that the validator must have the same signature as the Update method:
+     *
+     * @param non-empty-string $name
      */
     public static function registerUpdate(
         string $name,

--- a/src/Workflow/WorkflowContextInterface.php
+++ b/src/Workflow/WorkflowContextInterface.php
@@ -86,7 +86,7 @@ interface WorkflowContextInterface extends EnvironmentInterface
      *
      * @param non-empty-string $name
      */
-    public function registerUpdate(string $name, callable $handler, ?callable $validator): self;
+    public function registerUpdate(string $name, callable $handler, ?callable $validator): static;
 
     /**
      * Exchanges data between worker and host process.

--- a/src/Workflow/WorkflowContextInterface.php
+++ b/src/Workflow/WorkflowContextInterface.php
@@ -80,6 +80,15 @@ interface WorkflowContextInterface extends EnvironmentInterface
     public function registerSignal(string $queryType, callable $handler): self;
 
     /**
+     * Registers an update method with an optional validator.
+     *
+     * @see Workflow::registerUpdate()
+     *
+     * @param non-empty-string $name
+     */
+    public function registerUpdate(string $name, callable $handler, ?callable $validator): self;
+
+    /**
      * Exchanges data between worker and host process.
      *
      * @internal This is an internal method

--- a/tests/Acceptance/Extra/Update/DynamicUpdateTest.php
+++ b/tests/Acceptance/Extra/Update/DynamicUpdateTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Acceptance\Extra\Update\DynamicUpdate;
+
+use PHPUnit\Framework\Attributes\Test;
+use Ramsey\Uuid\Uuid;
+use Temporal\Client\Update\LifecycleStage;
+use Temporal\Client\Update\UpdateOptions;
+use Temporal\Client\WorkflowStubInterface;
+use Temporal\Exception\Client\WorkflowUpdateException;
+use Temporal\Exception\Failure\ApplicationFailure;
+use Temporal\Tests\Acceptance\App\Attribute\Stub;
+use Temporal\Tests\Acceptance\App\TestCase;
+use Temporal\Workflow;
+use Temporal\Workflow\WorkflowInterface;
+use Temporal\Workflow\WorkflowMethod;
+
+class DynamicUpdateTest extends TestCase
+{
+    #[Test]
+    public function addUpdateMethodWithoutValidation(
+        #[Stub('Extra_Update_DynamicUpdate')] WorkflowStubInterface $stub,
+    ): void {
+        $idResult = $stub->update(TestWorkflow::UPDATE_METHOD)->getValue(0);
+        self::assertNotNull($idResult);
+
+        $id = Uuid::uuid4()->toString();
+        $idResult = $stub->startUpdate(
+            UpdateOptions::new(TestWorkflow::UPDATE_METHOD, LifecycleStage::StageCompleted)
+                ->withUpdateId($id)
+        )->getResult();
+        self::assertSame($id, $idResult);
+    }
+
+    #[Test]
+    public function addUpdateMethodWithValidation(
+        #[Stub('Extra_Update_DynamicUpdate')] WorkflowStubInterface $stub,
+    ): void {
+        // Valid
+        $result = $stub->update(TestWorkflow::UPDATE_METHOD_WV, 42)->getValue(0);
+        self::assertSame(42, $result);
+
+        // Invalid input
+        try {
+            $stub->update(TestWorkflow::UPDATE_METHOD_WV, -42);
+        } catch (WorkflowUpdateException $e) {
+            $previous = $e->getPrevious();
+            self::assertInstanceOf(ApplicationFailure::class, $previous);
+            self::assertSame('Value must be positive', $previous->getOriginalMessage());
+        }
+    }
+}
+
+
+#[WorkflowInterface]
+class TestWorkflow
+{
+    public const UPDATE_METHOD = 'update-method';
+    public const UPDATE_METHOD_WV = 'update-method-with-validation';
+
+    private array $result = [];
+    private bool $exit = false;
+
+    #[WorkflowMethod(name: "Extra_Update_DynamicUpdate")]
+    public function handle()
+    {
+        // Register update methods
+        Workflow::registerUpdate(self::UPDATE_METHOD, function () {
+            // Also Update context is tested
+            $id = Workflow::getUpdateContext()->getUpdateId();
+            return $this->result[self::UPDATE_METHOD] = $id;
+        });
+        // Update method with validation
+        Workflow::registerUpdate(
+            self::UPDATE_METHOD_WV,
+            fn(int $value): int => $value,
+            fn(int $value) => $value > 0 or throw new \InvalidArgumentException('Value must be positive'),
+        );
+
+        yield Workflow::await(fn() => $this->exit);
+        return $this->result;
+    }
+
+    #[Workflow\SignalMethod]
+    public function exit(): void
+    {
+        $this->exit = true;
+    }
+}


### PR DESCRIPTION
## What was changed

Added `Workflow::registerUpdate($name, $handler, $validator)` to register updates dynamically

```php
#[WorkflowMethod]
public function handler()
{
   Workflow::registerUpdate(
      'my-update',
      fn(Task $task) => $this->queue->push($task),
      fn(Task $task) => $this->isValidTask($task) or throw new \InvalidArgumentException('Invalid task'),
   );
}
```

## Checklist
<!--- add/delete as needed --->

1. Closes #497 
2. How was this tested: added autotests
3. Any docs updates needed?
