### PR TITLE
Schedule update with Search Attributes

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -904,24 +904,6 @@
       <code><![CDATA[$path]]></code>
     </PossiblyInvalidArgument>
   </file>
-  <file src="src/Internal/Traits/CloneWith.php">
-    <RawObjectIteration>
-      <code><![CDATA[$this]]></code>
-      <code><![CDATA[$this]]></code>
-      <code><![CDATA[$this]]></code>
-      <code><![CDATA[$this]]></code>
-      <code><![CDATA[$this]]></code>
-      <code><![CDATA[$this]]></code>
-      <code><![CDATA[$this]]></code>
-      <code><![CDATA[$this]]></code>
-      <code><![CDATA[$this]]></code>
-      <code><![CDATA[$this]]></code>
-      <code><![CDATA[$this]]></code>
-      <code><![CDATA[$this]]></code>
-      <code><![CDATA[$this]]></code>
-      <code><![CDATA[$this]]></code>
-    </RawObjectIteration>
-  </file>
   <file src="src/Internal/Transport/Client.php">
     <InternalClass>
       <code><![CDATA[self::ERROR_REQUEST_ID_DUPLICATION]]></code>

--- a/src/Client/Schedule/Action/StartWorkflowAction.php
+++ b/src/Client/Schedule/Action/StartWorkflowAction.php
@@ -95,7 +95,9 @@ final class StartWorkflowAction extends ScheduleAction
     public readonly EncodedCollection $memo;
 
     /**
-     * Search attributes
+     * Search Attributes.
+     *
+     * For supported operations on different server versions see {@link https://docs.temporal.io/visibility}
      */
     #[Marshal(name: 'search_attributes', type: EncodedCollectionType::class, of: SearchAttributes::class)]
     public readonly EncodedCollection $searchAttributes;

--- a/src/Client/Schedule/Info/ScheduleDescription.php
+++ b/src/Client/Schedule/Info/ScheduleDescription.php
@@ -39,8 +39,8 @@ final class ScheduleDescription
     public readonly EncodedCollection $memo;
 
     /**
-     * Indexed info that can be used in query of List schedules APIs.
-     * The key and value type must be registered on Temporal server side.
+     * Additional indexed information used for search and visibility.
+     * The key and its value type are registered on Temporal server side
      * Use GetSearchAttributes API to get valid key and corresponding value type.
      * For supported operations on different server versions see {@link https://docs.temporal.io/visibility}.
      */

--- a/src/Client/Schedule/ScheduleHandle.php
+++ b/src/Client/Schedule/ScheduleHandle.php
@@ -60,6 +60,30 @@ final class ScheduleHandle
     /**
      * Update the Schedule.
      *
+     * Examples:
+     *
+     * Add a search attribute to the schedule:
+     * ```
+     *  $handle->update(function (ScheduleUpdateInput $input): ScheduleUpdate {
+     *      return ScheduleUpdate::new($input->description->schedule)
+     *          ->withSearchAttributes($input->description->searchAttributes
+     *              ->withValue('foo', 'bar'),
+     *              ->withValue('bar', 42),
+     *          );
+     * });
+     * ```
+     *
+     * Pause a described schedule:
+     * ```
+     *  $description = $handle->describe();
+     *  $schedule = $description->schedule;
+     *  $handle->update(
+     *      $schedule
+     *          ->withState($schedule->state->withPaused(true)),
+     *      $description->conflictToken,
+     *  );
+     * ```
+     *
      * NOTE: If two Update calls are made in parallel to the same Schedule there is the potential
      * for a race condition. Use $conflictToken to avoid this.
      *

--- a/src/Client/Schedule/ScheduleHandle.php
+++ b/src/Client/Schedule/ScheduleHandle.php
@@ -9,6 +9,7 @@ use Countable;
 use DateTimeImmutable;
 use DateTimeInterface;
 use Google\Protobuf\Timestamp;
+use Temporal\Api\Common\V1\SearchAttributes;
 use Temporal\Api\Schedule\V1\BackfillRequest;
 use Temporal\Api\Schedule\V1\SchedulePatch;
 use Temporal\Api\Schedule\V1\TriggerImmediatelyRequest;
@@ -22,6 +23,8 @@ use Temporal\Client\Common\ClientContextTrait;
 use Temporal\Client\GRPC\ServiceClientInterface;
 use Temporal\Client\Schedule\Info\ScheduleDescription;
 use Temporal\Client\Schedule\Policy\ScheduleOverlapPolicy;
+use Temporal\Client\Schedule\Update\ScheduleUpdate;
+use Temporal\Client\Schedule\Update\ScheduleUpdateInput;
 use Temporal\Common\Uuid;
 use Temporal\DataConverter\DataConverterInterface;
 use Temporal\Exception\InvalidArgumentException;
@@ -60,25 +63,46 @@ final class ScheduleHandle
      * NOTE: If two Update calls are made in parallel to the same Schedule there is the potential
      * for a race condition. Use $conflictToken to avoid this.
      *
-     * @param Schedule $schedule The new Schedule to update to.
+     * @param Schedule|\Closure(ScheduleUpdateInput): ScheduleUpdate $schedule The new Schedule to update to or
+     *        a closure that will be passed the current ScheduleDescription and should return a ScheduleUpdate.
      * @param string|null $conflictToken Can be the value of {@see ScheduleDescription::$conflictToken},
      *        which will cause this request to fail if the schedule has been modified
      *        between the {@see self::describe()} and this Update.
      *        If missing, the schedule will be updated unconditionally.
      */
     public function update(
-        Schedule $schedule,
+        Schedule|\Closure $schedule,
         ?string $conflictToken = null,
     ): void {
-        $mapper = new ScheduleMapper($this->converter, $this->marshaller);
-        $scheduleMessage = $mapper->toMessage($schedule);
-
         $request = (new UpdateScheduleRequest())
             ->setScheduleId($this->id)
             ->setNamespace($this->namespace)
             ->setConflictToken((string) $conflictToken)
             ->setIdentity($this->clientOptions->identity)
-            ->setSchedule($scheduleMessage);
+            ->setRequestId(Uuid::v4());
+
+        if ($schedule instanceof \Closure) {
+            $description = $this->describe();
+            $update = $schedule(new ScheduleUpdateInput($description));
+            $update instanceof ScheduleUpdate or throw new InvalidArgumentException(
+                'Closure for the schedule update method must return a ScheduleUpdate.'
+            );
+
+            $schedule = $update->schedule;
+
+            // Search attributes
+            if ($update->searchAttributes !== null) {
+                $update->searchAttributes->setDataConverter($this->converter);
+                $payloads = $update->searchAttributes->toPayloadArray();
+                $encodedSa = (new SearchAttributes())->setIndexedFields($payloads);
+                $request->setSearchAttributes($encodedSa);
+            }
+        }
+
+        $mapper = new ScheduleMapper($this->converter, $this->marshaller);
+        $scheduleMessage = $mapper->toMessage($schedule);
+        $request->setSchedule($scheduleMessage);
+
 
         $this->client->UpdateSchedule($request);
     }

--- a/src/Client/Schedule/Update/ScheduleUpdate.php
+++ b/src/Client/Schedule/Update/ScheduleUpdate.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Client\Schedule\Update;
+
+use Temporal\Client\Schedule\Schedule;
+use Temporal\DataConverter\EncodedCollection;
+use Temporal\Internal\Marshaller\Meta\Marshal;
+use Temporal\Internal\Traits\CloneWith;
+
+/**
+ * An update returned from a schedule updater.
+ *
+ * @see ScheduleHandle::update()
+ */
+final class ScheduleUpdate
+{
+    use CloneWith;
+
+    /**
+     * Search attributes to replace the existing search attributes with.
+     */
+    public readonly ?EncodedCollection $searchAttributes;
+
+    /**
+     * @param Schedule $schedule Schedule to replace the existing schedule with.
+     */
+    private function __construct(
+        #[Marshal]
+        public readonly Schedule $schedule,
+    ) {
+        $this->searchAttributes = null;
+    }
+
+    /**
+     * @param Schedule $schedule Schedule to replace the existing schedule with.
+     */
+    public static function new(Schedule $schedule): self
+    {
+        return new self($schedule);
+    }
+
+    public function withSchedule(Schedule $schedule): self
+    {
+        /** @see self::$schedule */
+        return $this->with('schedule', $schedule);
+    }
+
+    /**
+     * @param ?EncodedCollection $searchAttributes Search attributes to replace the existing search attributes with.
+     *        If null, it will not change the existing search attributes.
+     */
+    public function withSearchAttributes(?EncodedCollection $searchAttributes = null): self
+    {
+        /** @see self::$searchAttributes */
+        return $this->with('searchAttributes', $searchAttributes);
+    }
+}

--- a/src/Client/Schedule/Update/ScheduleUpdateInput.php
+++ b/src/Client/Schedule/Update/ScheduleUpdateInput.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Client\Schedule\Update;
+
+use Temporal\Client\Schedule\Info\ScheduleDescription;
+
+/**
+ * Parameter passed to a schedule updater.
+ *
+ * @see ScheduleHandle::update()
+ */
+final class ScheduleUpdateInput
+{
+    /**
+     * @param ScheduleDescription $description Description fetched from the server before this update.
+     *
+     * @internal The DTO is created by the SDK and should not be created manually.
+     */
+    public function __construct(
+        public readonly ScheduleDescription $description,
+    ) {}
+}

--- a/src/Internal/Traits/CloneWith.php
+++ b/src/Internal/Traits/CloneWith.php
@@ -15,6 +15,7 @@ trait CloneWith
     private function with(string $key, mixed $value): static {
         $new = (new \ReflectionClass($this))->newInstanceWithoutConstructor();
         $new->{$key} = $value;
+        /** @psalm-suppress RawObjectIteration */
         foreach ($this as $k => $v) {
             if ($k === $key) {
                 continue;

--- a/testing/src/Environment.php
+++ b/testing/src/Environment.php
@@ -63,6 +63,8 @@ final class Environment
                 '--dynamic-config-value', 'frontend.enableUpdateWorkflowExecution=true',
                 '--dynamic-config-value', 'frontend.enableUpdateWorkflowExecutionAsyncAccepted=true',
                 '--dynamic-config-value', 'system.enableEagerWorkflowStart=true',
+                '--search-attribute', 'foo=text',
+                '--search-attribute', 'bar=int',
                 '--log-level', 'error',
                 '--headless'
             ]

--- a/tests/Acceptance/App/TestCase.php
+++ b/tests/Acceptance/App/TestCase.php
@@ -12,7 +12,7 @@ use Temporal\Tests\Acceptance\App\Runtime\Feature;
 use Temporal\Tests\Acceptance\App\Runtime\RRStarter;
 use Temporal\Tests\Acceptance\App\Runtime\State;
 
-abstract class TestCase extends \PHPUnit\Framework\TestCase
+abstract class TestCase extends \Temporal\Tests\TestCase
 {
     protected function setUp(): void
     {

--- a/tests/Acceptance/Extra/Schedule/ScheduleUpdateTest.php
+++ b/tests/Acceptance/Extra/Schedule/ScheduleUpdateTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Acceptance\Extra\Update\DynamicUpdate;
+
+use PHPUnit\Framework\Attributes\Test;
+use Temporal\Client\Schedule\Action\StartWorkflowAction;
+use Temporal\Client\Schedule\Schedule;
+use Temporal\Client\Schedule\ScheduleOptions;
+use Temporal\Client\Schedule\Spec\ScheduleSpec;
+use Temporal\Client\Schedule\Update\ScheduleUpdate;
+use Temporal\Client\Schedule\Update\ScheduleUpdateInput;
+use Temporal\Client\ScheduleClientInterface;
+use Temporal\DataConverter\EncodedCollection;
+use Temporal\Tests\Acceptance\App\TestCase;
+
+class ScheduleUpdateTest extends TestCase
+{
+    #[Test]
+    public function searchAttributesClearViaUpdate(
+        ScheduleClientInterface $client,
+    ): void
+    {
+        // Create a new schedule
+        $handle = $client->createSchedule(
+            Schedule::new()
+                ->withAction(
+                    StartWorkflowAction::new('TestWorkflow')
+                )->withSpec(
+                    ScheduleSpec::new()
+                        ->withStartTime('+1 hour')
+                ),
+            ScheduleOptions::new()
+                ->withMemo(['memokey2' => 'memoval2'])
+                ->withSearchAttributes(
+                    EncodedCollection::fromValues([
+                        'foo' => 'bar',
+                        'bar' => 42,
+                    ])
+                )
+        );
+
+        try {
+            $description = $handle->describe();
+            self::assertEquals(2, $description->searchAttributes->count());
+
+            // Update the schedule search attribute by clearing them
+            $handle->update(function (ScheduleUpdateInput $input): ScheduleUpdate {
+                $schedule = $input->description->schedule;
+                return ScheduleUpdate::new($schedule)
+                    ->withSearchAttributes(EncodedCollection::empty());
+            });
+
+            sleep(1);
+            self::assertEquals(0, $handle->describe()->searchAttributes->count());
+        } finally {
+            $handle->delete();
+        }
+    }
+
+    #[Test]
+    public function searchAttributesAddViaUpdate(
+        ScheduleClientInterface $client,
+    ): void
+    {
+        // Create a new schedule
+        $handle = $client->createSchedule(
+            Schedule::new()
+                ->withAction(
+                    StartWorkflowAction::new('TestWorkflow')
+                )->withSpec(
+                    ScheduleSpec::new()
+                        ->withStartTime('+1 hour')
+                ),
+            ScheduleOptions::new()
+                ->withMemo(['memokey2' => 'memoval2'])
+                ->withSearchAttributes(
+                    EncodedCollection::fromValues([
+                        'foo' => 'bar',
+                    ])
+                )
+        );
+
+        try {
+            $description = $handle->describe();
+            self::assertEquals(1, $description->searchAttributes->count());
+
+            // Update the schedule search attribute by clearing them
+            $handle->update(function (ScheduleUpdateInput $input): ScheduleUpdate {
+                $schedule = $input->description->schedule;
+                return ScheduleUpdate::new($schedule)
+                    ->withSearchAttributes($input->description->searchAttributes->withValue('bar', 69));
+            });
+
+            sleep(1);
+            self::assertEquals(2, $handle->describe()->searchAttributes->count());
+            self::assertSame(69, $handle->describe()->searchAttributes->getValue('bar'));
+        } finally {
+            $handle->delete();
+        }
+    }
+
+    #[Test]
+    public function update(
+        ScheduleClientInterface $client,
+    ): void {
+        // Create a new schedule
+        $handle = $client->createSchedule(
+            Schedule::new()
+                ->withAction(
+                    StartWorkflowAction::new('TestWorkflow')
+                        ->withMemo(['memokey1' => 'memoval1'])
+                )->withSpec(
+                    ScheduleSpec::new()
+                        ->withStartTime('+1 hour')
+                ),
+            ScheduleOptions::new()
+                ->withMemo(['memokey2' => 'memoval2'])
+                ->withSearchAttributes(EncodedCollection::fromValues([
+                    'foo' => 'bar',
+                    'bar' => 42,
+                ]))
+        );
+
+        try {
+            // Describe the schedule
+            $description = $handle->describe();
+            self::assertSame("memoval2", $description->memo->getValue("memokey2"));
+            self::assertEquals(2, $description->searchAttributes->count());
+
+            /** @var StartWorkflowAction $startWfAction */
+            $startWfAction = $description->schedule->action;
+            self::assertSame('memoval1', $startWfAction->memo->getValue("memokey1"));
+
+            // Add memo and update task timeout
+            $handle->update(function (ScheduleUpdateInput $input): ScheduleUpdate {
+                $schedule = $input->description->schedule;
+                /** @var StartWorkflowAction $action */
+                $action = $schedule->action;
+                $action = $action->withWorkflowTaskTimeout('7 minutes')
+                    ->withMemo(['memokey3' => 'memoval3']);
+                return ScheduleUpdate::new($schedule->withAction($action));
+            });
+
+            $description = $handle->describe();
+            self::assertInstanceOf(StartWorkflowAction::class, $description->schedule->action);
+            self::assertSame("memoval2", $description->memo->getValue("memokey2"));
+            $startWfAction = $description->schedule->action;
+            self::assertSame("memoval3", $startWfAction->memo->getValue("memokey3"));
+            $this->assertEqualIntervals(new \DateInterval('PT7M'), $startWfAction->workflowTaskTimeout);
+
+            // Update the schedule state
+            $expectedUpdateTime = $description->info->lastUpdateAt;
+            $handle->update(function (ScheduleUpdateInput $input): ScheduleUpdate {
+                $schedule = $input->description->schedule;
+                $schedule = $schedule->withState($schedule->state->withPaused(true));
+                return ScheduleUpdate::new($schedule);
+            });
+            $description = $handle->describe();
+            //
+            self::assertSame("memoval2", $description->memo->getValue("memokey2"));
+            $startWfAction = $description->schedule->action;
+            self::assertSame("memoval3", $startWfAction->memo->getValue("memokey3"));
+            //
+            self::assertNotEquals($expectedUpdateTime, $description->info->lastUpdateAt);
+            self::assertTrue($description->schedule->state->paused);
+            self::assertEquals(2, $description->searchAttributes->count());
+            self::assertSame('bar', $description->searchAttributes->getValue('foo'));
+        } finally {
+            $handle->delete();
+        }
+    }
+}


### PR DESCRIPTION
## What was changed

- Added the ability to update Schedule via a closure, similar to other SDKs.
- Added the ability to modify SearchAttributes through Schedule::update.

## Checklist
<!--- add/delete as needed --->

1. Closes #478 
2. How was this tested: added autotests
3. Any docs updates needed?
