### PR TITLE
Fix typo in docstring for `hasExecution`

### DIFF
--- a/src/Client/WorkflowStubInterface.php
+++ b/src/Client/WorkflowStubInterface.php
@@ -53,7 +53,7 @@ interface WorkflowStubInterface extends WorkflowRunInterface
     public function getExecution(): WorkflowExecution;
 
     /**
-     * Check if workflow was stater and has associated execution.
+     * Check if workflow was started and has associated execution.
      *
      * @return bool
      */


### PR DESCRIPTION
Fixes a small typo in the docstring for the hasExecution method