### PR TITLE
Fix typo in `hasExecution` docstring

### DIFF
--- a/src/Client/WorkflowStubInterface.php
+++ b/src/Client/WorkflowStubInterface.php
@@ -53,7 +53,7 @@ interface WorkflowStubInterface extends WorkflowRunInterface
     public function getExecution(): WorkflowExecution;
 
     /**
-     * Check if workflow was stater and has associated execution.
+     * Check if workflow was started and has associated execution.
      *
      * @return bool
      */


### PR DESCRIPTION
### WHY

Fix a small typo in the docstring