### PR TITLE
Resolve deprecations

### DIFF
--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -48,17 +48,14 @@ jobs:
       fail-fast: ${{ inputs.fail-fast }}
       matrix:
         php: [ 8.1, 8.2, 8.3 ]
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-latest ]
         extensions-suffix: [ '', ', protobuf' ]
         dependencies: [ lowest , highest ]
         timeout-minutes: [ '${{ inputs.test-timeout }}' ]
-        exclude:
-          - os: windows-latest
-            php: 8.2
+        include:
           - os: windows-latest
             extensions-suffix: ', protobuf'
-          - os: windows-latest
-            php: 8.3
+            php: 8.1
     steps:
       - name: Set Git To Use LF
         run: |

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,6 +9,12 @@
          stopOnFailure="false"
          stopOnError="false"
          stderr="true"
+         displayDetailsOnIncompleteTests="true"
+         displayDetailsOnSkippedTests="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerWarnings="true"
 >
     <testsuites>
         <testsuite name="Acceptance">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -109,6 +109,12 @@
       <code><![CDATA[$workflowType]]></code>
     </PropertyNotSetInConstructor>
   </file>
+  <file src="src/Client/Schedule/Spec/ScheduleSpec.php">
+    <DeprecatedProperty>
+      <code><![CDATA[$this->excludeCalendarList]]></code>
+      <code><![CDATA[$this->excludeCalendarList]]></code>
+    </DeprecatedProperty>
+  </file>
   <file src="src/Client/Update/UpdateHandle.php">
     <PossiblyNullArgument>
       <code><![CDATA[$result->getSuccess()]]></code>
@@ -508,7 +514,6 @@
   </file>
   <file src="src/Internal/Declaration/Reader/WorkflowReader.php">
     <ArgumentTypeCoercion>
-      <code><![CDATA[$class]]></code>
       <code><![CDATA[$contextualRetry]]></code>
       <code><![CDATA[$method]]></code>
       <code><![CDATA[$name]]></code>
@@ -1218,10 +1223,6 @@
     <InvalidOperand>
       <code><![CDATA[$promisesOrValues]]></code>
     </InvalidOperand>
-    <MissingParamType>
-      <code><![CDATA[$promiseOrValue]]></code>
-      <code><![CDATA[$promiseOrValue]]></code>
-    </MissingParamType>
     <TooManyArguments>
       <code><![CDATA[$reduce($c, $value, $i++, $total)]]></code>
     </TooManyArguments>
@@ -1366,11 +1367,6 @@
       <code><![CDATA[$env->getRPCAddress()]]></code>
       <code><![CDATA[$method]]></code>
     </ArgumentTypeCoercion>
-  </file>
-  <file src="src/Worker/Transport/RPCConnectionInterface.php">
-    <MissingParamType>
-      <code><![CDATA[$payload]]></code>
-    </MissingParamType>
   </file>
   <file src="src/Worker/Transport/RoadRunner.php">
     <ArgumentTypeCoercion>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -112,6 +112,7 @@
   <file src="src/Client/Schedule/Spec/ScheduleSpec.php">
     <DeprecatedProperty>
       <code><![CDATA[$this->excludeCalendarList]]></code>
+      <code><![CDATA[$this->excludeCalendarList]]></code>
     </DeprecatedProperty>
   </file>
   <file src="src/Client/Update/UpdateHandle.php">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -112,7 +112,6 @@
   <file src="src/Client/Schedule/Spec/ScheduleSpec.php">
     <DeprecatedProperty>
       <code><![CDATA[$this->excludeCalendarList]]></code>
-      <code><![CDATA[$this->excludeCalendarList]]></code>
     </DeprecatedProperty>
   </file>
   <file src="src/Client/Update/UpdateHandle.php">

--- a/src/Client/Schedule/Spec/ScheduleSpec.php
+++ b/src/Client/Schedule/Spec/ScheduleSpec.php
@@ -76,6 +76,8 @@ final class ScheduleSpec
      * Any timestamps matching any of exclude* will be skipped.
      *
      * @var list<CalendarSpec>
+     *
+     * @deprecated
      */
     #[MarshalArray(name: 'exclude_calendar', of: CalendarSpec::class)]
     public readonly array $excludeCalendarList;

--- a/src/Client/Schedule/Spec/ScheduleSpec.php
+++ b/src/Client/Schedule/Spec/ScheduleSpec.php
@@ -246,24 +246,25 @@ final class ScheduleSpec
     }
 
     /**
-     * Returns a new instance with the replaced exclude calendar list.
+     * Does nothing.
+     *
+     * @deprecated This method is deprecated and will be removed in the next major release.
      */
     public function withExcludeCalendarList(CalendarSpec ...$calendar): self
     {
-        /** @see self::$excludeCalendarList */
-        return $this->with('excludeCalendarList', $calendar);
+        @\trigger_error('ScheduleSpec::withExcludeCalendarList() is deprecated', E_USER_DEPRECATED);
+        return $this;
     }
 
     /**
-     * Any timestamps matching any of exclude* will be skipped.
+     * Does nothing.
+     *
+     * @deprecated This method is deprecated and will be removed in the next major release.
      */
     public function withAddedExcludeCalendar(CalendarSpec $calendar): self
     {
-        $value = $this->excludeCalendarList;
-        $value[] = $calendar;
-
-        /** @see self::$excludeCalendarList */
-        return $this->with('excludeCalendarList', $value);
+        @\trigger_error('ScheduleSpec::withAddedExcludeCalendar() is deprecated', E_USER_DEPRECATED);
+        return $this;
     }
 
     /**

--- a/src/Client/Schedule/Spec/ScheduleSpec.php
+++ b/src/Client/Schedule/Spec/ScheduleSpec.php
@@ -246,25 +246,31 @@ final class ScheduleSpec
     }
 
     /**
-     * Does nothing.
+     * Returns a new instance with the replaced exclude calendar list.
      *
      * @deprecated This method is deprecated and will be removed in the next major release.
      */
     public function withExcludeCalendarList(CalendarSpec ...$calendar): self
     {
         @\trigger_error('ScheduleSpec::withExcludeCalendarList() is deprecated', E_USER_DEPRECATED);
-        return $this;
+
+        /** @see self::$excludeCalendarList */
+        return $this->with('excludeCalendarList', $calendar);
     }
 
     /**
-     * Does nothing.
+     * Any timestamps matching any of exclude* will be skipped.
      *
      * @deprecated This method is deprecated and will be removed in the next major release.
      */
     public function withAddedExcludeCalendar(CalendarSpec $calendar): self
     {
         @\trigger_error('ScheduleSpec::withAddedExcludeCalendar() is deprecated', E_USER_DEPRECATED);
-        return $this;
+        $value = $this->excludeCalendarList;
+        $value[] = $calendar;
+
+        /** @see self::$excludeCalendarList */
+        return $this->with('excludeCalendarList', $value);
     }
 
     /**

--- a/src/Exception/Client/ServiceClientException.php
+++ b/src/Exception/Client/ServiceClientException.php
@@ -31,7 +31,11 @@ class ServiceClientException extends \RuntimeException
             $this->status->mergeFromString($status->metadata['grpc-status-details-bin'][0]);
         }
 
-        parent::__construct($status->details . " (code: $status->code)", $status->code, $previous);
+        parent::__construct(\sprintf(
+            "%s (code: %d)",
+            isset($status->details) ? (string) $status->details : '',
+            $status->code,
+        ), $status->code, $previous);
     }
 
     public function getStatus(): Status

--- a/src/Internal/Mapper/ScheduleMapper.php
+++ b/src/Internal/Mapper/ScheduleMapper.php
@@ -92,7 +92,10 @@ final class ScheduleMapper
             $result['calendar'] ?? [],
         );
 
-        unset($result['exclude_calendar']);
+        $result['exclude_calendar'] = \array_map(
+            static fn(array $item): CalendarSpec => new CalendarSpec($item),
+            $result['exclude_calendar'] ?? [],
+        );
 
         $result['interval'] = \array_map(
             static fn(array $item): IntervalSpec => new IntervalSpec($item),

--- a/src/Internal/Mapper/ScheduleMapper.php
+++ b/src/Internal/Mapper/ScheduleMapper.php
@@ -92,10 +92,7 @@ final class ScheduleMapper
             $result['calendar'] ?? [],
         );
 
-        $result['exclude_calendar'] = \array_map(
-            static fn(array $item): CalendarSpec => new CalendarSpec($item),
-            $result['exclude_calendar'] ?? [],
-        );
+        unset($result['exclude_calendar']);
 
         $result['interval'] = \array_map(
             static fn(array $item): IntervalSpec => new IntervalSpec($item),

--- a/tests/Unit/Router/InvokeActivityTestCase.php
+++ b/tests/Unit/Router/InvokeActivityTestCase.php
@@ -32,6 +32,7 @@ final class InvokeActivityTestCase extends AbstractUnit
 {
     private ServiceContainer $services;
     private InvokeActivity $router;
+    private ActivityContext $activityContext;
 
     protected function setUp(): void
     {

--- a/tests/Unit/Router/StartWorkflowTestCase.php
+++ b/tests/Unit/Router/StartWorkflowTestCase.php
@@ -37,6 +37,8 @@ final class StartWorkflowTestCase extends AbstractUnit
 {
     private ServiceContainer $services;
     private StartWorkflow $router;
+    private WorkflowContext $workflowContext;
+    private MarshallerInterface $marshaller;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
## What was changed

- Fix deprecation on Service Client exception parsing
- Resolve all the deprecations in tests
- Deprecate `ScheduleSpec::$excludeCalendarList` and related methods; stop mapping it into the related protobuf message

## Why?

It may throw an error depending on user environment

## Checklist

1. Closes #522
2. Closes #501 (tests on windows are run only with protobuf ext)
