### PR TITLE
Fix intervals between retries in Client API calls

### DIFF
--- a/src/Client/GRPC/BaseClient.php
+++ b/src/Client/GRPC/BaseClient.php
@@ -328,7 +328,7 @@ abstract class BaseClient implements ServiceClientInterface
                     ? $congestionInitialIntervalMs
                     : $initialIntervalMs;
 
-                $wait = $throttler->calculateSleepTime(failureCount: $attempt, initialInterval: $baseInterval);
+                $wait = $throttler->calculateSleepTime(failureCount: $attempt, initialInterval: $baseInterval) * 1000;
 
                 // wait till the next call
                 $this->usleep($wait);


### PR DESCRIPTION
## What was changed

In the code that calculates the interval between attempts, milliseconds were passed to the wait function, whereas microseconds should have been passed.
