### PR TITLE
Add `WorkflowUpdateResultException`

### DIFF
--- a/src/Client/Update/UpdateHandle.php
+++ b/src/Client/Update/UpdateHandle.php
@@ -13,6 +13,7 @@ use Temporal\DataConverter\ValuesInterface;
 use Temporal\Exception\Client\CanceledException;
 use Temporal\Exception\Client\TimeoutException;
 use Temporal\Exception\Client\WorkflowUpdateException;
+use Temporal\Exception\Client\WorkflowUpdateResultException;
 use Temporal\Exception\Client\WorkflowUpdateRPCTimeoutOrCanceledException;
 use Temporal\Exception\Failure\FailureConverter;
 use Temporal\Workflow\WorkflowExecution;
@@ -127,7 +128,13 @@ final class UpdateHandle
 
         // Workflow Uprate accepted
         $result = $response->getOutcome();
-        \assert($result !== null);
+        $result === null and throw new WorkflowUpdateResultException(
+            LifecycleStage::tryFrom($response->getStage()),
+            execution: $this->getExecution(),
+            workflowType: $this->workflowType ?? '',
+            updateId: $this->getId(),
+            updateName: $this->updateName,
+        );
 
         // Accepted with result
         if ($result->getSuccess() !== null) {

--- a/src/Exception/Client/WorkflowUpdateResultException.php
+++ b/src/Exception/Client/WorkflowUpdateResultException.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Exception\Client;
+
+use Temporal\Client\Update\LifecycleStage;
+use Temporal\Workflow\WorkflowExecution;
+
+/**
+ * Indicates that a Workflow Update has no result yet.
+ */
+final class WorkflowUpdateResultException extends WorkflowException
+{
+    public function __construct(
+        private readonly ?LifecycleStage $stage,
+        WorkflowExecution $execution,
+        string $workflowType,
+        private readonly string $updateId,
+        private readonly string $updateName,
+    ) {
+        $message = match ($stage) {
+            LifecycleStage::StageAdmitted => \sprintf(
+                "Update `%s` has not yet been accepted or rejected by the Workflow `%s`.",
+                $updateName,
+                $workflowType,
+            ),
+            default => \sprintf("Update `%s` has no result.", $updateName),
+        };
+
+        parent::__construct($message, $execution, $workflowType);
+    }
+
+    public function getUpdateId(): string
+    {
+        return $this->updateId;
+    }
+
+    public function getUpdateName(): string
+    {
+        return $this->updateName;
+    }
+
+    public function getStage(): LifecycleStage
+    {
+        return $this->stage ?? LifecycleStage::StageUnspecified;
+    }
+}


### PR DESCRIPTION
## What was changed

Added the `WorkflowUpdateResultException`, which is thrown by `UpdateHandle->getResult()` when a Workflow Update Request is stuck in the ADMITTED status. This situation can occur when the Workflow neither accepts nor rejects the Update due to:
- No available workers
- Workflow Task fails in the same tick

## Why?

Developers need to distinguish between `null` as an actual result of a Workflow Update action and "no result."
Prior to this patch, the code used `assert($result === null)`, which did not align with reality. Additionally, assertions are typically disabled in production environments.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
