### PR TITLE
Fix exception propagation from nested promises inside yielded generator

### DIFF
--- a/src/Internal/Workflow/Process/DeferredGenerator.php
+++ b/src/Internal/Workflow/Process/DeferredGenerator.php
@@ -70,6 +70,7 @@ final class DeferredGenerator implements \Iterator
             $this->fill();
         } catch (\Throwable $e) {
             $this->handleException($e);
+            throw $e;
         }
     }
 
@@ -88,7 +89,7 @@ final class DeferredGenerator implements \Iterator
             return $result;
         } catch (\Throwable $e) {
             $this->handleException($e);
-            return null;
+            throw $e;
         }
     }
 
@@ -134,6 +135,7 @@ final class DeferredGenerator implements \Iterator
             $this->fill();
         } catch (\Throwable $e) {
             $this->handleException($e);
+            throw $e;
         }
     }
 
@@ -184,6 +186,7 @@ final class DeferredGenerator implements \Iterator
             $this->finished = true;
         } catch (\Throwable $e) {
             $this->handleException($e);
+            throw $e;
         } finally {
             unset($this->handler, $this->values);
         }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Fix exception propagation from nested promises inside yielded generator

## Why?

To be sure that awaiting exception from awaiting promise inside awaiting generator will be propagated well

## Checklist

1. Closes #530 
2. How was this tested: added tests
