### PR TITLE
Send ApiKey to RoadRunner with WorkerInfo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "roadrunner-php/roadrunner-api-dto": "^1.9.0",
         "roadrunner-php/version-checker": "^1.0",
         "spiral/attributes": "^3.1.6",
-        "spiral/roadrunner": "^2024.1",
+        "spiral/roadrunner": "^2024.3",
         "spiral/roadrunner-cli": "^2.5",
         "spiral/roadrunner-kv": "^4.2",
         "spiral/roadrunner-worker": "^3.5",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1477,6 +1477,7 @@
       <code><![CDATA[new static(
             $converter ?? DataConverter::createDefault(),
             $rpc ?? Goridge::create(),
+            $credentials ?? ServiceCredentials::create(),
         )]]></code>
     </UnsafeInstantiation>
   </file>

--- a/src/Client/GRPC/BaseClient.php
+++ b/src/Client/GRPC/BaseClient.php
@@ -145,6 +145,8 @@ abstract class BaseClient implements ServiceClientInterface
      * This will overwrite any "Authorization" header that may be on the context before each request to the
      * Temporal service.
      * You may pass your own {@see \Stringable} implementation to be able to change the key dynamically.
+     *
+     * @link https://docs.temporal.io/cloud/api-keys
      */
     public function withAuthKey(\Stringable|string $key): static
     {

--- a/src/Worker/ServiceCredentials.php
+++ b/src/Worker/ServiceCredentials.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Worker;
+
+use Temporal\Internal\Traits\CloneWith;
+
+/**
+ * DTO with credential configuration for connecting RoadRunner to the Temporal service.
+ */
+final class ServiceCredentials
+{
+    use CloneWith;
+
+    public readonly string $apiKey;
+
+    private function __construct()
+    {
+        $this->apiKey = '';
+    }
+
+    public static function create(): self
+    {
+        return new self();
+    }
+
+    /**
+     * Set the authentication token for API calls.
+     *
+     * To update the API key in runtime, call the `UpdateAPIKey` RPC method with the new key:
+     *
+     *      $result = \Temporal\Worker\Transport\Goridge::create()->call(
+     *          'temporal.UpdateAPIKey',
+     *          $newApiKey,
+     *      );
+     *
+     * @link https://docs.temporal.io/cloud/api-keys
+     * @since SDK 2.12.0
+     * @since RoadRunner 2024.3.0
+     */
+    public function withApiKey(string $key): static
+    {
+        /** @see self::$apiKey */
+        return $this->with('apiKey', $key);
+    }
+}

--- a/testing/src/WorkerFactory.php
+++ b/testing/src/WorkerFactory.php
@@ -13,6 +13,7 @@ use Temporal\Interceptor\SimplePipelineProvider;
 use Temporal\Internal\ServiceContainer;
 use Temporal\Worker\ActivityInvocationCache\ActivityInvocationCacheInterface;
 use Temporal\Worker\ActivityInvocationCache\RoadRunnerActivityInvocationCache;
+use Temporal\Worker\ServiceCredentials;
 use Temporal\Worker\Transport\Goridge;
 use Temporal\Worker\Transport\RPCConnectionInterface;
 use Temporal\Worker\Worker;
@@ -27,21 +28,24 @@ class WorkerFactory extends \Temporal\WorkerFactory
         DataConverterInterface $dataConverter,
         RPCConnectionInterface $rpc,
         ActivityInvocationCacheInterface $activityCache,
+        ServiceCredentials $credentials,
     ) {
         $this->activityCache = $activityCache;
 
-        parent::__construct($dataConverter, $rpc);
+        parent::__construct($dataConverter, $rpc, $credentials);
     }
 
     public static function create(
         ?DataConverterInterface $converter = null,
         ?RPCConnectionInterface $rpc = null,
+        ?ServiceCredentials $credentials = null,
         ?ActivityInvocationCacheInterface $activityCache = null,
     ): static {
         return new static(
             $converter ?? DataConverter::createDefault(),
             $rpc ?? Goridge::create(),
             $activityCache ?? RoadRunnerActivityInvocationCache::create($converter),
+            $credentials ?? ServiceCredentials::create(),
         );
     }
 

--- a/tests/Unit/Framework/WorkerFactoryMock.php
+++ b/tests/Unit/Framework/WorkerFactoryMock.php
@@ -33,6 +33,7 @@ use Temporal\Internal\Transport\ServerInterface;
 use Temporal\Worker\Environment\Environment;
 use Temporal\Worker\Environment\EnvironmentInterface;
 use Temporal\Worker\LoopInterface;
+use Temporal\Worker\ServiceCredentials;
 use Temporal\Worker\Transport\Codec\CodecInterface;
 use Temporal\Worker\Transport\Command\ServerRequestInterface;
 use Temporal\Worker\Transport\Command\ServerResponseInterface;
@@ -183,7 +184,7 @@ class WorkerFactoryMock implements WorkerFactoryInterface, LoopInterface
     private function createRouter(): RouterInterface
     {
         $router = new Router();
-        $router->add(new Router\GetWorkerInfo($this->queues, $this->marshaller));
+        $router->add(new Router\GetWorkerInfo($this->queues, $this->marshaller, ServiceCredentials::create()));
 
         return $router;
     }

--- a/tests/Unit/Worker/ServiceCredentialsTestCase.php
+++ b/tests/Unit/Worker/ServiceCredentialsTestCase.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\Worker;
+
+use PHPUnit\Framework\TestCase;
+use Temporal\Worker\ServiceCredentials;
+
+class ServiceCredentialsTestCase extends TestCase
+{
+    public function testWithApiKeyImmutability()
+    {
+        $dto = ServiceCredentials::create();
+
+        $new = $dto->withApiKey('test');
+
+        $this->assertNotSame($dto, $new);
+        $this->assertSame('test', $new->apiKey);
+        $this->assertSame('', $dto->apiKey);
+    }
+}


### PR DESCRIPTION
## What was changed

- Added `ServiceCredentials` DTO to have the ability to provide connection configuration from the PHP side to RoadRunner.

Related https://github.com/temporalio/roadrunner-temporal/pull/575

## Checklist

- How was this tested: can't test automatically
- Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
