### PR TITLE
Fix BC in WorkerFactory constructor

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1443,6 +1443,9 @@
     <DeprecatedClass>
       <code><![CDATA[new AnnotationReader()]]></code>
     </DeprecatedClass>
+    <ImpureMethodCall>
+      <code><![CDATA[create]]></code>
+    </ImpureMethodCall>
     <InternalClass>
       <code><![CDATA[new Client($this->responses)]]></code>
     </InternalClass>
@@ -1477,7 +1480,7 @@
       <code><![CDATA[new static(
             $converter ?? DataConverter::createDefault(),
             $rpc ?? Goridge::create(),
-            $credentials ?? ServiceCredentials::create(),
+            $credentials,
         )]]></code>
     </UnsafeInstantiation>
   </file>

--- a/src/WorkerFactory.php
+++ b/src/WorkerFactory.php
@@ -105,10 +105,10 @@ class WorkerFactory implements WorkerFactoryInterface, LoopInterface
     public function __construct(
         DataConverterInterface $dataConverter,
         protected RPCConnectionInterface $rpc,
-        ServiceCredentials $credentials,
+        ?ServiceCredentials $credentials = null,
     ) {
         $this->converter = $dataConverter;
-        $this->boot($credentials);
+        $this->boot($credentials ?? ServiceCredentials::create());
     }
 
     public static function create(
@@ -119,7 +119,7 @@ class WorkerFactory implements WorkerFactoryInterface, LoopInterface
         return new static(
             $converter ?? DataConverter::createDefault(),
             $rpc ?? Goridge::create(),
-            $credentials ?? ServiceCredentials::create(),
+            $credentials,
         );
     }
 

--- a/testing/src/WorkerFactory.php
+++ b/testing/src/WorkerFactory.php
@@ -28,11 +28,11 @@ class WorkerFactory extends \Temporal\WorkerFactory
         DataConverterInterface $dataConverter,
         RPCConnectionInterface $rpc,
         ActivityInvocationCacheInterface $activityCache,
-        ServiceCredentials $credentials,
+        ?ServiceCredentials $credentials = null,
     ) {
         $this->activityCache = $activityCache;
 
-        parent::__construct($dataConverter, $rpc, $credentials);
+        parent::__construct($dataConverter, $rpc, $credentials ?? ServiceCredentials::create());
     }
 
     public static function create(
@@ -45,7 +45,7 @@ class WorkerFactory extends \Temporal\WorkerFactory
             $converter ?? DataConverter::createDefault(),
             $rpc ?? Goridge::create(),
             $activityCache ?? RoadRunnerActivityInvocationCache::create($converter),
-            $credentials ?? ServiceCredentials::create(),
+            $credentials,
         );
     }
 


### PR DESCRIPTION
## What was changed

Made parameter `$credentials` in `\Temporal\WorkerFactory::__construct()` optional

## Why?

To fix BC
