### PR TITLE
Fix a floating error in the WorkerRestart test

### DIFF
--- a/tests/Acceptance/Harness/Update/WorkerRestartTest.php
+++ b/tests/Acceptance/Harness/Update/WorkerRestartTest.php
@@ -12,7 +12,6 @@ use Temporal\Activity\ActivityInterface;
 use Temporal\Activity\ActivityMethod;
 use Temporal\Activity\ActivityOptions;
 use Temporal\Client\WorkflowStubInterface;
-use Temporal\Exception\Failure\ApplicationFailure;
 use Temporal\Tests\Acceptance\App\Attribute\Stub;
 use Temporal\Tests\Acceptance\App\Runtime\RRStarter;
 use Temporal\Tests\Acceptance\App\TestCase;
@@ -32,7 +31,6 @@ class WorkerRestartTest extends TestCase
         ContainerInterface $c,
         RRStarter $runner,
     ): void {
-        $c->get(StorageInterface::class)->set(KV_ACTIVITY_BLOCKED, true);
         $handle = $stub->startUpdate('do_activities');
 
         # Wait for the activity to start.
@@ -95,9 +93,8 @@ class FeatureActivity
         $this->kv->set(KV_ACTIVITY_STARTED, true);
 
         do {
-            $blocked = $this->kv->get(KV_ACTIVITY_BLOCKED);
+            $blocked = $this->kv->get(KV_ACTIVITY_BLOCKED, true);
 
-            \is_bool($blocked) or throw new ApplicationFailure('KV BLOCKED key not set', 'KvNotSet', true);
             if (!$blocked) {
                 break;
             }


### PR DESCRIPTION
## What's wrong

The `WorkerRestartTest` has a floating error (race condition between phpunit runtime and runtime into Roadrunner workers activity). The `WorkerRestartTest` is unstable.
## How it works now:

The key-value cache (`StorageInterface`) has an **in-memory** implementation. Therefore set values are reset upon roadrunner restart.

1. First the activity is locked, key `KV_ACTIVITY_BLOCKED` is set to `true`
2. Then Roadrunner is restarted
	  2.1. `$runner->stop();`, `KV_ACTIVITY_BLOCKED` key is reset, because storage is **in-memory**
	  2.2. `$runner->start();`
	  2.3. Roadrunner starts the workers which may execute activity code **immediately**
3. Then the activity is unlocked (key `KV_ACTIVITY_BLOCKED` is set to `false`)

The activity code throws an exception, if key `KV_ACTIVITY_BLOCKED` has a value **that is not boolean** (`null` by default if key does't exists).

## What's the problem

If step `3` starts before step `2.2`, the test will pass.

But if an activity on step `2.3` in a roadrunner worker starts executing **before** step 3, (race condition), the test fails with `ApplicationFailure` `KV BLOCKED key not set exception`.

It depends only on the test execution environment and on the luck.

## Proposed solution

By default the activity is blocked, no matter if a value in the cache exists. The activity is only unblocked after setting the `KV_ACTIVITY_BLOCKED` key to `false`. No exception is thrown.

Also the problem would not exist if the storage was persistent of course.
