### PR TITLE
Fix calling update method with unknown workflow type

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -428,7 +428,6 @@
       <code><![CDATA[$attr->getFailure()]]></code>
       <code><![CDATA[$attr->getResult()]]></code>
       <code><![CDATA[$input->workflowType]]></code>
-      <code><![CDATA[$input->workflowType]]></code>
       <code><![CDATA[$result->getQueryResult()]]></code>
       <code><![CDATA[$this->execution]]></code>
       <code><![CDATA[$this->execution]]></code>

--- a/src/Internal/Client/ResponseToResultMapper.php
+++ b/src/Internal/Client/ResponseToResultMapper.php
@@ -25,7 +25,7 @@ final class ResponseToResultMapper
     public function mapUpdateWorkflowResponse(
         UpdateWorkflowExecutionResponse $result,
         string $updateName,
-        string $workflowType,
+        ?string $workflowType,
         WorkflowExecution $workflowExecution,
     ): StartUpdateOutput {
         $outcome = $result->getOutcome();

--- a/tests/Acceptance/Extra/Update/UntypedStubTest.php
+++ b/tests/Acceptance/Extra/Update/UntypedStubTest.php
@@ -69,6 +69,19 @@ class UntypedStubTest extends TestCase
     }
 
     #[Test]
+    public function useClientRunningWorkflowStub(
+        #[Stub('Extra_Update_UntypedStub')] WorkflowStubInterface $stub,
+        WorkflowClientInterface $client,
+    ): void {
+        $untyped = $client->newUntypedRunningWorkflowStub(
+            $stub->getExecution()->getID(),
+            $stub->getExecution()->getRunID(),
+        );
+
+        $this->fetchResolvedResultAfterWorkflowCompleted($untyped);
+    }
+
+    #[Test]
     public function handleUnknownUpdate(
         #[Stub('Extra_Update_UntypedStub')] WorkflowStubInterface $stub,
     ): void {


### PR DESCRIPTION
## What was changed

Fix issue when a workflow stub without defined type runs an update method

## Checklist

1. Closes #544
2. How was this tested: added acceptance test

