### PR TITLE
Use `namespace` from ClientOptions on creating of Schedule

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -109,10 +109,21 @@
       <code><![CDATA[$workflowType]]></code>
     </PropertyNotSetInConstructor>
   </file>
+  <file src="src/Client/Schedule/ScheduleOptions.php">
+    <DeprecatedProperty>
+      <code><![CDATA[$this->namespace]]></code>
+    </DeprecatedProperty>
+  </file>
   <file src="src/Client/Schedule/Spec/ScheduleSpec.php">
     <DeprecatedProperty>
       <code><![CDATA[$this->excludeCalendarList]]></code>
       <code><![CDATA[$this->excludeCalendarList]]></code>
+    </DeprecatedProperty>
+  </file>
+  <file src="src/Client/ScheduleClient.php">
+    <DeprecatedProperty>
+      <code><![CDATA[$options->namespace]]></code>
+      <code><![CDATA[$options->namespace]]></code>
     </DeprecatedProperty>
   </file>
   <file src="src/Client/Update/UpdateHandle.php">

--- a/src/Client/Schedule/ScheduleOptions.php
+++ b/src/Client/Schedule/ScheduleOptions.php
@@ -16,20 +16,23 @@ final class ScheduleOptions
 {
     use CloneWith;
 
-    public readonly string $namespace;
-    public readonly bool $triggerImmediately;
+    /**
+     * @deprecated will be removed in the next major version.
+     */
+    public readonly ?string $namespace;
 
     /**
      * @var list<BackfillPeriod>
      */
     public readonly array $backfills;
 
+    public readonly bool $triggerImmediately;
     public readonly EncodedCollection $memo;
     public readonly EncodedCollection $searchAttributes;
 
     private function __construct()
     {
-        $this->namespace = 'default';
+        $this->namespace = null;
         $this->triggerImmediately = false;
         $this->backfills = [];
         $this->memo = EncodedCollection::empty();
@@ -41,6 +44,10 @@ final class ScheduleOptions
         return new self();
     }
 
+    /**
+     * @deprecated Configure the namespace on the {@see \Temporal\Client\ClientOptions} instead
+     *             when creating the {@see \Temporal\Client\ScheduleClient}.
+     */
     public function withNamespace(string $namespace): self
     {
         /** @see self::$namespace */

--- a/src/Client/ScheduleClient.php
+++ b/src/Client/ScheduleClient.php
@@ -81,7 +81,7 @@ final class ScheduleClient implements ScheduleClientInterface
         $request = new CreateScheduleRequest();
         $request
             ->setRequestId(Uuid::v4())
-            ->setNamespace($options->namespace)
+            ->setNamespace($options->namespace ?? $this->clientOptions->namespace)
             ->setScheduleId($scheduleId)
             ->setIdentity($this->clientOptions->identity);
 
@@ -123,7 +123,7 @@ final class ScheduleClient implements ScheduleClientInterface
             $this->converter,
             $this->marshaller,
             $this->protoConverter,
-            $options->namespace,
+            $options->namespace ?? $this->clientOptions->namespace,
             $scheduleId,
         );
     }

--- a/tests/Unit/Schedule/ScheduleOptionsTestCase.php
+++ b/tests/Unit/Schedule/ScheduleOptionsTestCase.php
@@ -22,7 +22,7 @@ class ScheduleOptionsTestCase extends TestCase
         $new = $init->withNamespace('foo');
 
         $this->assertNotSame($init, $new, 'immutable method clones object');
-        $this->assertSame('default', $init->namespace, 'default value was not changed');
+        $this->assertNull($init->namespace, 'default value was not changed');
         $this->assertSame('foo', $new->namespace);
     }
 


### PR DESCRIPTION
## What was changed

- `ScheduleOptions->naemspace` has `null` value by default instead of `"default"`
- Deprecate `namespace` property and `withNamespace()` method in `ScheduleOptions`
- Use `namespace` from the ClientOptions as a fallback value when a Schedule is created

## Checklist

1. Closes #548
2. How was this tested: added unit tests
