### PR TITLE
Fix unmarshalling of ScheduleSpec with null jitter

### DIFF
--- a/src/Internal/Marshaller/Type/DurationJsonType.php
+++ b/src/Internal/Marshaller/Type/DurationJsonType.php
@@ -76,8 +76,12 @@ class DurationJsonType extends Type implements DetectableTypeInterface, RuleFact
     {
         if (\is_array($value) && isset($value['seconds']) && isset($value['nanos'])) {
             // The highest precision is milliseconds either way.
-            $value = $value['seconds'] * 1_000_000_000 + $value['nanos'];
-            return DateInterval::parse($value, DateInterval::FORMAT_NANOSECONDS);
+            $value = $value['seconds'] * 1_000_000 + (int) \round($value['nanos'] / 1000);
+            return DateInterval::parse($value, DateInterval::FORMAT_MICROSECONDS);
+        }
+
+        if ($value === null) {
+            return CarbonInterval::create();
         }
 
         return DateInterval::parse($value, $this->fallbackFormat);

--- a/src/Internal/Transport/Request/UpsertSearchAttributes.php
+++ b/src/Internal/Transport/Request/UpsertSearchAttributes.php
@@ -16,7 +16,7 @@ final class UpsertSearchAttributes extends Request
     public function __construct(
         private readonly array $searchAttributes,
     ) {
-        parent::__construct(self::NAME, ['searchAttributes' => $searchAttributes]);
+        parent::__construct(self::NAME, ['searchAttributes' => (object) $searchAttributes]);
     }
 
     /**

--- a/src/Internal/Transport/Request/UpsertTypedSearchAttributes.php
+++ b/src/Internal/Transport/Request/UpsertTypedSearchAttributes.php
@@ -18,7 +18,7 @@ final class UpsertTypedSearchAttributes extends Request
     public function __construct(
         private readonly array $searchAttributes,
     ) {
-        parent::__construct(self::NAME, ['search_attributes' => $this->prepareSearchAttributes()]);
+        parent::__construct(self::NAME, ['search_attributes' => (object) $this->prepareSearchAttributes()]);
     }
 
     /**

--- a/tests/Unit/DTO/Type/DurationJsonType/DurationJsonTestCase.php
+++ b/tests/Unit/DTO/Type/DurationJsonType/DurationJsonTestCase.php
@@ -21,12 +21,25 @@ class DurationJsonTestCase extends AbstractDTOMarshalling
     public function testMarshalAndUnmarshalDuration(): void
     {
         $dto = new DurationJsonDto();
-        $dto->duration = DateInterval::parse(1);
+        $dto->duration = DateInterval::parse(100);
+        $dto->durationProto = DateInterval::parse(12000);
 
         $result = $this->marshal($dto);
         $unmarshal = $this->unmarshal($result, new DurationJsonDto());
 
         self::assertInstanceOf(\DateInterval::class, $unmarshal->duration);
+        self::assertInstanceOf(\DateInterval::class, $unmarshal->durationProto);
+        self::assertSame('0 100000', $unmarshal->duration->format('%s %f'));
+        self::assertSame('12 0', $unmarshal->durationProto->format('%s %f'));
+    }
+
+    public function testUnmarshallEmptyDuration(): void
+    {
+        $result = ['duration' => null, 'duration_proto' => null];
+        $unmarshal = $this->unmarshal($result, new DurationJsonDto());
+
+        self::assertSame('0.0', $unmarshal->duration->format('%s.%f'));
+        self::assertSame('0.0', $unmarshal->durationProto->format('%s.%f'));
     }
 
     protected function getTypeMatchers(): array

--- a/tests/Unit/DTO/Type/DurationJsonType/Stub/DurationJsonDto.php
+++ b/tests/Unit/DTO/Type/DurationJsonType/Stub/DurationJsonDto.php
@@ -11,7 +11,13 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Unit\DTO\Type\DurationJsonType\Stub;
 
+use Google\Protobuf\Duration;
+use Temporal\Internal\Marshaller\Meta\Marshal;
+
 class DurationJsonDto
 {
     public \DateInterval $duration;
+
+    #[Marshal('duration_proto', of: Duration::class)]
+    public \DateInterval $durationProto;
 }


### PR DESCRIPTION
## What was changed

Marshaller decodes null value into an empty interval when a message of Duration type expected

## Why?

1. Closes #286
2. How was this tested: tests added
