### PR TITLE
Rename `InitMethod` to `WorkflowInit`

### DIFF
--- a/src/Internal/Declaration/WorkflowInstance.php
+++ b/src/Internal/Declaration/WorkflowInstance.php
@@ -20,7 +20,7 @@ use Temporal\Interceptor\WorkflowInboundCallsInterceptor;
 use Temporal\Internal\Declaration\Prototype\WorkflowPrototype;
 use Temporal\Internal\Declaration\WorkflowInstance\SignalQueue;
 use Temporal\Internal\Interceptor;
-use Temporal\Workflow\InitMethod;
+use Temporal\Workflow\WorkflowInit;
 
 /**
  * @psalm-type QueryHandler = \Closure(QueryInput): mixed
@@ -155,7 +155,7 @@ final class WorkflowInstance extends Instance implements WorkflowInstanceInterfa
 
         // Check InitMethod attribute
         $reflection = new \ReflectionMethod($this->context, '__construct');
-        $attributes = $reflection->getAttributes(InitMethod::class);
+        $attributes = $reflection->getAttributes(WorkflowInit::class);
         $attributes === []
             ? $this->context->__construct()
             : $this->context->__construct(...$arguments);

--- a/src/Internal/Declaration/WorkflowInstanceInterface.php
+++ b/src/Internal/Declaration/WorkflowInstanceInterface.php
@@ -25,7 +25,7 @@ interface WorkflowInstanceInterface extends InstanceInterface
 {
     /**
      * Trigger constructor in Process context.
-     * If the constructor is tagged with {@see \Temporal\Workflow\InitMethod} attribute,
+     * If the constructor is tagged with {@see \Temporal\Workflow\WorkflowInit} attribute,
      * it will be executed with the {@see \Temporal\Workflow\WorkflowMethod} arguments.
      */
     public function init(array $arguments = []): void;

--- a/src/Workflow/WorkflowInit.php
+++ b/src/Workflow/WorkflowInit.php
@@ -21,4 +21,4 @@ use Doctrine\Common\Annotations\Annotation\Target;
  * @Target({ "METHOD" })
  */
 #[\Attribute(\Attribute::TARGET_METHOD)]
-final class InitMethod {}
+final class WorkflowInit {}

--- a/tests/Acceptance/Extra/Workflow/InitMethodTest.php
+++ b/tests/Acceptance/Extra/Workflow/InitMethodTest.php
@@ -10,7 +10,7 @@ use Temporal\Exception\Client\WorkflowFailedException;
 use Temporal\Exception\Failure\TimeoutFailure;
 use Temporal\Tests\Acceptance\App\Attribute\Stub;
 use Temporal\Tests\Acceptance\App\TestCase;
-use Temporal\Workflow\InitMethod;
+use Temporal\Workflow\WorkflowInit;
 use Temporal\Workflow\WorkflowInterface;
 use Temporal\Workflow\WorkflowMethod;
 
@@ -57,7 +57,7 @@ class TestWorkflow
 {
     private array $initInput;
 
-    #[InitMethod]
+    #[WorkflowInit]
     public function __construct(Input $input)
     {
         $this->initInput = \func_get_args();
@@ -75,7 +75,7 @@ class TestWorkflowEmptyConstructor
 {
     private array $initInput;
 
-    #[InitMethod]
+    #[WorkflowInit]
     public function __construct()
     {
         $this->initInput = \func_get_args();
@@ -93,7 +93,7 @@ class TestWorkflowDifferentConstructorParams
 {
     private array $initInput;
 
-    #[InitMethod]
+    #[WorkflowInit]
     public function __construct(\stdClass $input)
     {
         $this->initInput = \func_get_args();


### PR DESCRIPTION
## What was changed

Attribute`InitMethod` renamed to `WorkflowInit`

## Why?

Other SDKs have init-attributes with the same name
