### PR TITLE
Add default implementation for upsertMemo method in interceptors

### DIFF
--- a/src/Interceptor/Trait/WorkflowOutboundCallsInterceptorTrait.php
+++ b/src/Interceptor/Trait/WorkflowOutboundCallsInterceptorTrait.php
@@ -25,6 +25,7 @@ use Temporal\Interceptor\WorkflowOutboundCalls\PanicInput;
 use Temporal\Interceptor\WorkflowOutboundCalls\SideEffectInput;
 use Temporal\Interceptor\WorkflowOutboundCalls\SignalExternalWorkflowInput;
 use Temporal\Interceptor\WorkflowOutboundCalls\TimerInput;
+use Temporal\Interceptor\WorkflowOutboundCalls\UpsertMemoInput;
 use Temporal\Interceptor\WorkflowOutboundCalls\UpsertSearchAttributesInput;
 use Temporal\Interceptor\WorkflowOutboundCalls\UpsertTypedSearchAttributesInput;
 use Temporal\Interceptor\WorkflowOutboundCallsInterceptor;
@@ -144,6 +145,14 @@ trait WorkflowOutboundCallsInterceptorTrait
      * @see WorkflowOutboundCallsInterceptor::getVersion()
      */
     public function getVersion(GetVersionInput $input, callable $next): PromiseInterface
+    {
+        return $next($input);
+    }
+
+    /**
+     * @param callable(UpsertMemoInput): PromiseInterface $next
+     */
+    public function upsertMemo(UpsertMemoInput $input, callable $next): PromiseInterface
     {
         return $next($input);
     }

--- a/src/Interceptor/Trait/WorkflowOutboundCallsInterceptorTrait.php
+++ b/src/Interceptor/Trait/WorkflowOutboundCallsInterceptorTrait.php
@@ -150,7 +150,9 @@ trait WorkflowOutboundCallsInterceptorTrait
     }
 
     /**
-     * @param callable(UpsertMemoInput): PromiseInterface $next
+     * Default implementation of the `upsertMemo` method.
+     *
+     * @see WorkflowOutboundCallsInterceptor::upsertMemo()
      */
     public function upsertMemo(UpsertMemoInput $input, callable $next): PromiseInterface
     {

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -912,34 +912,35 @@ final class Workflow extends Facade
      * For example:
      *
      * ```php
-     * Workflow::upsertMemo([
-     * 'key1' => 'value',
-     * 'key3' => ['subkey1' => 'value']
-     * 'key4' => 'value',
-     * });
+     *  Workflow::upsertMemo([
+     *      'key1' => 'value',
+     *      'key3' => ['subkey1' => 'value']
+     *      'key4' => 'value',
+     *  });
      *
-     * Workflow::upsertMemo([
-     * 'key2' => 'value',
-     * 'key3' => ['subkey2' => 'value']
-     * 'key4' => null,
-     * ]);
+     *  Workflow::upsertMemo([
+     *      'key2' => 'value',
+     *      'key3' => ['subkey2' => 'value']
+     *      'key4' => null,
+     *  ]);
      * ```
      *
      * would result in the Workflow having these Memo:
      *
      * ```php
-     * [
-     * 'key1' => 'value',
-     * 'key2' => 'value',
-     * 'key3' => ['subkey2' => 'value'], // Note this object was completely replaced
-     * // Note that 'key4' was completely removed
-     * ]
+     *  [
+     *      'key1' => 'value',
+     *      'key2' => 'value',
+     *      'key3' => ['subkey2' => 'value'], // Note this object was completely replaced
+     *      // Note that 'key4' was completely removed
+     *  ]
      * ```
      *
      * @param array<non-empty-string, mixed> $values
      *
      * @since SDK 2.13.0
      * @since RoadRunner 2024.3.3
+     * @link https://docs.temporal.io/glossary#memo
      */
     public static function upsertMemo(array $values): void
     {

--- a/tests/Acceptance/App/Runtime/RRStarter.php
+++ b/tests/Acceptance/App/Runtime/RRStarter.php
@@ -63,4 +63,9 @@ final class RRStarter
         $this->environment->stop();
         $this->started = false;
     }
+
+    public function __destruct()
+    {
+        $this->stop();
+    }
 }

--- a/tests/Acceptance/Extra/Workflow/MemoTest.php
+++ b/tests/Acceptance/Extra/Workflow/MemoTest.php
@@ -109,8 +109,6 @@ class TestWorkflow
             fn(): bool => $this->exit,
         );
 
-        tr(Workflow::getInfo()->memo);
-
         return Workflow::getInfo()->memo;
     }
 

--- a/tests/Unit/Interceptor/TraitsTestCase.php
+++ b/tests/Unit/Interceptor/TraitsTestCase.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\Interceptor;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Temporal\DataConverter\DataConverter;
+use Temporal\DataConverter\DataConverterInterface;
+use Temporal\Interceptor\ActivityInboundInterceptor;
+use Temporal\Interceptor\Header;
+use Temporal\Interceptor\Trait\ActivityInboundInterceptorTrait;
+use Temporal\Interceptor\Trait\WorkflowClientCallsInterceptorTrait;
+use Temporal\Interceptor\Trait\WorkflowInboundCallsInterceptorTrait;
+use Temporal\Interceptor\Trait\WorkflowOutboundCallsInterceptorTrait;
+use Temporal\Interceptor\Trait\WorkflowOutboundRequestInterceptorTrait;
+use Temporal\Interceptor\WorkflowClientCallsInterceptor;
+use Temporal\Interceptor\WorkflowInboundCallsInterceptor;
+use Temporal\Interceptor\WorkflowOutboundCallsInterceptor;
+use Temporal\Interceptor\WorkflowOutboundRequestInterceptor;
+use Temporal\Tests\Unit\AbstractUnit;
+
+/**
+ * Check that interceptor traits cover all interfaces methods.
+ *
+ * @group unit
+ * @group interceptor
+ */
+class TraitsTestCase extends AbstractUnit
+{
+    public function testActivityInboundInterceptor(): void
+    {
+        new class implements ActivityInboundInterceptor {
+            use ActivityInboundInterceptorTrait;
+        };
+
+        self::assertTrue(true);
+    }
+
+    public function testWorkflowClientCallsInterceptor(): void
+    {
+        new class implements WorkflowClientCallsInterceptor {
+            use WorkflowClientCallsInterceptorTrait;
+        };
+
+        self::assertTrue(true);
+    }
+
+    public function testWorkflowInboundCallsInterceptor(): void
+    {
+        new class implements WorkflowInboundCallsInterceptor {
+            use WorkflowInboundCallsInterceptorTrait;
+        };
+
+        self::assertTrue(true);
+    }
+
+    public function testWorkflowOutboundCallsInterceptor(): void
+    {
+        new class implements WorkflowOutboundCallsInterceptor {
+            use WorkflowOutboundCallsInterceptorTrait;
+        };
+
+        self::assertTrue(true);
+    }
+
+    public function testWorkflowOutboundRequestInterceptor(): void
+    {
+        new class implements WorkflowOutboundRequestInterceptor {
+            use WorkflowOutboundRequestInterceptorTrait;
+        };
+
+        self::assertTrue(true);
+    }
+}


### PR DESCRIPTION
## What was changed

Added `upsertMemo()` method with default implementation for WorkflowOutboundCallsInterceptor.
