### PR TITLE
Skip magic methods in Activity classes

### DIFF
--- a/src/Internal/Declaration/Reader/ActivityReader.php
+++ b/src/Internal/Declaration/Reader/ActivityReader.php
@@ -139,6 +139,10 @@ class ActivityReader extends Reader
                     continue;
                 }
 
+                if ($attribute === null && $this->isMagic($method)) {
+                    continue;
+                }
+
                 //
                 // The name of the activity must be generated based on the
                 // optional prefix on the #[ActivityInterface] attribute and

--- a/src/Internal/Declaration/Reader/Reader.php
+++ b/src/Internal/Declaration/Reader/Reader.php
@@ -18,6 +18,11 @@ use Spiral\Attributes\ReaderInterface;
  */
 abstract class Reader
 {
+    private const MAGIC_METHODS = [
+        '__construct', '__destruct', '__call', '__callStatic', '__get', '__set', '__isset', '__unset', '__sleep',
+        '__wakeup', '__serialize', '__unserialize', '__toString', '__invoke', '__set_state', '__clone', '__debugInfo',
+    ];
+
     protected ReaderInterface $reader;
 
     public function __construct(ReaderInterface $reader)
@@ -34,5 +39,10 @@ abstract class Reader
     protected function isValidMethod(\ReflectionMethod $method): bool
     {
         return !$method->isStatic() && $method->isPublic();
+    }
+
+    protected function isMagic(\ReflectionMethod $method): bool
+    {
+        return \in_array($method->getName(), self::MAGIC_METHODS, true);
     }
 }

--- a/tests/Unit/Activity/DummyActivity.php
+++ b/tests/Unit/Activity/DummyActivity.php
@@ -11,7 +11,5 @@ use Temporal\Activity\ActivityMethod;
 final class DummyActivity
 {
     #[ActivityMethod(name: "DoNothing")]
-    public function doNothing(): void
-    {
-    }
+    public function doNothing(): void {}
 }

--- a/tests/Unit/Activity/MagicActivity.php
+++ b/tests/Unit/Activity/MagicActivity.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\Activity;
+
+use Temporal\Activity\ActivityInterface;
+use Temporal\Activity\ActivityMethod;
+
+#[ActivityInterface(prefix: 'MagicActivity.')]
+final class MagicActivity
+{
+    public function __construct() {}
+
+    #[ActivityMethod(name: "Do")]
+    public function __invoke(): void {}
+
+    public function __destruct() {}
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Magic methods that was not marked by the ActivityMethod attribute will not be registered as activity methods

## Checklist
<!--- add/delete as needed --->

1. Closes #566
2. How was this tested: added tests
