### PR TITLE
Expose Namespace in client requests metadata

### DIFF
--- a/src/Client/GRPC/BaseClient.php
+++ b/src/Client/GRPC/BaseClient.php
@@ -276,8 +276,6 @@ abstract class BaseClient implements ServiceClientInterface
                     $options['timeout'] = CarbonInterval::instance($diff)->totalMicroseconds;
                 }
 
-                tr(['method' => $method, 'arg' => $arg, 'metadata' => $ctx->getMetadata(), 'options' => $options]);
-
                 /** @var UnaryCall $call */
                 $call = $this->connection->getWorkflowService()->{$method}($arg, $ctx->getMetadata(), $options);
                 [$result, $status] = $call->wait();

--- a/src/Client/GRPC/BaseClient.php
+++ b/src/Client/GRPC/BaseClient.php
@@ -237,14 +237,14 @@ abstract class BaseClient implements ServiceClientInterface
      */
     protected function invoke(string $method, object $arg, ?ContextInterface $ctx = null): mixed
     {
-        $ctx ??= $this->context;
+        $ctx ??= $this->getContext();
 
         // Add the API key to the context
         $key = (string) $this->apiKey;
         if ($key !== '') {
             $ctx = $ctx->withMetadata([
                 'Authorization' => ["Bearer $key"],
-            ]);
+            ] + $ctx->getMetadata());
         }
 
         return $this->invokePipeline !== null
@@ -275,6 +275,8 @@ abstract class BaseClient implements ServiceClientInterface
                     $diff = (new \DateTime())->diff($deadline);
                     $options['timeout'] = CarbonInterval::instance($diff)->totalMicroseconds;
                 }
+
+                tr(['method' => $method, 'arg' => $arg, 'metadata' => $ctx->getMetadata(), 'options' => $options]);
 
                 /** @var UnaryCall $call */
                 $call = $this->connection->getWorkflowService()->{$method}($arg, $ctx->getMetadata(), $options);

--- a/src/Client/ScheduleClient.php
+++ b/src/Client/ScheduleClient.php
@@ -51,13 +51,20 @@ final class ScheduleClient implements ScheduleClientInterface
         ?ClientOptions $options = null,
         ?DataConverterInterface $converter = null,
     ) {
-        $this->client = $serviceClient;
         $this->clientOptions = $options ?? new ClientOptions();
         $this->converter = $converter ?? DataConverter::createDefault();
         $this->marshaller = new Marshaller(
             new AttributeMapperFactory(new AttributeReader()),
         );
         $this->protoConverter = new ProtoToArrayConverter($this->converter);
+
+        // Set Temporal-Namespace metadata
+        $context = $serviceClient->getContext();
+        $this->client = $serviceClient->withContext(
+            $context->withMetadata(
+                ['Temporal-Namespace' => [$this->clientOptions->namespace]] + $context->getMetadata(),
+            ),
+        );
     }
 
     public static function create(

--- a/src/Client/WorkflowClient.php
+++ b/src/Client/WorkflowClient.php
@@ -74,12 +74,19 @@ class WorkflowClient implements WorkflowClientInterface
         ?DataConverterInterface $converter = null,
         ?PipelineProvider $interceptorProvider = null,
     ) {
-        $this->client = $serviceClient;
         $this->interceptorPipeline = ($interceptorProvider ?? new SimplePipelineProvider())
             ->getPipeline(WorkflowClientCallsInterceptor::class);
         $this->clientOptions = $options ?? new ClientOptions();
         $this->converter = $converter ?? DataConverter::createDefault();
         $this->reader = new WorkflowReader($this->createReader());
+
+        // Set Temporal-Namespace metadata
+        $context = $serviceClient->getContext();
+        $this->client = $serviceClient->withContext(
+            $context->withMetadata(
+                ['Temporal-Namespace' => [$this->clientOptions->namespace]] + $context->getMetadata(),
+            ),
+        );
     }
 
     /**

--- a/tests/Unit/Client/GRPC/BaseClientTestCase.php
+++ b/tests/Unit/Client/GRPC/BaseClientTestCase.php
@@ -127,11 +127,13 @@ class BaseClientTestCase extends TestCase
         $ctx1 = $client->testCall()->ctx;
         self::assertInstanceOf(ContextInterface::class, $ctx1);
         $this->assertArrayNotHasKey('Authorization', $ctx1->getMetadata());
+        $keysBefore = \count($ctx1->getMetadata());
 
         $ctx2 = $client2->testCall()->ctx;
         self::assertInstanceOf(ContextInterface::class, $ctx2);
         $this->assertArrayHasKey('Authorization', $ctx2->getMetadata());
         $this->assertSame(['Bearer test-key'], $ctx2->getMetadata()['Authorization']);
+        $this->assertSame($keysBefore + 1, \count($ctx2->getMetadata()), 'API Key doesnt affect other metadata');
     }
 
     public function testWithDynamicAuthKey(): void

--- a/tests/Unit/Schedule/ScheduleClientTestCase.php
+++ b/tests/Unit/Schedule/ScheduleClientTestCase.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Unit\Schedule;
 
-use DateTimeImmutable;
 use PHPUnit\Framework\Attributes\CoversClass;
 use Spiral\Attributes\AttributeReader;
 use Temporal\Api\Workflowservice\V1\CreateScheduleRequest;
@@ -43,9 +42,10 @@ class ScheduleClientTestCase extends TestCase
         };
         // Prepare mocks
         $clientMock = $this->createMock(ServiceClientInterface::class);
+        $clientMock->expects($this->once())->method('withContext')->willReturnSelf();
         $clientMock->expects($this->once())
             ->method('CreateSchedule')
-            ->with($this->callback(fn(CreateScheduleRequest $request) => $testContext->request = $request or true))
+            ->with($this->callback(static fn(CreateScheduleRequest $request) => $testContext->request = $request or true))
             ->willReturn((new CreateScheduleResponse())->setConflictToken('test-conflict-token'));
         $scheduleClient = $this->createScheduleClient(
             client: $clientMock,
@@ -71,9 +71,10 @@ class ScheduleClientTestCase extends TestCase
         };
         // Prepare mocks
         $clientMock = $this->createMock(ServiceClientInterface::class);
+        $clientMock->expects($this->once())->method('withContext')->willReturnSelf();
         $clientMock->expects($this->once())
             ->method('CreateSchedule')
-            ->with($this->callback(fn(CreateScheduleRequest $request) => $testContext->request = $request or true))
+            ->with($this->callback(static fn(CreateScheduleRequest $request) => $testContext->request = $request or true))
             ->willReturn((new CreateScheduleResponse())->setConflictToken('test-conflict-token'));
         $scheduleClient = $this->createScheduleClient(
             client: $clientMock,
@@ -97,9 +98,10 @@ class ScheduleClientTestCase extends TestCase
         };
         // Prepare mocks
         $clientMock = $this->createMock(ServiceClientInterface::class);
+        $clientMock->expects($this->once())->method('withContext')->willReturnSelf();
         $clientMock->expects($this->once())
             ->method('CreateSchedule')
-            ->with($this->callback(fn(CreateScheduleRequest $request) => $testContext->request = $request or true))
+            ->with($this->callback(static fn(CreateScheduleRequest $request) => $testContext->request = $request or true))
             ->willReturn((new CreateScheduleResponse())->setConflictToken('test-conflict-token'));
         $scheduleClient = $this->createScheduleClient(
             client: $clientMock,
@@ -124,16 +126,17 @@ class ScheduleClientTestCase extends TestCase
         };
         // Prepare mocks
         $clientMock = $this->createMock(ServiceClientInterface::class);
+        $clientMock->expects($this->once())->method('withContext')->willReturnSelf();
         $clientMock->expects($this->once())
             ->method('CreateSchedule')
-            ->with($this->callback(fn(CreateScheduleRequest $request) => $testContext->request = $request or true))
+            ->with($this->callback(static fn(CreateScheduleRequest $request) => $testContext->request = $request or true))
             ->willReturn((new CreateScheduleResponse())->setConflictToken('test-conflict-token'));
         $scheduleClient = $this->createScheduleClient(
             client: $clientMock,
         );
         $result = $scheduleClient->createSchedule(
             Schedule::new()->withAction(
-                StartWorkflowAction::new('PingSite')
+                StartWorkflowAction::new('PingSite'),
             ),
             scheduleId: 'test-id',
         );
@@ -149,9 +152,10 @@ class ScheduleClientTestCase extends TestCase
         };
         // Prepare mocks
         $clientMock = $this->createMock(ServiceClientInterface::class);
+        $clientMock->expects($this->once())->method('withContext')->willReturnSelf();
         $clientMock->expects($this->once())
             ->method('ListSchedules')
-            ->with($this->callback(fn(ListSchedulesRequest $request) => $testContext->request = $request or true))
+            ->with($this->callback(static fn(ListSchedulesRequest $request) => $testContext->request = $request or true))
             ->willReturn((new ListSchedulesResponse()));
         $scheduleClient = $this->createScheduleClient(
             client: $clientMock,
@@ -176,9 +180,10 @@ class ScheduleClientTestCase extends TestCase
         };
         // Prepare mocks
         $clientMock = $this->createMock(ServiceClientInterface::class);
+        $clientMock->expects($this->once())->method('withContext')->willReturnSelf();
         $clientMock->expects($this->once())
             ->method('CreateSchedule')
-            ->with($this->callback(fn(CreateScheduleRequest $request) => $testContext->request = $request or true))
+            ->with($this->callback(static fn(CreateScheduleRequest $request) => $testContext->request = $request or true))
             ->willReturn((new CreateScheduleResponse())->setConflictToken('test-conflict-token'));
         $scheduleClient = $this->createScheduleClient(
             client: $clientMock,
@@ -279,35 +284,36 @@ class ScheduleClientTestCase extends TestCase
                 ->withMemo(['foo' => 'memo'])
                 ->withSearchAttributes(['foo' => 'search'])
                 ->withWorkflowId('workflow-id')
-                ->withWorkflowIdReusePolicy(WorkflowIdReusePolicy::AllowDuplicateFailedOnly)
+                ->withWorkflowIdReusePolicy(WorkflowIdReusePolicy::AllowDuplicateFailedOnly),
         )->withSpec(
             ScheduleSpec::new()
                 ->withStructuredCalendarList(
                     StructuredCalendarSpec::new()
                         ->withDaysOfWeek(Range::new(1, 5))
-                        ->withHours(Range::new(9, 9), Range::new(12, 12))
+                        ->withHours(Range::new(9, 9), Range::new(12, 12)),
                 )
                 ->withCalendarList(
                     CalendarSpec::new()
                         ->withSecond(6)
                         ->withMinute('*/6')
-                        ->withComment('test comment')
+                        ->withComment('test comment'),
                 )
                 ->withCronStringList('0 12 * * 5', '0 12 * * 1')
-                ->withStartTime(new DateTimeImmutable('2024-10-01T00:00:00Z'))
-                ->withEndTime(new DateTimeImmutable('2024-10-31T00:00:00Z'))
+                ->withStartTime(new \DateTimeImmutable('2024-10-01T00:00:00Z'))
+                ->withEndTime(new \DateTimeImmutable('2024-10-31T00:00:00Z'))
                 ->withJitter('10m')
-                ->withTimezoneName('UTC')
-        )->withPolicies(SchedulePolicies::new()
-            ->withCatchupWindow('10m')
-            ->withPauseOnFailure(true)
-            ->withOverlapPolicy(ScheduleOverlapPolicy::CancelOther)
+                ->withTimezoneName('UTC'),
+        )->withPolicies(
+            SchedulePolicies::new()
+                ->withCatchupWindow('10m')
+                ->withPauseOnFailure(true)
+                ->withOverlapPolicy(ScheduleOverlapPolicy::CancelOther),
         )->withState(
             ScheduleState::new()
                 ->withLimitedActions(true)
                 ->withRemainingActions(10)
                 ->withPaused(true)
-                ->withNotes('test notes')
+                ->withNotes('test notes'),
         );
     }
 }


### PR DESCRIPTION

## What was changed

- Fix: Auth Key doesn't affect other metadata now
- Added `Temporal-Namespace` header into each client request

## Why?

To be able to work with Temporal Cloud

## Checklist

1. Closes #582
