### PR TITLE
Add Workflow Logger

### DIFF
--- a/src/Interceptor/WorkflowInboundCallsInterceptor.php
+++ b/src/Interceptor/WorkflowInboundCallsInterceptor.php
@@ -29,7 +29,7 @@ use Temporal\Internal\Interceptor\Interceptor;
  *
  *     public function handleSignal(SignalInput $input, callable $next): void
  *     {
- *         error_log('Workflow received signal: ' . $input->signalName);
+ *         Workflow::getLogger()->info('Workflow received signal: ' . $input->signalName);
  *
  *         $next($input);
  *     }

--- a/src/Interceptor/WorkflowOutboundCallsInterceptor.php
+++ b/src/Interceptor/WorkflowOutboundCallsInterceptor.php
@@ -46,7 +46,7 @@ use Temporal\Internal\Interceptor\Interceptor;
  *         ExecuteActivityInput $input,
  *         callable $next,
  *     ): PromiseInterface {
- *         error_log('Calling activity: ' . $input->type);
+ *         Workflow::getLogger()->info('Calling activity: ' . $input->type);
  *
  *         return $next($input);
  *     }

--- a/src/Interceptor/WorkflowOutboundRequestInterceptor.php
+++ b/src/Interceptor/WorkflowOutboundRequestInterceptor.php
@@ -29,7 +29,7 @@ use Temporal\Worker\Transport\Command\RequestInterface;
  *
  *     private function executeActivityRequest(ExecuteActivity $request, callable $next): PromiseInterface
  *     {
- *         error_log('Starting activity: ' . $request->getActivityName());
+ *         Workflow::getLogger()->info('Starting activity: ' . $request->getActivityName());
  *
  *         return $next($request);
  *     }

--- a/src/Internal/ServiceContainer.php
+++ b/src/Internal/ServiceContainer.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Temporal\Internal;
 
+use Psr\Log\LoggerInterface;
 use Spiral\Attributes\ReaderInterface;
 use Temporal\DataConverter\DataConverterInterface;
 use Temporal\Exception\ExceptionInterceptorInterface;
@@ -52,6 +53,7 @@ final class ServiceContainer
         public readonly DataConverterInterface $dataConverter,
         public readonly ExceptionInterceptorInterface $exceptionInterceptor,
         public readonly PipelineProvider $interceptorProvider,
+        public readonly LoggerInterface $logger,
     ) {
         $this->workflows = new WorkflowCollection();
         $this->activities = new ActivityCollection();
@@ -64,6 +66,7 @@ final class ServiceContainer
         WorkerFactory|LoopInterface $worker,
         ExceptionInterceptorInterface $exceptionInterceptor,
         PipelineProvider $interceptorProvider,
+        LoggerInterface $logger,
     ): self {
         return new self(
             $worker,
@@ -75,6 +78,7 @@ final class ServiceContainer
             $worker->getDataConverter(),
             $exceptionInterceptor,
             $interceptorProvider,
+            $logger,
         );
     }
 }

--- a/src/Internal/Workflow/Logger.php
+++ b/src/Internal/Workflow/Logger.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Internal\Workflow;
+
+use Psr\Log\LoggerInterface;
+use Temporal\Workflow;
+
+/**
+ * A logger decorator for using in Workflows.
+ *
+ * @internal
+ */
+class Logger implements LoggerInterface
+{
+    public function __construct(
+        private readonly LoggerInterface $logger,
+        private readonly bool $loggingInReplay,
+        private readonly string $taskQueue,
+    ) {}
+
+    public function log($level, \Stringable|string $message, array $context = []): void
+    {
+        $this->shouldBeSkipped() or $this->logger->log($level, $message, $this->context($context));
+    }
+
+    public function emergency(string|\Stringable $message, array $context = []): void
+    {
+        $this->shouldBeSkipped() or $this->logger->emergency($message, $this->context($context));
+    }
+
+    public function alert(string|\Stringable $message, array $context = []): void
+    {
+        $this->shouldBeSkipped() or $this->logger->alert($message, $this->context($context));
+    }
+
+    public function critical(string|\Stringable $message, array $context = []): void
+    {
+        $this->shouldBeSkipped() or $this->logger->critical($message, $this->context($context));
+    }
+
+    public function error(string|\Stringable $message, array $context = []): void
+    {
+        $this->shouldBeSkipped() or $this->logger->error($message, $this->context($context));
+    }
+
+    public function warning(\Stringable|string $message, array $context = []): void
+    {
+        $this->shouldBeSkipped() or $this->logger->warning($message, $this->context($context));
+    }
+
+    public function notice(\Stringable|string $message, array $context = []): void
+    {
+        $this->shouldBeSkipped() or $this->logger->notice($message, $this->context($context));
+    }
+
+    public function info(\Stringable|string $message, array $context = []): void
+    {
+        $this->shouldBeSkipped() or $this->logger->info($message, $this->context($context));
+    }
+
+    public function debug(\Stringable|string $message, array $context = []): void
+    {
+        $this->shouldBeSkipped() or $this->logger->debug($message, $this->context($context));
+    }
+
+    private function context(array $source): array
+    {
+        return ['task_queue' => $this->taskQueue] + $source;
+    }
+
+    private function shouldBeSkipped(): bool
+    {
+        return Workflow::isReplaying() and !$this->loggingInReplay;
+    }
+}

--- a/src/Internal/Workflow/Process/Process.php
+++ b/src/Internal/Workflow/Process/Process.php
@@ -281,7 +281,9 @@ class Process extends Scope implements ProcessInterface
             $warnUpdates[] = $tuple;
         }
 
-        $workflowName = $this->getContext()->getInfo()->type->name;
+        $info = $this->getContext()->getInfo();
+        $workflowName = $info->type->name;
+        $logger = $this->services->logger;
 
         // Warn messages
         if ($warnUpdates !== []) {
@@ -297,7 +299,11 @@ class Process extends Scope implements ProcessInterface
                 'The following updates were unfinished (and warnings were not disabled for their handler): ' .
                 \implode(', ', \array_map(static fn(array $v): string => "`$v[name]` id:$v[id]", $warnUpdates));
 
-            \error_log($message);
+            $logger->warning($message, [
+                'workflow_type' => $workflowName,
+                'workflow_id' => $info->execution->getID(),
+                'run_id' => $info->execution->getRunID(),
+            ]);
         }
 
         if ($warnSignals !== []) {
@@ -312,7 +318,11 @@ class Process extends Scope implements ProcessInterface
                 'The following signals were unfinished (and warnings were not disabled for their handler): ' .
                 \implode(', ', \array_map(static fn(array $v): string => "`$v[name]` x$v[count]", $warnSignals));
 
-            \error_log($message);
+            $logger->warning($message, [
+                'workflow_type' => $workflowName,
+                'workflow_id' => $info->execution->getID(),
+                'run_id' => $info->execution->getRunID(),
+            ]);
         }
     }
 }

--- a/src/Internal/Workflow/WorkflowContext.php
+++ b/src/Internal/Workflow/WorkflowContext.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Temporal\Internal\Workflow;
 
+use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\UuidInterface;
 use React\Promise\Deferred;
 use React\Promise\PromiseInterface;
@@ -634,6 +635,11 @@ class WorkflowContext implements WorkflowContextInterface, HeaderCarrier, Destro
     public function uuid7(?\DateTimeInterface $dateTime = null): PromiseInterface
     {
         return $this->sideEffect(static fn(): UuidInterface => \Ramsey\Uuid\Uuid::uuid7($dateTime));
+    }
+
+    public function getLogger(): LoggerInterface
+    {
+        return $this->services->logger;
     }
 
     /**

--- a/src/Worker/FeatureFlags.php
+++ b/src/Worker/FeatureFlags.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Temporal\Worker;
 
+use Temporal\Workflow;
+
 /**
  * Feature flags help to smoothly introduce behavior changes that may affect existing workflows.
  * Also, there may be experimental features that are in the testing phase.
@@ -24,7 +26,7 @@ final class FeatureFlags
 
     /**
      * Warn about running Signal and Update handlers on Workflow finish.
-     * It uses `error_log()` function to output a warning message.
+     * It uses {@see Workflow::getLogger()} to output a warning message.
      *
      * @since SDK 2.11.0
      */

--- a/src/Worker/Logger/StderrLogger.php
+++ b/src/Worker/Logger/StderrLogger.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Worker\Logger;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\LoggerTrait;
+
+final class StderrLogger implements LoggerInterface
+{
+    use LoggerTrait;
+
+    public function log($level, \Stringable|string $message, array $context = []): void
+    {
+        \fwrite(\STDERR, \sprintf(
+            "[%s] %s: %s%s\n",
+            (new \DateTimeImmutable())->format('Y-m-d H:i:s'),
+            $level,
+            $message,
+            $context === [] ? '' : ' ' . (string) \json_encode($context, \JSON_INVALID_UTF8_IGNORE),
+        ));
+    }
+}

--- a/src/Worker/WorkerFactoryInterface.php
+++ b/src/Worker/WorkerFactoryInterface.php
@@ -11,6 +11,10 @@ declare(strict_types=1);
 
 namespace Temporal\Worker;
 
+use Psr\Log\LoggerInterface;
+use Temporal\Exception\ExceptionInterceptorInterface;
+use Temporal\Interceptor\PipelineProvider;
+
 /**
  * The interface is responsible for providing an interface for registering all dependencies and creating a global
  * event loop.
@@ -36,6 +40,9 @@ interface WorkerFactoryInterface
     public function newWorker(
         string $taskQueue = self::DEFAULT_TASK_QUEUE,
         ?WorkerOptions $options = null,
+        ?ExceptionInterceptorInterface $exceptionInterceptor = null,
+        ?PipelineProvider $interceptorProvider = null,
+        ?LoggerInterface $logger = null,
     ): WorkerInterface;
 
     /**

--- a/src/Worker/WorkerOptions.php
+++ b/src/Worker/WorkerOptions.php
@@ -18,6 +18,7 @@ use Temporal\Internal\Marshaller\Type\DateIntervalType;
 use Temporal\Internal\Marshaller\Type\EnumValueType;
 use Temporal\Internal\Marshaller\Type\NullableType;
 use Temporal\Internal\Support\DateInterval;
+use Temporal\Workflow;
 
 /**
  * @psalm-import-type DateIntervalValue from DateInterval
@@ -139,8 +140,9 @@ class WorkerOptions
     /**
      * Optional: Enable logging in replay.
      *
-     * In the workflow code you can use workflow.GetLogger(ctx) to write logs. By default, the logger will skip log
-     * entry during replay mode so you won't see duplicate logs. This option will enable the logging in replay mode.
+     * In the workflow code you can use {@see Workflow::getLogger()} to write logs.
+     * By default, the logger will skip log entry during replay mode so you won't see duplicate logs.
+     * This option will enable the logging in replay mode.
      * This is only useful for debugging purpose.
      */
     #[Marshal(name: 'EnableLoggingInReplay')]

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Temporal;
 
+use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\UuidInterface;
 use React\Promise\PromiseInterface;
 use Temporal\Activity\ActivityOptions;
@@ -1126,5 +1127,21 @@ final class Workflow extends Facade
                 $mutex->unlock();
             }
         });
+    }
+
+    /**
+     * Get logger to use inside the Workflow.
+     *
+     * Logs in replay mode are omitted unless {@see WorkerOptions::$enableLoggingInReplay} is set to true.
+     *
+     * ```php
+     *  Workflow::getLogger()->notice('Workflow started');
+     * ```
+     *
+     * @since SDK 2.14.0
+     */
+    public static function getLogger(): LoggerInterface
+    {
+        return self::getCurrentContext()->getLogger();
     }
 }

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -371,7 +371,7 @@ final class Workflow extends Facade
      *
      * ```php
      *  Workflow::registerDynamicSignal(function (string $name, ValuesInterface $arguments): void {
-     *      \error_log(\sprintf(
+     *      Workflow::getLogger()->info(\sprintf(
      *          'Executed signal `%s` with %d arguments',
      *          $name,
      *          $arguments->count(),

--- a/src/Workflow/WorkflowContextInterface.php
+++ b/src/Workflow/WorkflowContextInterface.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Temporal\Workflow;
 
+use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\UuidInterface;
 use React\Promise\PromiseInterface;
 use Temporal\Activity\ActivityOptions;
@@ -430,4 +431,11 @@ interface WorkflowContextInterface extends EnvironmentInterface
      * @return PromiseInterface<UuidInterface>
      */
     public function uuid7(?\DateTimeInterface $dateTime = null): PromiseInterface;
+
+    /**
+     * Get logger to use inside the Workflow.
+     *
+     * Logs in replay mode are omitted unless {@see WorkerOptions::$enableLoggingInReplay} is set to true.
+     */
+    public function getLogger(): LoggerInterface;
 }

--- a/tests/Acceptance/App/Logger/ClientLogger.php
+++ b/tests/Acceptance/App/Logger/ClientLogger.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Acceptance\App\Logger;
+
+/**
+ * Logger client for reading and analyzing log entries in acceptance tests.
+ *
+ * Provides methods to read, filter, and analyze log records produced by the {@see FileLogger}
+ * during test execution.
+ */
+final class ClientLogger
+{
+    /** @var non-empty-string Path to the log file */
+    private readonly string $logFile;
+
+    /**
+     * @param non-empty-string $dir Directory where logs are stored
+     * @param non-empty-string $taskQueue TaskQueue name used as log file identifier
+     */
+    public function __construct(
+        private readonly string $dir,
+        private readonly string $taskQueue,
+    ) {
+        $this->logFile = LoggerFactory::getLogFilename($this->dir, $this->taskQueue);
+    }
+
+    /**
+     * Get the log file path.
+     *
+     * @return non-empty-string Absolute path to the log file
+     */
+    public function getLogFile(): string
+    {
+        return $this->logFile;
+    }
+
+    /**
+     * Retrieve all log records from the log file.
+     *
+     * @return list<LogRecord> All log records in chronological order
+     */
+    public function getRecords(): array
+    {
+        return \iterator_to_array($this->readAll(), false);
+    }
+
+    /**
+     * Find log records by matching message content.
+     *
+     * @param string $messagePattern Regular expression to match against log messages
+     * @return list<LogRecord> Matching log records
+     */
+    public function findByMessage(string $messagePattern): array
+    {
+        $result = [];
+        foreach ($this->readAll() as $record) {
+            if (\preg_match($messagePattern, $record->message)) {
+                $result[] = $record;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Find log records by specific log level.
+     *
+     * @param string $level Log level to filter by (debug, info, warning, error, etc.)
+     * @return list<LogRecord> Matching log records
+     */
+    public function findByLevel(string $level): array
+    {
+        $result = [];
+        foreach ($this->readAll() as $record) {
+            if ($record->level === $level) {
+                $result[] = $record;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Find log records by message content and context data.
+     *
+     * @param string $messagePattern Regular expression to match against log messages
+     * @param array<string, mixed> $contextKeys Keys that must exist in the context
+     * @return list<LogRecord> Matching log records
+     */
+    public function findByMessageAndContext(string $messagePattern, array $contextKeys = []): array
+    {
+        $result = [];
+        foreach ($this->readAll() as $record) {
+            if (!\preg_match($messagePattern, $record->message)) {
+                continue;
+            }
+
+            $hasAllKeys = true;
+            foreach ($contextKeys as $key) {
+                if (!isset($record->context[$key])) {
+                    $hasAllKeys = false;
+                    break;
+                }
+            }
+
+            if ($hasAllKeys) {
+                $result[] = $record;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Check if a specific log message exists.
+     *
+     * @param string $messagePattern Regular expression to match against log messages
+     * @return bool True if at least one matching message is found
+     */
+    public function hasMessage(string $messagePattern): bool
+    {
+        return \count($this->findByMessage($messagePattern)) > 0;
+    }
+
+    /**
+     * Clear all logs for current task queue.
+     *
+     * Removes the log file if it exists.
+     */
+    public function clear(): void
+    {
+        if (\is_file($this->logFile)) {
+            \unlink($this->logFile);
+        }
+    }
+
+    /**
+     * Read all log records from the log file.
+     *
+     * @return \Traversable<LogRecord> Generator yielding LogRecord objects
+     */
+    private function readAll(): \Traversable
+    {
+        if (!\is_file($this->logFile)) {
+            return [];
+        }
+
+        $lines = \file($this->logFile);
+        if ($lines === false) {
+            return [];
+        }
+
+        foreach ($lines as $line) {
+            $line = \trim($line);
+            if ($line === '') {
+                continue;
+            }
+
+            yield \unserialize($line, ['allowed_classes' => [LogRecord::class]]);
+        }
+    }
+}

--- a/tests/Acceptance/App/Logger/FileLogger.php
+++ b/tests/Acceptance/App/Logger/FileLogger.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Acceptance\App\Logger;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\LoggerTrait;
+
+/**
+ * File-based logger implementation for testing purposes.
+ *
+ * Stores serialized log records in a file for later analysis. Each log entry is stored as a serialized LogRecord
+ * on a separate line in the log file.
+ */
+final class FileLogger implements LoggerInterface
+{
+    use LoggerTrait;
+
+    /** @var non-empty-string Path to the log file */
+    private readonly string $logFile;
+
+    /**
+     * @param non-empty-string $dir Directory where logs will be stored
+     * @param non-empty-string $taskQueue Task queue name used to identify the log file
+     */
+    public function __construct(
+        private readonly string $dir,
+        private readonly string $taskQueue = 'default',
+    ) {
+        // Create directory if it doesn't exist
+        if (!\is_dir($dir)) {
+            \mkdir($dir, 0777, true);
+        }
+
+        $this->logFile = LoggerFactory::getLogFilename($this->dir, $this->taskQueue);
+    }
+
+    /**
+     * Get the absolute path to the log file.
+     *
+     * @return non-empty-string
+     */
+    public function getLogFile(): string
+    {
+        return $this->logFile;
+    }
+
+    /**
+     * Records a log entry to the log file.
+     *
+     * Each log entry is serialized as a LogRecord object and appended to the log file with a newline separator.
+     *
+     * @param non-empty-string $level Log level
+     * @param \Stringable|string $message Log message
+     * @param array<string, mixed> $context Additional contextual data
+     */
+    public function log($level, \Stringable|string $message, array $context = []): void
+    {
+        $record = new LogRecord(
+            timestamp: \time(),
+            level: (string) $level,
+            message: (string) $message,
+            context: $context,
+        );
+
+        \file_put_contents(
+            $this->logFile,
+            \serialize($record) . \PHP_EOL,
+            \FILE_APPEND | \LOCK_EX,
+        );
+    }
+}

--- a/tests/Acceptance/App/Logger/LogRecord.php
+++ b/tests/Acceptance/App/Logger/LogRecord.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Acceptance\App\Logger;
+
+/**
+ * Represents a log entry with timestamp, level, message, and context.
+ *
+ * This immutable class serves as a data container for log entries stored in the test logs.
+ */
+final class LogRecord
+{
+    /**
+     * @param int<0, max> $timestamp Unix timestamp when the log was created
+     * @param non-empty-string $level Log level (debug, info, warning, error, etc.)
+     * @param string $message Log message content
+     * @param array<non-empty-string, mixed> $context Additional contextual data for the log entry
+     */
+    public function __construct(
+        public readonly int $timestamp,
+        public readonly string $level,
+        public readonly string $message,
+        public readonly array $context = [],
+    ) {}
+}

--- a/tests/Acceptance/App/Logger/LoggerFactory.php
+++ b/tests/Acceptance/App/Logger/LoggerFactory.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Acceptance\App\Logger;
+
+/**
+ * Factory for creating logger instances used in acceptance tests.
+ *
+ * Provides methods to create both server-side and client-side loggers with appropriate
+ * configuration for test environments.
+ */
+final class LoggerFactory
+{
+    /** @var non-empty-string Default relative path for test logs */
+    private const DEFAULT_LOG_DIR = 'runtime/tests/logs';
+
+    /**
+     * Create a server-side file logger.
+     *
+     * @param non-empty-string $taskQueue Task queue name used to identify the log file
+     * @param non-empty-string|null $baseDir Optional base directory, defaults to project root
+     * @return FileLogger Configured file logger instance
+     */
+    public static function createServerLogger(
+        string $taskQueue,
+        ?string $baseDir = null,
+    ): FileLogger {
+        $logDir = self::getLogDirectory($baseDir);
+        return new FileLogger($logDir, $taskQueue);
+    }
+
+    /**
+     * Create a client-side logger for assertions.
+     *
+     * The client logger provides methods for reading and analyzing log entries
+     * created by the server-side logger.
+     *
+     * @param non-empty-string $taskQueue Task queue name used to identify the log file
+     * @param non-empty-string|null $baseDir Optional base directory, defaults to project root
+     * @return ClientLogger Configured client logger instance
+     */
+    public static function createClientLogger(
+        string $taskQueue,
+        ?string $baseDir = null,
+    ): ClientLogger {
+        $logDir = self::getLogDirectory($baseDir);
+        return new ClientLogger($logDir, $taskQueue);
+    }
+
+    /**
+     * Generate the log filename for a specific task queue.
+     *
+     * Uses sha1 hash of task queue name to handle special characters.
+     *
+     * @param non-empty-string $dir Directory path
+     * @param non-empty-string $taskQueue Task queue name
+     * @return non-empty-string Full path to the log file
+     */
+    public static function getLogFilename(
+        string $dir,
+        string $taskQueue,
+    ): string {
+        $filename = \sha1($taskQueue) . '.log';
+
+        return \preg_replace(
+            '#/{2,}#',
+            '/',
+            \str_replace('\\', '/', "{$dir}/{$filename}"),
+        );
+    }
+
+    /**
+     * Get the absolute path to the log directory.
+     *
+     * Creates the directory if it doesn't exist.
+     *
+     * @param non-empty-string|null $baseDir Optional base directory, defaults to project root
+     * @return non-empty-string Absolute path to the log directory
+     */
+    private static function getLogDirectory(?string $baseDir = null): string
+    {
+        $baseDir ??= \dirname(__DIR__, 4); // Go up to project root
+        $logDir = $baseDir . '/' . self::DEFAULT_LOG_DIR;
+
+        // Ensure directory exists
+        if (!\is_dir($logDir)) {
+            \mkdir($logDir, 0777, true);
+        }
+
+        return $logDir;
+    }
+}

--- a/tests/Acceptance/App/Runtime/Feature.php
+++ b/tests/Acceptance/App/Runtime/Feature.php
@@ -20,8 +20,10 @@ final class Feature
     /** @var list<class-string<PayloadConverterInterface>> Lazy callables */
     public array $converters = [];
 
+    /**
+     * @param non-empty-string $taskQueue
+     */
     public function __construct(
         public readonly string $taskQueue,
-    ) {
-    }
+    ) {}
 }

--- a/tests/Acceptance/Extra/Workflow/LoggerTest.php
+++ b/tests/Acceptance/Extra/Workflow/LoggerTest.php
@@ -1,0 +1,258 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Acceptance\Extra\Workflow\Logger;
+
+use PHPUnit\Framework\Attributes\Test;
+use Temporal\Client\WorkflowStubInterface;
+use Temporal\Tests\Acceptance\App\Attribute\Stub;
+use Temporal\Tests\Acceptance\App\Logger\ClientLogger;
+use Temporal\Tests\Acceptance\App\Runtime\Feature;
+use Temporal\Tests\Acceptance\App\TestCase;
+use Temporal\Workflow;
+use Temporal\Workflow\WorkflowInterface;
+use Temporal\Workflow\WorkflowMethod;
+
+class LoggerTest extends TestCase
+{
+    #[Test]
+    public function loggerBasicLogging(
+        #[Stub('Logger_Test_Workflow')] WorkflowStubInterface $stub,
+        ClientLogger $logger,
+    ): void {
+        // Send signal to complete the workflow
+        $stub->signal('exit');
+
+        // Execute workflow that logs a basic message
+        $result = $stub->getResult();
+
+        $this->assertTrue($result, 'Workflow completed successfully');
+
+        // Check logs
+        $records = $logger->getRecords();
+        $this->assertCount(2, $records); // Start and completion logs
+
+        $this->assertSame('info', $records[0]->level);
+        $this->assertSame('Workflow execution started', $records[0]->message);
+
+        $this->assertSame('info', $records[1]->level);
+        $this->assertSame('Workflow completed', $records[1]->message);
+    }
+
+    #[Test]
+    public function loggerWithContext(
+        #[Stub('Logger_Test_Workflow')] WorkflowStubInterface $stub,
+        ClientLogger $logger,
+    ): void {
+        // Execute query to log with context
+        $result = $stub->query('logWithContext')->getValue(0);
+
+        $this->assertSame('query executed', $result);
+
+        // Check logs - not checking count as query might be called multiple times
+        $records = $logger->getRecords();
+        $hasExpectedLog = false;
+
+        foreach ($records as $record) {
+            if ($record->level === 'debug' && $record->message === 'Log message with context from query') {
+                $hasExpectedLog = true;
+                $this->assertArrayHasKey('key1', $record->context);
+                $this->assertArrayHasKey('key2', $record->context);
+                $this->assertSame('value1', $record->context['key1']);
+                $this->assertSame(42, $record->context['key2']);
+                break;
+            }
+        }
+
+        $this->assertTrue($hasExpectedLog, 'Expected debug log with context not found');
+
+        // Complete the workflow
+        $stub->signal('exit');
+        $stub->getResult();
+    }
+
+    #[Test]
+    public function loggerMultipleLevels(
+        #[Stub('Logger_Test_Workflow')] WorkflowStubInterface $stub,
+        ClientLogger $logger,
+        Feature $feature,
+    ): void {
+        // Execute update to log at multiple levels
+        $updateResult = $stub->update('logMultipleLevels')->getValue(0);
+
+        $this->assertSame('update completed', $updateResult);
+
+        // Complete the workflow
+        $stub->signal('exit');
+        $stub->getResult();
+
+        // Check logs
+        $records = $logger->getRecords();
+
+        // Extract update logs
+        $updateLogs = [];
+        foreach ($records as $record) {
+            if (\str_contains($record->message, 'from update')) {
+                $updateLogs[] = $record;
+            }
+        }
+
+        $this->assertCount(5, $updateLogs, 'Expected 5 update logs');
+
+        $expectedLevels = ['debug', 'info', 'notice', 'warning', 'error'];
+        $expectedMessages = [
+            'Debug message from update',
+            'Info message from update',
+            'Notice message from update',
+            'Warning message from update',
+            'Error message from update',
+        ];
+
+        foreach ($updateLogs as $index => $record) {
+            $this->assertSame($expectedLevels[$index], $record->level);
+            $this->assertSame($expectedMessages[$index], $record->message);
+            $this->assertSame($feature->taskQueue, $record->context['task_queue']);
+        }
+    }
+
+    #[Test]
+    public function loggerDuringSignalProcessing(
+        #[Stub('Logger_Test_Workflow')] WorkflowStubInterface $stub,
+        ClientLogger $logger,
+    ): void {
+        // Send signal to trigger logging
+        $stub->signal('logFromSignal', 'Signal triggered log');
+
+        // Complete the workflow
+        $stub->signal('exit');
+        $stub->getResult();
+
+        // Check logs
+        $records = $logger->getRecords();
+
+        // Verify signal log exists
+        $hasSignalLog = false;
+        foreach ($records as $record) {
+            if ($record->level === 'warning' && $record->message === 'Signal triggered log') {
+                $hasSignalLog = true;
+                break;
+            }
+        }
+
+        $this->assertTrue($hasSignalLog, 'Expected signal log not found');
+    }
+
+    #[Test]
+    public function loggingInAllHandlers(
+        #[Stub('Logger_Test_Workflow')] WorkflowStubInterface $stub,
+        ClientLogger $logger,
+    ): void {
+        // Send signal
+        $stub->signal('logFromSignal', 'Signal log message');
+
+        // Execute query
+        $queryResult = $stub->query('logWithContext')->getValue(0);
+        $this->assertSame('query executed', $queryResult);
+
+        // Execute update
+        $updateResult = $stub->update('logMultipleLevels')->getValue(0);
+        $this->assertSame('update completed', $updateResult);
+
+        // Close workflow
+        $stub->signal('exit');
+        $result = $stub->getResult();
+
+        $this->assertTrue($result, 'Workflow completed successfully');
+
+        // Check logs
+        $records = $logger->getRecords();
+
+        // Verify the signal log exists
+        $hasSignalLog = false;
+        foreach ($records as $record) {
+            if ($record->level === 'warning' && $record->message === 'Signal log message') {
+                $hasSignalLog = true;
+                break;
+            }
+        }
+        $this->assertTrue($hasSignalLog, 'Expected signal log not found');
+
+        // Verify update logs exist
+        $updateLogCount = 0;
+        foreach ($records as $record) {
+            if (\strpos($record->message, 'from update') !== false) {
+                $updateLogCount++;
+            }
+        }
+        $this->assertSame(5, $updateLogCount, 'Expected 5 update logs');
+
+        // Verify the exit log exists
+        $hasExitLog = false;
+        foreach ($records as $record) {
+            if ($record->level === 'info' && $record->message === 'Workflow completed') {
+                $hasExitLog = true;
+                break;
+            }
+        }
+        $this->assertTrue($hasExitLog, 'Expected workflow completion log not found');
+    }
+}
+
+#[WorkflowInterface]
+class TestWorkflow
+{
+    private bool $exit = false;
+
+    #[WorkflowMethod(name: "Logger_Test_Workflow")]
+    public function handle()
+    {
+        $logger = Workflow::getLogger();
+        $logger->info('Workflow execution started');
+
+        yield Workflow::await(fn(): bool => $this->exit);
+
+        $logger->info('Workflow completed');
+
+        return true;
+    }
+
+    #[Workflow\SignalMethod(name: 'logFromSignal')]
+    public function logFromSignal(string $message): void
+    {
+        $logger = Workflow::getLogger();
+        $logger->warning($message);
+    }
+
+    #[Workflow\SignalMethod(name: 'exit')]
+    public function exit(): void
+    {
+        $this->exit = true;
+    }
+
+    #[Workflow\QueryMethod(name: 'logWithContext')]
+    public function logWithContext()
+    {
+        $logger = Workflow::getLogger();
+        $logger->debug('Log message with context from query', [
+            'key1' => 'value1',
+            'key2' => 42,
+        ]);
+
+        return 'query executed';
+    }
+
+    #[Workflow\UpdateMethod(name: 'logMultipleLevels')]
+    public function logMultipleLevels()
+    {
+        $logger = Workflow::getLogger();
+
+        $logger->debug('Debug message from update');
+        $logger->info('Info message from update');
+        $logger->notice('Notice message from update');
+        $logger->warning('Warning message from update');
+        $logger->error('Error message from update');
+
+        return 'update completed';
+    }
+}

--- a/tests/Acceptance/worker.php
+++ b/tests/Acceptance/worker.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Temporal\Tests\Acceptance\App\Input\Command;
+use Temporal\Tests\Acceptance\App\Logger\LoggerFactory;
 use Temporal\Tests\Acceptance\App\Runtime\State;
 use Temporal\Tests\Acceptance\App\RuntimeBuilder;
 use Psr\Container\ContainerInterface;
@@ -64,7 +65,8 @@ try {
     $getWorker = static function (string $taskQueue) use (&$workers, $factory): WorkerInterface {
         return $workers[$taskQueue] ??= $factory->newWorker(
             $taskQueue,
-            WorkerOptions::new()->withMaxConcurrentActivityExecutionSize(10)
+            WorkerOptions::new()->withMaxConcurrentActivityExecutionSize(10),
+            logger: LoggerFactory::createServerLogger($taskQueue),
         );
     };
 

--- a/tests/Unit/Internal/Workflow/LoggerTestCase.php
+++ b/tests/Unit/Internal/Workflow/LoggerTestCase.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\Internal\Workflow;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use Temporal\Internal\Workflow\Logger;
+use Temporal\Workflow;
+use Temporal\Workflow\ScopedContextInterface;
+
+#[CoversClass(Logger::class)]
+final class LoggerTestCase extends TestCase
+{
+    private LoggerInterface&MockObject $decoratedLogger;
+    private Logger $logger;
+    private ScopedContextInterface&MockObject $scopedContext;
+
+    public function testAddsTaskQueueToContext(): void
+    {
+        $this->setReplayState(false);
+
+        $taskQueue = 'test-queue';
+        $this->logger = new Logger($this->decoratedLogger, true, $taskQueue);
+
+        $this->decoratedLogger->expects($this->once())
+            ->method('log')
+            ->with(
+                LogLevel::INFO,
+                'Test message',
+                ['task_queue' => $taskQueue, 'test' => 'value'],
+            );
+
+        $this->logger->log(LogLevel::INFO, 'Test message', ['test' => 'value']);
+    }
+
+    public function testSkipsLoggingDuringReplayWhenNotEnabled(): void
+    {
+        $this->setReplayState(true);
+
+        $this->logger = new Logger($this->decoratedLogger, false, 'test-queue');
+
+        $this->decoratedLogger->expects($this->never())->method('log');
+
+        $this->logger->log(LogLevel::INFO, 'This message should be skipped');
+    }
+
+    public function testLogsInReplayWhenEnabled(): void
+    {
+        $this->setReplayState(true);
+
+        $this->logger = new Logger($this->decoratedLogger, true, 'test-queue');
+
+        $this->decoratedLogger->expects($this->once())
+            ->method('log')
+            ->with(LogLevel::INFO, 'This message should be logged');
+
+        $this->logger->log(LogLevel::INFO, 'This message should be logged');
+    }
+
+    public function testNotInReplayAlwaysLogs(): void
+    {
+        $this->setReplayState(false);
+
+        // loggingInReplay is false, but since we're not replaying, it should log anyway
+        $this->logger = new Logger($this->decoratedLogger, false, 'test-queue');
+
+        $this->decoratedLogger->expects($this->once())
+            ->method('log')
+            ->with(LogLevel::INFO, 'This message should be logged');
+
+        $this->logger->log(LogLevel::INFO, 'This message should be logged');
+    }
+
+    public function testLogLevelMethods(): void
+    {
+        $this->setReplayState(false);
+        $this->logger = new Logger($this->decoratedLogger, true, 'test-queue');
+
+        $logLevels = [
+            'emergency', 'alert', 'critical', 'error',
+            'warning', 'notice', 'info', 'debug',
+        ];
+
+        foreach ($logLevels as $level) {
+            $this->decoratedLogger->expects($this->once())
+                ->method($level)
+                ->with("Test $level message", ['task_queue' => 'test-queue']);
+
+            $this->logger->$level("Test $level message");
+        }
+    }
+
+    public function testAcceptsStringableObject(): void
+    {
+        $this->setReplayState(false);
+        $this->logger = new Logger($this->decoratedLogger, true, 'test-queue');
+
+        $stringable = new class implements \Stringable {
+            public function __toString(): string
+            {
+                return 'Stringable message';
+            }
+        };
+
+        $this->decoratedLogger->expects($this->once())
+            ->method('info')
+            ->with($stringable, ['task_queue' => 'test-queue']);
+
+        $this->logger->info($stringable);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->decoratedLogger = $this->createMock(LoggerInterface::class);
+        $this->scopedContext = $this->createMock(ScopedContextInterface::class);
+        Workflow::setCurrentContext($this->scopedContext);
+    }
+
+    protected function tearDown(): void
+    {
+        Workflow::setCurrentContext(null);
+        parent::tearDown();
+    }
+
+    /**
+     * Helper method to set the replay state in the workflow context
+     */
+    private function setReplayState(bool $isReplaying): void
+    {
+        $this->scopedContext->method('isReplaying')
+            ->willReturn($isReplaying);
+
+        // Set the mocked context as the current Workflow context
+        $reflectionClass = new \ReflectionClass(Workflow::class);
+        $method = $reflectionClass->getMethod('setCurrentContext');
+        $method->invoke(null, $this->scopedContext);
+    }
+}

--- a/tests/Unit/Router/InvokeActivityTestCase.php
+++ b/tests/Unit/Router/InvokeActivityTestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Unit\Router;
 
+use Psr\Log\NullLogger;
 use React\Promise\Deferred;
 use Spiral\Attributes\AnnotationReader;
 use Spiral\Attributes\AttributeReader;
@@ -21,6 +22,7 @@ use Temporal\Internal\Queue\QueueInterface;
 use Temporal\Internal\ServiceContainer;
 use Temporal\Internal\Transport\ClientInterface;
 use Temporal\Internal\Transport\Router\InvokeActivity;
+use Temporal\Internal\Workflow\Logger;
 use Temporal\Tests\Unit\Framework\Requests\InvokeActivity as Request;
 use Temporal\Tests\Unit\AbstractUnit;
 use Temporal\Worker\Environment\EnvironmentInterface;
@@ -91,6 +93,7 @@ final class InvokeActivityTestCase extends AbstractUnit
             $dataConverter,
             $this->createMock(ExceptionInterceptorInterface::class),
             new SimplePipelineProvider(),
+            new NullLogger(),
         );
         $activityReader = new ActivityReader(new SelectiveReader([new AnnotationReader(), new AttributeReader()]));
         foreach ($activityReader->fromClass(DummyActivity::class) as $proto) {


### PR DESCRIPTION
## What was changed

Exposed Logger in Workflow with StderrLogger by default

## Checklist
<!--- add/delete as needed --->

1. Closes #533 
2. How was this tested: added tests
3. Any docs updates needed?

## Documentation

Logging is a critical component for monitoring and troubleshooting your Temporal applications. The PHP SDK provides a dedicated logger for use within Workflows that respects replay semantics and adds contextual information automatically.

### Using the Workflow Logger

To get a PSR-3 compatible logger in your Workflow code, use the `Workflow::getLogger()` method:

```php
use Temporal\Workflow;

#[Workflow\WorkflowInterface]
class MyWorkflow
{
    #[Workflow\WorkflowMethod]
    public function execute(string $param): \Generator
    {
        Workflow::getLogger()->info('Workflow started', ['parameter' => $param]);

        // Your workflow implementation

        Workflow::getLogger()->info('Workflow completed');
        return 'Done';
    }
}
```

### Logging Levels

The logger follows the standard PSR-3 logging levels:

| Level     | Method        | Use                               |
|-----------|---------------|-----------------------------------|
| Emergency | `emergency()` | System is unusable                |
| Alert     | `alert()`     | Action must be taken immediately  |
| Critical  | `critical()`  | Critical conditions               |
| Error     | `error()`     | Error conditions                  |
| Warning   | `warning()`   | Warning conditions                |
| Notice    | `notice()`    | Normal but significant conditions |
| Info      | `info()`      | Informational messages            |
| Debug     | `debug()`     | Detailed debug information        |

### Replay Mode Behavior

An important feature of the Workflow logger is its replay-aware behavior. By default, logs are only emitted during the initial Workflow execution and are suppressed during replay to prevent duplicate log entries.

If you want to enable logging during replay (for debugging purposes), you can configure this with the `enableLoggingInReplay` option in your worker configuration:

```php
$factory = WorkerFactory::create();
$worker = $factory->newWorker('your-task-queue', WorkerOptions::new()
    ->withEnableLoggingInReplay(true)
);
```

### Automatic Context Enrichment

The Workflow logger automatically enriches log entries with the current task queue information. Every log message will include a `task_queue` key in its context, making it easier to filter and correlate logs in multi-worker or multi-task-queue environments.

For example, if a log statement is:

```php
$logger->info('Processing order', ['order_id' => 123]);
```

The actual logged context will be:
```
{ "task_queue": "your-task-queue", "order_id": 123 }
```

This happens automatically without any additional configuration.

### Default Logger

By default, the PHP SDK uses a `StderrLogger` that outputs log messages to the standard error stream.
These messages are automatically captured by RoadRunner and incorporated into its logging system with the INFO level, ensuring proper log collection in both development and production environments.
For more details on RoadRunner's logging capabilities, see the [RoadRunner Logger documentation](https://docs.roadrunner.dev/docs/logging-and-observability/logger).

### Using a Custom Logger

You can configure your Temporal worker to use a custom PSR-3 compatible logger implementation:

```php
$myLogger = new MyLogger();

$workerFactory = WorkerFactory::create(converter: $converter);
$worker = $workerFactory->newWorker(
    taskQueue: 'my-task-queue',
    logger: $myLogger,
);
```

Your custom logger will be used throughout the Temporal SDK, including for Workflow logging when accessed through `Workflow::getLogger()`.
