### PR TITLE
Fix memory leak on upsert SA/MEMO requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ Thumbs.db
 rr
 temporal-test-server
 .ai
+.context

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -966,19 +966,6 @@
     </PossiblyInvalidArgument>
   </file>
   <file src="src/Internal/Transport/Client.php">
-    <InternalClass>
-      <code><![CDATA[self::ERROR_REQUEST_ID_DUPLICATION]]></code>
-      <code><![CDATA[self::ERROR_REQUEST_NOT_FOUND]]></code>
-    </InternalClass>
-    <InternalMethod>
-      <code><![CDATA[fetch]]></code>
-      <code><![CDATA[get]]></code>
-      <code><![CDATA[reject]]></code>
-      <code><![CDATA[request]]></code>
-    </InternalMethod>
-    <InternalProperty>
-      <code><![CDATA[$this->requests]]></code>
-    </InternalProperty>
     <PossiblyInvalidArgument>
       <code><![CDATA[$command->getID()]]></code>
       <code><![CDATA[$command->getID()]]></code>

--- a/src/Internal/Transport/Client.php
+++ b/src/Internal/Transport/Client.php
@@ -25,7 +25,7 @@ use Temporal\Workflow\WorkflowContextInterface;
 
 /**
  * @internal Client is an internal library class, please do not use it in your code.
- * @psalm-internal Temporal\Client\Internal\Transport
+ * @psalm-internal Temporal\Internal\Transport
  */
 final class Client implements ClientInterface
 {
@@ -84,12 +84,12 @@ final class Client implements ClientInterface
 
         $id = $request->getID();
 
-        if (isset($this->requests[$id])) {
-            throw new \OutOfBoundsException(\sprintf(self::ERROR_REQUEST_ID_DUPLICATION, $id));
-        }
+        \array_key_exists($id, $this->requests) and throw new \OutOfBoundsException(
+            \sprintf(self::ERROR_REQUEST_ID_DUPLICATION, $id),
+        );
 
         $deferred = new Deferred();
-        $this->requests[$id] = [$deferred, $context, $request::class];
+        $this->requests[$id] = [$deferred, $context];
 
         return $deferred->promise();
     }

--- a/src/Internal/Transport/Client.php
+++ b/src/Internal/Transport/Client.php
@@ -89,7 +89,7 @@ final class Client implements ClientInterface
         }
 
         $deferred = new Deferred();
-        $this->requests[$id] = [$deferred, $context];
+        $this->requests[$id] = [$deferred, $context, $request::class];
 
         return $deferred->promise();
     }

--- a/src/Internal/Transport/Client.php
+++ b/src/Internal/Transport/Client.php
@@ -49,7 +49,7 @@ final class Client implements ClientInterface
     {
         $id = $response->getID();
         if (!isset($this->requests[$id])) {
-            $this->request(new UndefinedResponse(
+            $this->send(new UndefinedResponse(
                 \sprintf('Got the response to undefined request %s', $id),
             ));
             return;

--- a/src/Internal/Workflow/ScopeContext.php
+++ b/src/Internal/Workflow/ScopeContext.php
@@ -16,7 +16,6 @@ use React\Promise\PromiseInterface;
 use Temporal\Exception\Failure\CanceledFailure;
 use Temporal\Internal\Transport\CompletableResult;
 use Temporal\Internal\Workflow\Process\Scope;
-use Temporal\Promise;
 use Temporal\Worker\Transport\Command\RequestInterface;
 use Temporal\Workflow\CancellationScopeInterface;
 use Temporal\Workflow\ScopedContextInterface;

--- a/src/Internal/Workflow/ScopeContext.php
+++ b/src/Internal/Workflow/ScopeContext.php
@@ -75,11 +75,11 @@ class ScopeContext extends WorkflowContext implements ScopedContextInterface
             'Attempt to send request to cancelled scope',
         );
 
-        $promise = $this->parent->request($request);
         if (!$waitResponse) {
-            return Promise::resolve();
+            return $this->parent->request($request, $cancellable, false);
         }
 
+        $promise = $this->parent->request($request);
         ($this->onRequest)($request, $promise);
 
         return new CompletableResult(

--- a/src/Internal/Workflow/WorkflowContext.php
+++ b/src/Internal/Workflow/WorkflowContext.php
@@ -484,7 +484,7 @@ class WorkflowContext implements WorkflowContextInterface, HeaderCarrier, Destro
                     return resolve();
                 }
 
-                $result = $this->request(new UpsertMemo($input->memo), false);
+                $result = $this->request(new UpsertMemo($input->memo), false, false);
 
                 /** @psalm-suppress UnsupportedPropertyReferenceUsage $memo */
                 $memo = &$this->input->info->memo;
@@ -513,7 +513,7 @@ class WorkflowContext implements WorkflowContextInterface, HeaderCarrier, Destro
                     return resolve();
                 }
 
-                $result = $this->request(new UpsertSearchAttributes($input->searchAttributes), false);
+                $result = $this->request(new UpsertSearchAttributes($input->searchAttributes), false, false);
 
                 /** @psalm-suppress UnsupportedPropertyReferenceUsage $sa */
                 $sa = &$this->input->info->searchAttributes;
@@ -541,7 +541,7 @@ class WorkflowContext implements WorkflowContextInterface, HeaderCarrier, Destro
                     return resolve();
                 }
 
-                $result = $this->request(new UpsertTypedSearchAttributes($input->updates), false);
+                $result = $this->request(new UpsertTypedSearchAttributes($input->updates), false, false);
 
                 // Merge changes
                 $tsa = $this->input->info->typedSearchAttributes;

--- a/src/Workflow/WorkflowContextInterface.php
+++ b/src/Workflow/WorkflowContextInterface.php
@@ -128,7 +128,11 @@ interface WorkflowContextInterface extends EnvironmentInterface
      *
      * @internal This is an internal method
      */
-    public function request(RequestInterface $request, bool $cancellable = true): PromiseInterface;
+    public function request(
+        RequestInterface $request,
+        bool $cancellable = true,
+        bool $waitResponse = true,
+    ): PromiseInterface;
 
     /**
      * Updates the behavior of an existing workflow to resolve inconsistency errors during replay.

--- a/tests/Acceptance/App/Attribute/Client.php
+++ b/tests/Acceptance/App/Attribute/Client.php
@@ -16,6 +16,5 @@ final class Client
         public float|null $timeout = null,
         public \Closure|array|string|null $pipelineProvider = null,
         public array $payloadConverters = [],
-    ) {
-    }
+    ) {}
 }

--- a/tests/Unit/Framework/ClientMock.php
+++ b/tests/Unit/Framework/ClientMock.php
@@ -45,7 +45,7 @@ final class ClientMock implements ClientInterface
     public function dispatch(ServerResponseInterface $response): void
     {
         if (!isset($this->requests[$response->getID()])) {
-            $this->request(new UndefinedResponse(
+            $this->send(new UndefinedResponse(
                 \sprintf('Got the response to undefined request %s', $response->getID()),
             ));
             return;


### PR DESCRIPTION
## What was changed

Fixed a memory leak where `upsertSearchAttributes`, `upsertTypedSearchAttributes`, and `upsertMemo` requests were being stored indefinitely in memory waiting for responses that RoadRunner never sends.

## Why?

Workflow workers were accumulating these pending requests, causing memory growth up to 2GB. This led to performance degradation due to excessive garbage collection cycles (`gc_collect_cycles()`), ultimately resulting in timeouts.

## Checklist
- [x] Pending confirmation from users that the issue is resolved