### PR TITLE
Continuous polling in UpdateHandle::fetchResult() until deadline

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -135,11 +135,6 @@
       <code><![CDATA[$options->namespace]]></code>
     </DeprecatedProperty>
   </file>
-  <file src="src/Client/Update/UpdateHandle.php">
-    <PossiblyNullArgument>
-      <code><![CDATA[$result->getSuccess()]]></code>
-    </PossiblyNullArgument>
-  </file>
   <file src="src/Client/WorkflowClient.php">
     <ArgumentTypeCoercion>
       <code><![CDATA[$counter]]></code>

--- a/src/Exception/Failure/FailureConverter.php
+++ b/src/Exception/Failure/FailureConverter.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 
 namespace Temporal\Exception\Failure;
 
-use Psr\Log\LoggerInterface;
 use Temporal\Api\Common\V1\ActivityType;
 use Temporal\Api\Common\V1\WorkflowExecution;
 use Temporal\Api\Common\V1\WorkflowType;
@@ -30,8 +29,6 @@ use Temporal\Internal\Support\DateInterval;
 
 final class FailureConverter
 {
-    private static ?LoggerInterface $logger;
-
     public static function mapFailureToException(Failure $failure, DataConverterInterface $converter): TemporalFailure
     {
         $e = self::createFailureException($failure, $converter);
@@ -158,11 +155,6 @@ final class FailureConverter
         }
 
         return $failure;
-    }
-
-    public function setLogger(LoggerInterface $logger): void
-    {
-        self::$logger = $logger;
     }
 
     private static function createFailureException(Failure $failure, DataConverterInterface $converter): TemporalFailure


### PR DESCRIPTION
## What was changed
Replaced the approach in PR #526 by modifying `UpdateHandle::fetchResult()` to repeatedly poll the Temporal service until either the configured deadline is reached or a response is received. This eliminates the need for a special `WorkflowUpdateResultException` when a Workflow Update Request is stuck in ADMITTED status.

## Why?
This implementation aligns with other Temporal SDKs by continuing to poll rather than throwing an exception when updates are stuck. This provides a more consistent behavior across Temporal implementations and better handles scenarios where workflows are delayed due to unavailable workers or failed workflow tasks.

## Checklist

1. Tested manually