### PR TITLE
Expose Activity and Workflow instance from context

### DIFF
--- a/src/Activity.php
+++ b/src/Activity.php
@@ -141,4 +141,15 @@ final class Activity extends Facade
 
         $context->heartbeat($details);
     }
+
+    /**
+     * Get the currently running activity instance.
+     */
+    public static function getInstance(): object
+    {
+        /** @var ActivityContextInterface $context */
+        $context = self::getCurrentContext();
+
+        return $context->getInstance();
+    }
 }

--- a/src/Activity/ActivityContextInterface.php
+++ b/src/Activity/ActivityContextInterface.php
@@ -63,4 +63,11 @@ interface ActivityContextInterface
      * @param mixed $details
      */
     public function heartbeat($details): void;
+
+    /**
+     * Get the currently running activity instance.
+     *
+     * @see Activity::getInstance()
+     */
+    public function getInstance(): object;
 }

--- a/src/Internal/Activity/ActivityContext.php
+++ b/src/Internal/Activity/ActivityContext.php
@@ -36,6 +36,7 @@ final class ActivityContext implements ActivityContextInterface, HeaderCarrier
     private ?ValuesInterface $heartbeatDetails;
     private ValuesInterface $input;
     private HeaderInterface $header;
+    private ?\WeakReference $instance = null;
 
     public function __construct(
         RPCConnectionInterface $rpc,
@@ -146,5 +147,27 @@ final class ActivityContext implements ActivityContextInterface, HeaderCarrier
         } catch (ServiceClientException $e) {
             throw ActivityCompletionException::fromActivityInfo($this->info, $e);
         }
+    }
+
+    public function getInstance(): object
+    {
+        \assert($this->instance !== null, 'Activity instance is not available');
+        $activity = $this->instance->get();
+        \assert($activity !== null, 'Activity instance is not available');
+        return $activity;
+    }
+
+    /**
+     * Set activity instance.
+     *
+     * @param object $instance Activity instance.
+     * @return $this
+     * @internal
+     */
+    public function withInstance(object $instance): self
+    {
+        $clone = clone $this;
+        $clone->instance = \WeakReference::create($instance);
+        return $clone;
     }
 }

--- a/src/Internal/Declaration/Prototype/WorkflowPrototype.php
+++ b/src/Internal/Declaration/Prototype/WorkflowPrototype.php
@@ -14,6 +14,7 @@ namespace Temporal\Internal\Declaration\Prototype;
 use Temporal\Common\CronSchedule;
 use Temporal\Common\MethodRetry;
 use Temporal\Workflow\ReturnType;
+use Temporal\Workflow\WorkflowInit;
 
 final class WorkflowPrototype extends Prototype
 {
@@ -42,6 +43,9 @@ final class WorkflowPrototype extends Prototype
     private ?ReturnType $returnType = null;
     private bool $hasInitializer = false;
 
+    /**
+     * Indicates if the workflow has a constructor with {@see WorkflowInit} attribute.
+     */
     public function hasInitializer(): bool
     {
         return $this->hasInitializer;

--- a/src/Internal/Declaration/Prototype/WorkflowPrototype.php
+++ b/src/Internal/Declaration/Prototype/WorkflowPrototype.php
@@ -40,6 +40,17 @@ final class WorkflowPrototype extends Prototype
     private ?CronSchedule $cronSchedule = null;
     private ?MethodRetry $methodRetry = null;
     private ?ReturnType $returnType = null;
+    private bool $hasInitializer = false;
+
+    public function hasInitializer(): bool
+    {
+        return $this->hasInitializer;
+    }
+
+    public function setHasInitializer(bool $hasInitializer): void
+    {
+        $this->hasInitializer = $hasInitializer;
+    }
 
     public function getCronSchedule(): ?CronSchedule
     {

--- a/src/Internal/Declaration/Reader/WorkflowReader.php
+++ b/src/Internal/Declaration/Reader/WorkflowReader.php
@@ -24,6 +24,7 @@ use Temporal\Workflow\ReturnType;
 use Temporal\Workflow\SignalMethod;
 use Temporal\Workflow\UpdateMethod;
 use Temporal\Workflow\UpdateValidatorMethod;
+use Temporal\Workflow\WorkflowInit;
 use Temporal\Workflow\WorkflowInterface;
 use Temporal\Workflow\WorkflowMethod;
 
@@ -124,6 +125,13 @@ class WorkflowReader extends Reader
 
         foreach ($class->getMethods() as $method) {
             $contextClass = $method->getDeclaringClass();
+
+            // Check WorkflowInit method
+            if ($method->isConstructor()) {
+                $this->getAttributedMethod($graph, $method, WorkflowInit::class);
+                $prototype->setHasInitializer(true);
+                continue;
+            }
 
             /** @var UpdateMethod|null $update */
             $update = $this->getAttributedMethod($graph, $method, UpdateMethod::class);

--- a/src/Internal/Declaration/WorkflowInstance.php
+++ b/src/Internal/Declaration/WorkflowInstance.php
@@ -296,15 +296,12 @@ final class WorkflowInstance extends Instance implements WorkflowInstanceInterfa
                 static fn(ValuesInterface $arguments): mixed => $validator($input->updateName, $arguments),
             );
 
-        $this->updateDynamicHandler = $this->pipeline->with(
+        $this->updateDynamicHandler =
             fn(UpdateInput $input, Deferred $deferred): mixed => ($this->updateExecutor)(
                 $input,
                 static fn(ValuesInterface $arguments): mixed => $handler($input->updateName, $arguments),
                 $deferred,
-            ),
-            /** @see WorkflowInboundCallsInterceptor::handleUpdate() */
-            'handleUpdate',
-        )(...);
+            );
     }
 
     public function clearSignalQueue(): void

--- a/src/Internal/Declaration/WorkflowInstance.php
+++ b/src/Internal/Declaration/WorkflowInstance.php
@@ -149,17 +149,7 @@ final class WorkflowInstance extends Instance implements WorkflowInstanceInterfa
             return;
         }
 
-        if ($arguments === []) {
-            $this->context->__construct();
-            return;
-        }
-
-        // Check InitMethod attribute
-        $reflection = new \ReflectionMethod($this->context, '__construct');
-        $attributes = $reflection->getAttributes(WorkflowInit::class);
-        $attributes === []
-            ? $this->context->__construct()
-            : $this->context->__construct(...$arguments);
+        $this->context->__construct(...$arguments);
     }
 
     public function getSignalQueue(): SignalQueue

--- a/src/Internal/Declaration/WorkflowInstance.php
+++ b/src/Internal/Declaration/WorkflowInstance.php
@@ -20,7 +20,6 @@ use Temporal\Interceptor\WorkflowInboundCallsInterceptor;
 use Temporal\Internal\Declaration\Prototype\WorkflowPrototype;
 use Temporal\Internal\Declaration\WorkflowInstance\SignalQueue;
 use Temporal\Internal\Interceptor;
-use Temporal\Workflow\WorkflowInit;
 
 /**
  * @psalm-type QueryHandler = \Closure(QueryInput): mixed

--- a/src/Internal/Transport/Router/InvokeActivity.php
+++ b/src/Internal/Transport/Router/InvokeActivity.php
@@ -77,7 +77,12 @@ class InvokeActivity extends Route
         $prototype = $this->findDeclarationOrFail($context->getInfo());
 
         try {
-            $handler = $prototype->getInstance()->getHandler();
+            // Create ActivityInstance
+            $instance = $prototype->getInstance();
+
+            // Register Activity instance in the context
+            $context = $context->withInstance($instance->getContext());
+            $handler = $instance->getHandler();
 
             // Define Context for interceptors Pipeline
             Activity::setCurrentContext($context);

--- a/src/Internal/Transport/Router/StartWorkflow.php
+++ b/src/Internal/Transport/Router/StartWorkflow.php
@@ -17,8 +17,6 @@ use Temporal\Api\Common\V1\SearchAttributes;
 use Temporal\Common\TypedSearchAttributes;
 use Temporal\DataConverter\EncodedCollection;
 use Temporal\DataConverter\EncodedValues;
-use Temporal\Interceptor\WorkflowInbound\WorkflowInput;
-use Temporal\Interceptor\WorkflowInboundCallsInterceptor;
 use Temporal\Internal\Declaration\Instantiator\WorkflowInstantiator;
 use Temporal\Internal\Declaration\Prototype\WorkflowPrototype;
 use Temporal\Internal\ServiceContainer;
@@ -93,10 +91,10 @@ final class StartWorkflow extends Route
         $runId = $request->getID();
 
         Workflow::setCurrentContext($context);
-        $process = new Process($this->services, $context, $runId);
+        $process = new Process($this->services, $runId, $instance);
         $this->services->running->add($process);
         $resolver->resolve(EncodedValues::fromValues([null]));
-        $process->initAndStart($instance, $this->wfStartDeferred);
+        $process->initAndStart($context, $instance, $this->wfStartDeferred);
     }
 
     private function findWorkflowOrFail(WorkflowInfo $info): WorkflowPrototype

--- a/src/Internal/Workflow/Process/Process.php
+++ b/src/Internal/Workflow/Process/Process.php
@@ -208,6 +208,8 @@ class Process extends Scope implements ProcessInterface
                 $instance->init();
             }
 
+            $context->setReadonly(false);
+
             // Execute
             //
             // Run workflow handler in an interceptor pipeline
@@ -234,7 +236,7 @@ class Process extends Scope implements ProcessInterface
                 ));
         } catch (\Throwable $e) {
             /** @psalm-suppress RedundantPropertyInitializationCheck */
-            isset($this->context) or $this->setContext($context);
+            isset($this->context) or $this->setContext($context->setReadonly(false));
             $this->complete($e);
         } finally {
             Workflow::setCurrentContext(null);

--- a/src/Internal/Workflow/Process/Scope.php
+++ b/src/Internal/Workflow/Process/Scope.php
@@ -86,17 +86,7 @@ class Scope implements CancellationScopeInterface, Destroyable
 
     public function __construct(
         ServiceContainer $services,
-        WorkflowContext $ctx,
-        ?Workflow\UpdateContext $updateContext = null,
     ) {
-        $this->context = $ctx;
-        $this->scopeContext = ScopeContext::fromWorkflowContext(
-            $this->context,
-            $this,
-            $this->onRequest(...),
-            $updateContext,
-        );
-
         $this->services = $services;
         $this->deferred = new Deferred();
     }
@@ -312,7 +302,8 @@ class Scope implements CancellationScopeInterface, Destroyable
         ?WorkflowContext $context = null,
         ?Workflow\UpdateContext $updateContext = null,
     ): self {
-        $scope = new Scope($this->services, $context ?? $this->context, $updateContext);
+        $scope = new Scope($this->services);
+        $scope->setContext($context ?? $this->context, $updateContext);
         $scope->detached = $detached;
 
         if ($layer !== null) {
@@ -329,6 +320,17 @@ class Scope implements CancellationScopeInterface, Destroyable
         );
 
         return $scope;
+    }
+
+    protected function setContext(WorkflowContext $ctx, ?Workflow\UpdateContext $updateContext = null): void
+    {
+        $this->context = $ctx;
+        $this->scopeContext = ScopeContext::fromWorkflowContext(
+            $this->context,
+            $this,
+            $this->onRequest(...),
+            $updateContext,
+        );
     }
 
     /**

--- a/src/Internal/Workflow/Process/Scope.php
+++ b/src/Internal/Workflow/Process/Scope.php
@@ -44,11 +44,15 @@ class Scope implements CancellationScopeInterface, Destroyable
 
     /**
      * Workflow context.
+     *
+     * @psalm-suppress PropertyNotSetInConstructor
      */
     protected WorkflowContext $context;
 
     /**
      * Coroutine scope context.
+     *
+     * @psalm-suppress PropertyNotSetInConstructor
      */
     protected ScopeContext $scopeContext;
 

--- a/src/Internal/Workflow/WorkflowContext.php
+++ b/src/Internal/Workflow/WorkflowContext.php
@@ -89,6 +89,7 @@ class WorkflowContext implements WorkflowContextInterface, HeaderCarrier, Destro
 
     private array $trace = [];
     private bool $continueAsNew = false;
+    private bool $readonly = true;
 
     /** @var Pipeline<WorkflowOutboundRequestInterceptor, PromiseInterface> */
     private Pipeline $requestInterceptor;
@@ -148,9 +149,10 @@ class WorkflowContext implements WorkflowContextInterface, HeaderCarrier, Destro
         return $this->input->input;
     }
 
-    public function setInput(Input $input): void
+    public function setReadonly(bool $value = true): static
     {
-        $this->input = $input;
+        $this->readonly = $value;
+        return $this;
     }
 
     public function withInput(Input $input): static
@@ -460,6 +462,7 @@ class WorkflowContext implements WorkflowContextInterface, HeaderCarrier, Destro
         bool $cancellable = true,
         bool $waitResponse = true,
     ): PromiseInterface {
+        $this->readonly and throw new \RuntimeException('Workflow is not initialized.');
         $this->recordTrace();
 
         // Intercept workflow outbound calls

--- a/src/Internal/Workflow/WorkflowContext.php
+++ b/src/Internal/Workflow/WorkflowContext.php
@@ -103,7 +103,7 @@ class WorkflowContext implements WorkflowContextInterface, HeaderCarrier, Destro
         protected ServiceContainer $services,
         protected ClientInterface $client,
         protected WorkflowInstanceInterface&Destroyable $workflowInstance,
-        protected Input $input,
+        public Input $input,
         protected ?ValuesInterface $lastCompletionResult = null,
         protected HandlerState $handlers = new HandlerState(),
     ) {
@@ -146,6 +146,11 @@ class WorkflowContext implements WorkflowContextInterface, HeaderCarrier, Destro
     public function getInput(): ValuesInterface
     {
         return $this->input->input;
+    }
+
+    public function setInput(Input $input): void
+    {
+        $this->input = $input;
     }
 
     public function withInput(Input $input): static

--- a/src/Internal/Workflow/WorkflowContext.php
+++ b/src/Internal/Workflow/WorkflowContext.php
@@ -118,6 +118,11 @@ class WorkflowContext implements WorkflowContextInterface, HeaderCarrier, Destro
         return $this->workflowInstance;
     }
 
+    public function getInstance(): object
+    {
+        return $this->workflowInstance->getContext();
+    }
+
     public function now(): \DateTimeInterface
     {
         return $this->services->env->now();

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -1144,4 +1144,12 @@ final class Workflow extends Facade
     {
         return self::getCurrentContext()->getLogger();
     }
+
+    /**
+     * Get the currently running Workflow instance.
+     */
+    public static function getInstance(): object
+    {
+        return self::getCurrentContext()->getInstance();
+    }
 }

--- a/tests/Acceptance/App/Attribute/Worker.php
+++ b/tests/Acceptance/App/Attribute/Worker.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Acceptance\App\Attribute;
+
+use Psr\Log\LoggerInterface;
+use Temporal\Interceptor\PipelineProvider;
+use Temporal\Worker\WorkerOptions;
+
+/**
+ * Customize worker options.
+ *
+ * The attribute can be used once per TaskQueue.
+ *
+ * @see \Temporal\Tests\Acceptance\App\Feature\WorkerFactory
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class Worker
+{
+    /**
+     * @param array|null $pipelineProvider Callable that returns {@see PipelineProvider}
+     * @param array|null $logger Callable that returns {@see LoggerInterface}
+     */
+    public function __construct(
+        public readonly ?WorkerOptions $options = null,
+        public readonly ?array $pipelineProvider = null,
+        public readonly ?array $logger = null,
+    ) {}
+}

--- a/tests/Acceptance/App/Feature/WorkerFactory.php
+++ b/tests/Acceptance/App/Feature/WorkerFactory.php
@@ -39,8 +39,6 @@ final class WorkerFactory
             $options = $attr->options;
             $attr->pipelineProvider === null or $interceptorProvider = $this->invoker->invoke($attr->pipelineProvider);
             $attr->logger === null or $logger = $this->invoker->invoke($attr->logger);
-
-            tr($interceptorProvider);
         }
 
         return $this->workerFactory->newWorker(

--- a/tests/Acceptance/App/Feature/WorkerFactory.php
+++ b/tests/Acceptance/App/Feature/WorkerFactory.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Acceptance\App\Feature;
+
+use Spiral\Core\Attribute\Singleton;
+use Spiral\Core\InvokerInterface;
+use Temporal\Tests\Acceptance\App\Attribute\Worker;
+use Temporal\Tests\Acceptance\App\Logger\LoggerFactory;
+use Temporal\Tests\Acceptance\App\Runtime\Feature;
+use Spiral\Core\Container\InjectorInterface;
+use Temporal\Client\WorkflowStubInterface;
+use Temporal\Worker\WorkerFactoryInterface;
+use Temporal\Worker\WorkerInterface;
+use Temporal\Worker\WorkerOptions;
+
+/**
+ * @implements InjectorInterface<WorkflowStubInterface>
+ */
+#[Singleton]
+final class WorkerFactory
+{
+    public function __construct(
+        private readonly WorkerFactoryInterface $workerFactory,
+        private readonly InvokerInterface $invoker,
+    ) {}
+
+    public function createWorker(
+        Feature $feature,
+    ): WorkerInterface {
+        // Find Worker attribute
+        $attr = self::findAttribute(
+            ...\array_map(static fn(array $check): string => $check[0], $feature->checks),
+            ...$feature->workflows,
+            ...$feature->activities,
+        );
+        if ($attr !== null) {
+            $options = $attr->options;
+            $attr->pipelineProvider === null or $interceptorProvider = $this->invoker->invoke($attr->pipelineProvider);
+            $attr->logger === null or $logger = $this->invoker->invoke($attr->logger);
+
+            tr($interceptorProvider);
+        }
+
+        return $this->workerFactory->newWorker(
+            $feature->taskQueue,
+            $options ?? WorkerOptions::new()->withMaxConcurrentActivityExecutionSize(10),
+            interceptorProvider: $interceptorProvider ?? null,
+            logger: $logger ?? LoggerFactory::createServerLogger($feature->taskQueue),
+        );
+    }
+
+    /**
+     * Find {@see Worker} attribute in the classes collection.
+     * If more than one attribute is found, an exception is thrown.
+     */
+    private static function findAttribute(string ...$classes): ?Worker
+    {
+        $classes = \array_unique($classes);
+        /** @var array<array{0: Worker, 1: class-string}> $found */
+        $found = [];
+
+        foreach ($classes as $class) {
+            $reflection = new \ReflectionClass($class);
+            $attributes = $reflection->getAttributes(Worker::class);
+            foreach ($attributes as $attribute) {
+                $found[] = [$attribute->newInstance(), $class];
+            }
+        }
+
+        if (\count($found) > 1) {
+            throw new \RuntimeException(
+                'Multiple #[Worker] attributes found: ' . \implode(', ', \array_column($found, 1)),
+            );
+        }
+
+        return $found[0][0] ?? null;
+    }
+}

--- a/tests/Acceptance/App/Logger/ClientLogger.php
+++ b/tests/Acceptance/App/Logger/ClientLogger.php
@@ -49,14 +49,14 @@ final class ClientLogger
     /**
      * Find log records by matching message content.
      *
-     * @param string $messagePattern Regular expression to match against log messages
+     * @param non-empty-string $messagePattern Regular expression to match against log messages
      * @return list<LogRecord> Matching log records
      */
     public function findByMessage(string $messagePattern): array
     {
         $result = [];
         foreach ($this->readAll() as $record) {
-            if (\preg_match($messagePattern, $record->message)) {
+            if (\preg_match($messagePattern, $record->message) === 1) {
                 $result[] = $record;
             }
         }

--- a/tests/Acceptance/App/TestCase.php
+++ b/tests/Acceptance/App/TestCase.php
@@ -45,7 +45,7 @@ abstract class TestCase extends \Temporal\Tests\TestCase
                 LoggerInterface::class => ClientLogger::class,
                 ClientLogger::class => $logger,
             ]),
-            function (Container $container) {
+            function (Container $container): mixed {
                 $reflection = new \ReflectionMethod($this, $this->name());
                 $args = $container->resolveArguments($reflection);
                 $this->setDependencyInput($args);

--- a/tests/Acceptance/Extra/Interceptors/ContextTest.php
+++ b/tests/Acceptance/Extra/Interceptors/ContextTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Acceptance\Extra\Interceptors\Context;
+
+use PHPUnit\Framework\Attributes\Test;
+use Temporal\Activity;
+use Temporal\Client\WorkflowStubInterface;
+use Temporal\DataConverter\EncodedValues;
+use Temporal\Interceptor\ActivityInbound\ActivityInput;
+use Temporal\Interceptor\PipelineProvider;
+use Temporal\Interceptor\SimplePipelineProvider;
+use Temporal\Interceptor\Trait\ActivityInboundInterceptorTrait;
+use Temporal\Tests\Acceptance\App\Attribute\Stub;
+use Temporal\Tests\Acceptance\App\Attribute\Worker;
+use Temporal\Tests\Acceptance\App\TestCase;
+use Temporal\Workflow;
+use Temporal\Workflow\WorkflowInterface;
+use Temporal\Workflow\WorkflowMethod;
+
+#[Worker(pipelineProvider: [WorkerServices::class, 'interceptors'])]
+class ContextTest extends TestCase
+{
+    #[Test]
+    public function instanceInContext(
+        #[Stub('Extra_Interceptors_Context')] WorkflowStubInterface $stub,
+    ): void {
+        $stub->signal('exit');
+        $result = $stub->getResult('array');
+        self::assertSame(TestActivity::class, $result['activity']);
+    }
+}
+
+class WorkerServices
+{
+    public static function interceptors(): PipelineProvider
+    {
+        return new SimplePipelineProvider([
+            new ActivityInboundInterceptor(),
+        ]);
+    }
+}
+
+
+final class ActivityInboundInterceptor implements \Temporal\Interceptor\ActivityInboundInterceptor
+{
+    use ActivityInboundInterceptorTrait;
+
+    public function handleActivityInbound(ActivityInput $input, callable $next): mixed
+    {
+        $instance = Activity::getInstance();
+        $input = $input->with(
+            arguments: EncodedValues::fromValues([$instance::class]),
+        );
+        return $next($input);
+    }
+}
+
+#[WorkflowInterface]
+class TestWorkflow
+{
+    private array $result = [];
+    private bool $exit = false;
+
+    #[WorkflowMethod(name: "Extra_Interceptors_Context")]
+    public function handle()
+    {
+        $activityClass = yield Workflow::executeActivity(
+            'Extra_Interceptors_Context.handler',
+            ['foo'],
+            Activity\ActivityOptions::new()->withScheduleToCloseTimeout('10 seconds'),
+        );
+        yield Workflow::await(fn() => $this->exit);
+        return [
+            'activity' => $activityClass,
+        ];
+    }
+
+    #[Workflow\SignalMethod]
+    public function exit(): void
+    {
+        $this->exit = true;
+    }
+}
+
+#[Activity\ActivityInterface(prefix: 'Extra_Interceptors_Context.')]
+class TestActivity
+{
+    #[Activity\ActivityMethod]
+    public function handler(string $result): string
+    {
+        return $result;
+    }
+}

--- a/tests/Acceptance/Extra/Workflow/FallbackHandlersTest.php
+++ b/tests/Acceptance/Extra/Workflow/FallbackHandlersTest.php
@@ -156,6 +156,8 @@ class FallbackHandlersTest extends TestCase
         // Check interceptors working
         self::assertCount(2, $logger->findByMessage('/Intercepted update: foo/'));
         self::assertCount(1, $logger->findByMessage('/Intercepted update: baz/'));
+        self::assertCount(0, $logger->findByMessage('/Intercepted update validator: foo/'));
+        self::assertCount(0, $logger->findByMessage('/Intercepted update validator: foo/'));
     }
 
     #[Test]

--- a/tests/Acceptance/Extra/Workflow/FallbackHandlersTest.php
+++ b/tests/Acceptance/Extra/Workflow/FallbackHandlersTest.php
@@ -4,24 +4,33 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Acceptance\Extra\Workflow\FallbackHandlers;
 
-use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\Attributes\Test;
 use Temporal\Client\WorkflowStubInterface;
 use Temporal\DataConverter\ValuesInterface;
 use Temporal\Exception\Client\WorkflowQueryException;
 use Temporal\Exception\Client\WorkflowUpdateException;
+use Temporal\Interceptor\PipelineProvider;
+use Temporal\Interceptor\SimplePipelineProvider;
+use Temporal\Interceptor\Trait\WorkflowInboundCallsInterceptorTrait;
+use Temporal\Interceptor\WorkflowInbound\QueryInput;
+use Temporal\Interceptor\WorkflowInbound\SignalInput;
+use Temporal\Interceptor\WorkflowInbound\UpdateInput;
+use Temporal\Interceptor\WorkflowInboundCallsInterceptor;
 use Temporal\Tests\Acceptance\App\Attribute\Stub;
+use Temporal\Tests\Acceptance\App\Attribute\Worker;
+use Temporal\Tests\Acceptance\App\Logger\ClientLogger;
 use Temporal\Tests\Acceptance\App\TestCase;
 use Temporal\Workflow;
 use Temporal\Workflow\WorkflowInterface;
 use Temporal\Workflow\WorkflowMethod;
 
-#[CoversFunction('Temporal\Internal\Workflow\Process\Process::logRunningHandlers')]
+#[Worker(pipelineProvider: [WorkerServices::class, 'interceptors'])]
 class FallbackHandlersTest extends TestCase
 {
     #[Test]
     public function fallbackQuery(
         #[Stub('Extra_Workflow_FallbackHandlers')] WorkflowStubInterface $stub,
+        ClientLogger $logger,
     ): void {
         try {
             $stub->query('foo', 'bar', 'baz');
@@ -38,11 +47,15 @@ class FallbackHandlersTest extends TestCase
             $stub->query('foo', 'bar', 'baz')?->getValues()[0] ?? null,
             'Query should be handled by the fallback handler',
         );
+
+        // Check interceptors working
+        self::assertGreaterThanOrEqual(1, \count($logger->findByMessage('/Intercepted query: foo/')));
     }
 
     #[Test]
     public function fallbackSignal(
         #[Stub('Extra_Workflow_FallbackHandlers')] WorkflowStubInterface $stub,
+        ClientLogger $logger,
     ): void {
         /** @see TestWorkflow::registerSignalFallback() */
         $stub->update('register_signals_fallback');
@@ -61,6 +74,10 @@ class FallbackHandlersTest extends TestCase
             ['foo', [42]],
             ['baz', [['foo' => 'bar']]],
         ], $result['signals']);
+
+        // Check interceptors working
+        self::assertCount(2, $logger->findByMessage('/Intercepted signal: foo/'));
+        self::assertCount(1, $logger->findByMessage('/Intercepted signal: baz/'));
     }
 
     #[Test]
@@ -116,6 +133,7 @@ class FallbackHandlersTest extends TestCase
     #[Test]
     public function fallbackUpdate(
         #[Stub('Extra_Workflow_FallbackHandlers')] WorkflowStubInterface $stub,
+        ClientLogger $logger,
     ): void {
         /** @see TestWorkflow::registerUpdateFallback() */
         $stub->update('register_updates_fallback', false);
@@ -134,11 +152,16 @@ class FallbackHandlersTest extends TestCase
             ['foo', [42]],
             ['baz', [['foo' => 'bar']]],
         ], $result['updates']);
+
+        // Check interceptors working
+        self::assertCount(2, $logger->findByMessage('/Intercepted update: foo/'));
+        self::assertCount(1, $logger->findByMessage('/Intercepted update: baz/'));
     }
 
     #[Test]
     public function fallbackUpdateValidationFail(
         #[Stub('Extra_Workflow_FallbackHandlers')] WorkflowStubInterface $stub,
+        ClientLogger $logger,
     ): void {
         /** @see TestWorkflow::registerUpdateFallback() */
         $stub->update('register_updates_fallback', true);
@@ -149,11 +172,61 @@ class FallbackHandlersTest extends TestCase
         // Validation passed
         $stub->update('foo', 'bar', 'baz');
 
+        // Check interceptors working
+        self::assertCount(1, $logger->findByMessage('/Intercepted update: foo/'));
+        self::assertCount(1, $logger->findByMessage('/Intercepted update validator: foo/'));
+
         // Validation failed
         $this->expectException(WorkflowUpdateException::class);
         $stub->update('fail', 42);
     }
 }
+
+
+class WorkerServices
+{
+    public static function interceptors(): PipelineProvider
+    {
+        return new SimplePipelineProvider([
+            new WorkflowInboundInterceptor(),
+        ]);
+    }
+}
+
+final class WorkflowInboundInterceptor implements WorkflowInboundCallsInterceptor
+{
+    use WorkflowInboundCallsInterceptorTrait;
+
+    public function handleSignal(SignalInput $input, callable $next): void
+    {
+        $input->isReplaying or Workflow::getLogger()->info('Intercepted signal: ' . $input->signalName);
+        $next($input);
+    }
+
+    public function handleQuery(QueryInput $input, callable $next): mixed
+    {
+        Workflow::getLogger()->info('Intercepted query: ' . $input->queryName);
+        return $next($input);
+    }
+
+    public function handleUpdate(UpdateInput $input, callable $next): mixed
+    {
+        $input->isReplaying or Workflow::getLogger()->info('Intercepted update: ' . $input->updateName);
+        return $next($input);
+    }
+
+    /**
+     * Default implementation of the `validateUpdate` method.
+     *
+     * @see WorkflowInboundCallsInterceptor::validateUpdate()
+     */
+    public function validateUpdate(UpdateInput $input, callable $next): void
+    {
+        Workflow::getLogger()->info('Intercepted update validator: ' . $input->updateName);
+        $next($input);
+    }
+}
+
 
 #[WorkflowInterface]
 class TestWorkflow


### PR DESCRIPTION
## What was changed

- Added `Activity::getInstance()` and `Workflow::getInstance()`
- Changed workflow execution flow:
    - First, the Workflow is initialized.
        - It is recommended not to make calls to start Activity, ChildWorkflow, Timer, etc.
        - If the `#[WorkflowInit]` attribute is present, the arguments are resolved.
    - `WorkflowInboundCallInterceptor::execute()` is called
        - Arguments from the previous step are used, but they can be overridden.
    - Workflow Handler is called.
- Now errors from `WorkflowInboundCallInterceptor::execute()` are recorded in the Workflow history.

Tests:
- Acceptance Tests: added ability to customize workers per TaskQueue in tests.
- Added tests for workflow dynamic handlers.

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist

1. Closes #546
2. How was this tested: added tests
3. Any docs updates needed?