### PR TITLE
fix: incorrect updateWithStart signature

### DIFF
--- a/src/Client/WorkflowClient.php
+++ b/src/Client/WorkflowClient.php
@@ -250,7 +250,7 @@ class WorkflowClient implements WorkflowClientInterface
         );
         $workflowStub->hasExecution() and throw new InvalidArgumentException(self::ERROR_WORKFLOW_START_DUPLICATION);
 
-        [$execution, $handle] = $this->getStarter()->updateWithStart(
+        $output = $this->getStarter()->updateWithStart(
             $workflowType,
             $workflowStub->getOptions() ?? WorkflowOptions::new(),
             $update,
@@ -258,11 +258,9 @@ class WorkflowClient implements WorkflowClientInterface
             $startArgs,
         );
 
-        $workflowStub->setExecution($execution);
+        $workflowStub->setExecution($output->getExecution());
 
-        return $handle instanceof \Throwable
-            ? throw $handle
-            : $handle;
+        return $output->getHandle();
     }
 
     /**

--- a/src/Client/WorkflowClient.php
+++ b/src/Client/WorkflowClient.php
@@ -258,9 +258,11 @@ class WorkflowClient implements WorkflowClientInterface
             $startArgs,
         );
 
-        $workflowStub->setExecution($output->getExecution());
+        $workflowStub->setExecution($output->execution);
 
-        return $output->getHandle();
+        return $output->handle instanceof UpdateHandle
+            ? $output->handle
+            : throw $output->handle;
     }
 
     /**

--- a/src/Interceptor/Trait/WorkflowClientCallsInterceptorTrait.php
+++ b/src/Interceptor/Trait/WorkflowClientCallsInterceptorTrait.php
@@ -80,7 +80,7 @@ trait WorkflowClientCallsInterceptorTrait
      *
      * @see WorkflowClientCallsInterceptor::updateWithStart()
      */
-    public function updateWithStart(UpdateWithStartInput $input, callable $next): UpdateHandle
+    public function updateWithStart(UpdateWithStartInput $input, callable $next): array
     {
         return $next($input);
     }

--- a/src/Interceptor/Trait/WorkflowClientCallsInterceptorTrait.php
+++ b/src/Interceptor/Trait/WorkflowClientCallsInterceptorTrait.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 
 namespace Temporal\Interceptor\Trait;
 
-use Temporal\Client\Update\UpdateHandle;
 use Temporal\Client\Workflow\WorkflowExecutionDescription;
 use Temporal\DataConverter\EncodedValues;
 use Temporal\Interceptor\WorkflowClient\CancelInput;
@@ -25,6 +24,7 @@ use Temporal\Interceptor\WorkflowClient\StartUpdateOutput;
 use Temporal\Interceptor\WorkflowClient\TerminateInput;
 use Temporal\Interceptor\WorkflowClient\UpdateInput;
 use Temporal\Interceptor\WorkflowClient\UpdateWithStartInput;
+use Temporal\Interceptor\WorkflowClient\UpdateWithStartOutput;
 use Temporal\Interceptor\WorkflowClientCallsInterceptor;
 use Temporal\Workflow\WorkflowExecution;
 
@@ -80,7 +80,7 @@ trait WorkflowClientCallsInterceptorTrait
      *
      * @see WorkflowClientCallsInterceptor::updateWithStart()
      */
-    public function updateWithStart(UpdateWithStartInput $input, callable $next): array
+    public function updateWithStart(UpdateWithStartInput $input, callable $next): UpdateWithStartOutput
     {
         return $next($input);
     }

--- a/src/Interceptor/WorkflowClient/UpdateWithStartOutput.php
+++ b/src/Interceptor/WorkflowClient/UpdateWithStartOutput.php
@@ -17,21 +17,7 @@ use Temporal\Workflow\WorkflowExecution;
 final class UpdateWithStartOutput
 {
     public function __construct(
-        private readonly WorkflowExecution $execution,
-        private readonly UpdateHandle|\Throwable $handle,
+        public readonly WorkflowExecution $execution,
+        public readonly UpdateHandle|\Throwable $handle,
     ) {}
-
-    public function getExecution(): WorkflowExecution
-    {
-        return $this->execution;
-    }
-
-    public function getHandle(): UpdateHandle
-    {
-        if ($this->handle instanceof \Throwable) {
-            throw $this->handle;
-        }
-
-        return $this->handle;
-    }
 }

--- a/src/Interceptor/WorkflowClient/UpdateWithStartOutput.php
+++ b/src/Interceptor/WorkflowClient/UpdateWithStartOutput.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Interceptor\WorkflowClient;
+
+use Temporal\Client\Update\UpdateHandle;
+use Temporal\Workflow\WorkflowExecution;
+
+final class UpdateWithStartOutput
+{
+    public function __construct(
+        private readonly WorkflowExecution $execution,
+        private readonly UpdateHandle|\Throwable $handle,
+    ) {}
+
+    public function getExecution(): WorkflowExecution
+    {
+        return $this->execution;
+    }
+
+    public function getHandle(): UpdateHandle
+    {
+        if ($this->handle instanceof \Throwable) {
+            throw $this->handle;
+        }
+
+        return $this->handle;
+    }
+}

--- a/src/Interceptor/WorkflowClientCallsInterceptor.php
+++ b/src/Interceptor/WorkflowClientCallsInterceptor.php
@@ -75,9 +75,9 @@ interface WorkflowClientCallsInterceptor extends Interceptor
      * @param UpdateWithStartInput $input
      * @param callable(UpdateWithStartInput): WorkflowExecution $next
      *
-     * @return UpdateHandle
+     * @return array{WorkflowExecution, UpdateHandle|\Throwable}
      */
-    public function updateWithStart(UpdateWithStartInput $input, callable $next): UpdateHandle;
+    public function updateWithStart(UpdateWithStartInput $input, callable $next): array;
 
     /**
      * @param callable(GetResultInput): ?ValuesInterface $next

--- a/src/Interceptor/WorkflowClientCallsInterceptor.php
+++ b/src/Interceptor/WorkflowClientCallsInterceptor.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 
 namespace Temporal\Interceptor;
 
-use Temporal\Client\Update\UpdateHandle;
 use Temporal\Client\Workflow\WorkflowExecutionDescription;
 use Temporal\DataConverter\ValuesInterface;
 use Temporal\Interceptor\Trait\WorkflowClientCallsInterceptorTrait;
@@ -26,6 +25,7 @@ use Temporal\Interceptor\WorkflowClient\StartUpdateOutput;
 use Temporal\Interceptor\WorkflowClient\TerminateInput;
 use Temporal\Interceptor\WorkflowClient\UpdateInput;
 use Temporal\Interceptor\WorkflowClient\UpdateWithStartInput;
+use Temporal\Interceptor\WorkflowClient\UpdateWithStartOutput;
 use Temporal\Internal\Interceptor\Interceptor;
 use Temporal\Workflow\WorkflowExecution;
 
@@ -74,10 +74,8 @@ interface WorkflowClientCallsInterceptor extends Interceptor
     /**
      * @param UpdateWithStartInput $input
      * @param callable(UpdateWithStartInput): WorkflowExecution $next
-     *
-     * @return array{WorkflowExecution, UpdateHandle|\Throwable}
      */
-    public function updateWithStart(UpdateWithStartInput $input, callable $next): array;
+    public function updateWithStart(UpdateWithStartInput $input, callable $next): UpdateWithStartOutput;
 
     /**
      * @param callable(GetResultInput): ?ValuesInterface $next

--- a/tests/Fixtures/src/Interceptor/InterceptorCallsCounter.php
+++ b/tests/Fixtures/src/Interceptor/InterceptorCallsCounter.php
@@ -22,6 +22,7 @@ use Temporal\Interceptor\Trait\WorkflowOutboundRequestInterceptorTrait;
 use Temporal\Interceptor\WorkflowClient\SignalWithStartInput;
 use Temporal\Interceptor\WorkflowClient\StartInput;
 use Temporal\Interceptor\WorkflowClient\UpdateWithStartInput;
+use Temporal\Interceptor\WorkflowClient\UpdateWithStartOutput;
 use Temporal\Interceptor\WorkflowClientCallsInterceptor;
 use Temporal\Interceptor\WorkflowInbound\SignalInput;
 use Temporal\Interceptor\WorkflowInbound\UpdateInput;
@@ -95,7 +96,7 @@ final class InterceptorCallsCounter implements
         );
     }
 
-    public function updateWithStart(UpdateWithStartInput $input, callable $next): array
+    public function updateWithStart(UpdateWithStartInput $input, callable $next): UpdateWithStartOutput
     {
         return $next(
             $input->with(

--- a/tests/Fixtures/src/Interceptor/InterceptorCallsCounter.php
+++ b/tests/Fixtures/src/Interceptor/InterceptorCallsCounter.php
@@ -21,8 +21,10 @@ use Temporal\Interceptor\Trait\WorkflowInboundCallsInterceptorTrait;
 use Temporal\Interceptor\Trait\WorkflowOutboundRequestInterceptorTrait;
 use Temporal\Interceptor\WorkflowClient\SignalWithStartInput;
 use Temporal\Interceptor\WorkflowClient\StartInput;
+use Temporal\Interceptor\WorkflowClient\UpdateWithStartInput;
 use Temporal\Interceptor\WorkflowClientCallsInterceptor;
 use Temporal\Interceptor\WorkflowInbound\SignalInput;
+use Temporal\Interceptor\WorkflowInbound\UpdateInput;
 use Temporal\Interceptor\WorkflowInbound\WorkflowInput;
 use Temporal\Interceptor\WorkflowInboundCallsInterceptor;
 use Temporal\Interceptor\WorkflowOutboundRequestInterceptor;
@@ -83,6 +85,17 @@ final class InterceptorCallsCounter implements
     }
 
     public function signalWithStart(SignalWithStartInput $input, callable $next): WorkflowExecution
+    {
+        return $next(
+            $input->with(
+                workflowStartInput: $input->workflowStartInput->with(
+                    header: $this->increment($input->workflowStartInput->header, __FUNCTION__),
+                ),
+            ),
+        );
+    }
+
+    public function updateWithStart(UpdateWithStartInput $input, callable $next): array
     {
         return $next(
             $input->with(

--- a/tests/Fixtures/src/Workflow/Interceptor/UpdateHeadersWorkflow.php
+++ b/tests/Fixtures/src/Workflow/Interceptor/UpdateHeadersWorkflow.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Workflow\Interceptor;
+
+use Temporal\Workflow;
+use Temporal\Workflow\WorkflowMethod;
+
+#[Workflow\WorkflowInterface]
+class UpdateHeadersWorkflow
+{
+    private ?array $headers = null;
+    private bool $updated = false;
+
+    #[WorkflowMethod(name: 'InterceptorUpdateHeadersWorkflow')]
+    public function handler(): mixed
+    {
+        yield Workflow::await(fn() => $this->updated);
+
+        $this->headers = \iterator_to_array(Workflow::getCurrentContext()->getHeader());
+
+        return $this->headers;
+    }
+
+    #[Workflow\UpdateMethod]
+    public function update(): void
+    {
+        $this->updated = true;
+    }
+
+    #[Workflow\QueryMethod]
+    public function headers(): mixed
+    {
+        return $this->headers;
+    }
+}

--- a/tests/Functional/.rr.silent.yaml
+++ b/tests/Functional/.rr.silent.yaml
@@ -4,7 +4,7 @@ rpc:
     listen: tcp://127.0.0.1:6001
 
 server:
-    command: "php -derror_reporting=0 worker.php"
+    command: "php worker.php"
     env:
         XDEBUG_SESSION: 1
 

--- a/tests/Functional/.rr.silent.yaml
+++ b/tests/Functional/.rr.silent.yaml
@@ -4,7 +4,7 @@ rpc:
     listen: tcp://127.0.0.1:6001
 
 server:
-    command: "php worker.php"
+    command: "php -derror_reporting=0 worker.php"
     env:
         XDEBUG_SESSION: 1
 

--- a/tests/Functional/Interceptor/InterceptorsTestCase.php
+++ b/tests/Functional/Interceptor/InterceptorsTestCase.php
@@ -12,11 +12,14 @@ declare(strict_types=1);
 namespace Temporal\Tests\Functional\Interceptor;
 
 use Carbon\CarbonInterval;
+use Temporal\Client\Update\LifecycleStage;
+use Temporal\Client\Update\UpdateOptions;
 use Temporal\Client\WorkflowOptions;
 use Temporal\Testing\WithoutTimeSkipping;
 use Temporal\Tests\Workflow\Interceptor\HeadersWorkflow;
 use Temporal\Tests\Workflow\Interceptor\QueryHeadersWorkflow;
 use Temporal\Tests\Workflow\Interceptor\SignalHeadersWorkflow;
+use Temporal\Tests\Workflow\Interceptor\UpdateHeadersWorkflow;
 
 /**
  * @group client
@@ -109,6 +112,30 @@ final class InterceptorsTestCase extends AbstractClient
             /** @see \Temporal\Tests\Interceptor\InterceptorCallsCounter::handleSignal() */
             'handleSignal' => '1',
         ], (array)$run->getResult());
+    }
+
+    public function testUpdateWithStartMethod(): void
+    {
+        $client = $this->createClient();
+        $workflow = $client->newWorkflowStub(
+            UpdateHeadersWorkflow::class,
+            WorkflowOptions::new()
+                ->withWorkflowExecutionTimeout(CarbonInterval::seconds(5)),
+        );
+
+        $run = $client->updateWithStart($workflow, 'update');
+
+        // Workflow header
+        $this->assertEquals([
+            /** @see \Temporal\Tests\Interceptor\InterceptorCallsCounter::updateWithStart() */
+            'updateWithStart' => '1',
+            /**
+             * Inherited from handler run
+             *
+             * @see \Temporal\Tests\Interceptor\InterceptorCallsCounter::execute()
+             */
+            'execute' => '1',
+        ], $workflow->headers());
     }
 
     // todo: rewrite tests because there is no header in query call

--- a/tests/Functional/Interceptor/InterceptorsTestCase.php
+++ b/tests/Functional/Interceptor/InterceptorsTestCase.php
@@ -135,7 +135,7 @@ final class InterceptorsTestCase extends AbstractClient
              * @see \Temporal\Tests\Interceptor\InterceptorCallsCounter::execute()
              */
             'execute' => '1',
-        ], $workflow->headers());
+        ], (array) $workflow->headers());
     }
 
     // todo: rewrite tests because there is no header in query call


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

- Fixed `WorkflowClientCallsInterceptor::updateWithStart()` signature to match value returned from `WorkflowStarter::updateWithStart()`
- Added test case to cover fixed area.
## Why?
<!-- Tell your future self why have you made these changes -->
Because whenever `WorkflowClientCallsInterceptor` implementation is provided and `updateWithStart()` is called exception happens.
Example output, from the provided test case, if signature change is reverted
```
TypeError: Temporal\Tests\Interceptor\InterceptorCallsCounter::updateWithStart(): Return value must be of type Temporal\Client\Update\UpdateHandle, array returned
```

## Checklist
<!--- add/delete as needed --->

1. Closes _nothing_ (did not find any related issue)

2. How was this tested:
See the added test case

3. Any docs updates needed?
No
