### PR TITLE
Fix collecting Workflow requests after destroying

### DIFF
--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -85,8 +85,7 @@ jobs:
 
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer Dependencies
         uses: actions/cache@v3

--- a/.github/workflows/security-check.yml
+++ b/.github/workflows/security-check.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Dependencies
         uses: actions/cache@v3

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Dependencies
         uses: actions/cache@v3
@@ -68,7 +68,7 @@ jobs:
 
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Dependencies
         uses: actions/cache@v3

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "composer/composer": "^2.8.4",
         "dereuromark/composer-prefer-lowest": "^0.1.10",
         "doctrine/annotations": "^1.14.4 || ^2.0.2",
-        "internal/dload": "^1.0",
+        "internal/dload": "^1.0.2",
         "jetbrains/phpstorm-attributes": "dev-master",
         "laminas/laminas-code": "^4.16",
         "phpunit/phpunit": "^10.5.41",

--- a/dload.xml
+++ b/dload.xml
@@ -1,14 +1,17 @@
 <?xml version="1.0"?>
-<dload>
+<dload xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="vendor/internal/dload/dload.xsd"
+       temp-dir="./runtime"
+>
     <actions>
-        <download software="rr" version="^2024.2"/>
+        <download software="rr" version="^2024.3.3"/>
         <download software="temporal"/>
         <download software="temporal-tests-server"/>
     </actions>
     <registry>
         <software name="Temporal Tests Server" alias="temporal-tests-server">
             <repository type="github" uri="temporalio/sdk-java" asset-pattern="/^temporal-test-server.*/"/>
-            <file pattern="/^(temporal-test-server)(?:\.exe)?$/" />
+            <binary name="temporal-test-server"/>
         </software>
     </registry>
 </dload>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1483,7 +1483,6 @@
     <UndefinedInterfaceMethod>
       <code><![CDATA[dispatch]]></code>
       <code><![CDATA[dispatch]]></code>
-      <code><![CDATA[dispatch]]></code>
       <code><![CDATA[update]]></code>
     </UndefinedInterfaceMethod>
     <UnsafeInstantiation>

--- a/src/Client/Workflow/WorkflowExecutionDescription.php
+++ b/src/Client/Workflow/WorkflowExecutionDescription.php
@@ -11,8 +11,6 @@ use Temporal\Workflow\WorkflowExecutionInfo;
  * DTO that contains detailed information about Workflow Execution.
  *
  * @see \Temporal\Api\Workflowservice\V1\DescribeWorkflowExecutionResponse
- *
- * @internal
  */
 final class WorkflowExecutionDescription
 {

--- a/src/Internal/Transport/Client.php
+++ b/src/Internal/Transport/Client.php
@@ -116,6 +116,21 @@ final class Client implements ClientInterface
         $this->fetch($command->getID())->reject($reason);
     }
 
+    public function fork(): ClientInterface
+    {
+        return new DetachedClient($this, function (array $ids): void {
+            foreach ($ids as $id) {
+                unset($this->requests[$id]);
+            }
+        });
+    }
+
+    public function destroy(): void
+    {
+        $this->requests = [];
+        unset($this->queue);
+    }
+
     private function fetch(int $id): Deferred
     {
         $request = $this->get($id);

--- a/src/Internal/Transport/ClientInterface.php
+++ b/src/Internal/Transport/ClientInterface.php
@@ -12,11 +12,13 @@ declare(strict_types=1);
 namespace Temporal\Internal\Transport;
 
 use React\Promise\PromiseInterface;
+use Temporal\Internal\Declaration\Destroyable;
 use Temporal\Worker\Transport\Command\CommandInterface;
 use Temporal\Worker\Transport\Command\RequestInterface;
+use Temporal\Worker\Transport\Command\ServerResponseInterface;
 use Temporal\Workflow\WorkflowContextInterface;
 
-interface ClientInterface
+interface ClientInterface extends Destroyable
 {
     /**
      * Send a request and return a promise.
@@ -39,4 +41,14 @@ interface ClientInterface
      * Reject pending promise.
      */
     public function reject(CommandInterface $command, \Throwable $reason): void;
+
+    /**
+     * Dispatch a response to the request.
+     */
+    public function dispatch(ServerResponseInterface $response): void;
+
+    /**
+     * Create a new client that can work with parent's request queue.
+     */
+    public function fork(): ClientInterface;
 }

--- a/src/Internal/Transport/DetachedClient.php
+++ b/src/Internal/Transport/DetachedClient.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace Temporal\Internal\Transport;
 
 use React\Promise\PromiseInterface;
-use Temporal\Internal\Declaration\Destroyable;
 use Temporal\Worker\Transport\Command\CommandInterface;
 use Temporal\Worker\Transport\Command\RequestInterface;
 use Temporal\Worker\Transport\Command\ServerResponseInterface;
@@ -22,7 +21,7 @@ use Temporal\Workflow\WorkflowContextInterface;
  * @internal Client is an internal library class, please do not use it in your code.
  * @psalm-internal Temporal\Internal\Transport
  */
-final class DetachedClient implements ClientInterface, Destroyable
+final class DetachedClient implements ClientInterface
 {
     /** @var list<int> */
     private array $requests = [];

--- a/src/Internal/Transport/DetachedClient.php
+++ b/src/Internal/Transport/DetachedClient.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Internal\Transport;
+
+use React\Promise\PromiseInterface;
+use Temporal\Internal\Declaration\Destroyable;
+use Temporal\Worker\Transport\Command\CommandInterface;
+use Temporal\Worker\Transport\Command\RequestInterface;
+use Temporal\Worker\Transport\Command\ServerResponseInterface;
+use Temporal\Workflow\WorkflowContextInterface;
+
+/**
+ * @internal Client is an internal library class, please do not use it in your code.
+ * @psalm-internal Temporal\Internal\Transport
+ */
+final class DetachedClient implements ClientInterface, Destroyable
+{
+    /** @var list<int> */
+    private array $requests = [];
+
+    /**
+     * @param \Closure(list<int>): void $cleanup Handler that removes requests from the parent using their IDs.
+     */
+    public function __construct(
+        private ClientInterface $parent,
+        private \Closure $cleanup,
+    ) {}
+
+    #[\Override]
+    public function request(RequestInterface $request, ?WorkflowContextInterface $context = null): PromiseInterface
+    {
+        $this->requests[] = $request->getID();
+        return $this->parent->request($request, $context);
+    }
+
+    #[\Override]
+    public function send(CommandInterface $request): void
+    {
+        $this->parent->send($request);
+    }
+
+    #[\Override]
+    public function isQueued(CommandInterface $command): bool
+    {
+        return $this->parent->isQueued($command);
+    }
+
+    #[\Override]
+    public function cancel(CommandInterface $command): void
+    {
+        $this->parent->cancel($command);
+    }
+
+    #[\Override]
+    public function reject(CommandInterface $command, \Throwable $reason): void
+    {
+        $this->parent->reject($command, $reason);
+    }
+
+    #[\Override]
+    public function dispatch(ServerResponseInterface $response): void
+    {
+        $this->parent->dispatch($response);
+    }
+
+    #[\Override]
+    public function fork(): ClientInterface
+    {
+        return $this->parent->fork();
+    }
+
+    public function destroy(): void
+    {
+        $this->requests === [] or ($this->cleanup)($this->requests);
+        $this->requests = [];
+        unset($this->parent, $this->cleanup);
+    }
+}

--- a/src/Internal/Transport/Router/StartWorkflow.php
+++ b/src/Internal/Transport/Router/StartWorkflow.php
@@ -85,7 +85,7 @@ final class StartWorkflow extends Route
 
         $context = new WorkflowContext(
             $this->services,
-            $this->services->client,
+            $this->services->client->fork(),
             $instance,
             $input,
             $lastCompletionResult,

--- a/src/Internal/Workflow/WorkflowContext.php
+++ b/src/Internal/Workflow/WorkflowContext.php
@@ -666,7 +666,8 @@ class WorkflowContext implements WorkflowContextInterface, HeaderCarrier, Destro
     {
         $this->awaits = [];
         $this->workflowInstance->destroy();
-        unset($this->workflowInstance);
+        $this->client->destroy();
+        unset($this->workflowInstance, $this->client);
     }
 
     protected function awaitRequest(callable|Mutex|PromiseInterface ...$conditions): PromiseInterface

--- a/src/Workflow/WorkflowExecutionConfig.php
+++ b/src/Workflow/WorkflowExecutionConfig.php
@@ -17,6 +17,9 @@ use Temporal\Common\TaskQueue\TaskQueue;
 #[Immutable]
 final class WorkflowExecutionConfig
 {
+    /**
+     * @internal
+     */
     public function __construct(
         public readonly TaskQueue $taskQueue,
         public readonly ?\DateInterval $workflowExecutionTimeout,

--- a/tests/Feature/Testing/CapturedClient.php
+++ b/tests/Feature/Testing/CapturedClient.php
@@ -53,33 +53,6 @@ class CapturedClient implements ClientInterface
     }
 
     /**
-     * @param RequestInterface $request
-     * @return \Closure
-     */
-    private function onFulfilled(RequestInterface $request): \Closure
-    {
-        return function ($response) use ($request) {
-            unset($this->requests[$request->getID()]);
-
-            return $response;
-        };
-    }
-
-    /**
-     * @param RequestInterface $request
-     * @return \Closure
-     * @psalm-suppress UnusedClosureParam
-     */
-    private function onRejected(RequestInterface $request): \Closure
-    {
-        return function (\Throwable $error) use ($request) {
-            unset($this->requests[$request->getID()]);
-
-            throw $error;
-        };
-    }
-
-    /**
      * {@inheritDoc}
      */
     public function fetchUnresolvedRequests(): array
@@ -120,5 +93,42 @@ class CapturedClient implements ClientInterface
     public function reject(CommandInterface $command, \Throwable $reason): void
     {
         $this->parent->reject($command, $reason);
+    }
+
+    public function dispatch(CommandInterface $response): void
+    {
+        $this->parent->dispatch($response);
+    }
+
+    public function fork(): ClientInterface
+    {
+        return $this->parent->fork();
+    }
+
+    /**
+     * @param RequestInterface $request
+     * @return \Closure
+     */
+    private function onFulfilled(RequestInterface $request): \Closure
+    {
+        return function ($response) use ($request) {
+            unset($this->requests[$request->getID()]);
+
+            return $response;
+        };
+    }
+
+    /**
+     * @param RequestInterface $request
+     * @return \Closure
+     * @psalm-suppress UnusedClosureParam
+     */
+    private function onRejected(RequestInterface $request): \Closure
+    {
+        return function (\Throwable $error) use ($request): void {
+            unset($this->requests[$request->getID()]);
+
+            throw $error;
+        };
     }
 }

--- a/tests/Fixtures/src/Workflow/DetachedScopeWorkflow.php
+++ b/tests/Fixtures/src/Workflow/DetachedScopeWorkflow.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Workflow;
+
+use Temporal\Workflow;
+use Temporal\Workflow\WorkflowMethod;
+
+#[Workflow\WorkflowInterface]
+class DetachedScopeWorkflow
+{
+    #[WorkflowMethod]
+    public function handler()
+    {
+        yield Workflow::asyncDetached(
+            static function (): void {
+                // Don't add `yield` here. It's important for the tests.
+                Workflow::await(Workflow::timer(5000));
+            },
+        );
+
+        return 'ok';
+    }
+}

--- a/tests/Functional/WorkflowTestCase.php
+++ b/tests/Functional/WorkflowTestCase.php
@@ -436,6 +436,6 @@ class WorkflowTestCase extends AbstractFunctional
      */
     private static function getPrivate(object $object, string $key): mixed
     {
-        return (fn (object $value) => $value->{$key} ?? null)->call($object, $object);
+        return (static fn(object $value) => $value->{$key} ?? null)->call($object, $object);
     }
 }

--- a/tests/Functional/WorkflowTestCase.php
+++ b/tests/Functional/WorkflowTestCase.php
@@ -436,6 +436,6 @@ class WorkflowTestCase extends AbstractFunctional
      */
     private static function getPrivate(object $object, string $key): mixed
     {
-        return (static fn(object $value) => $value->{$key} ?? null)->call($object, $object);
+        return (static fn(object $value) => $value->{$key} ?? null)->bindTo(null, $object)($object);
     }
 }

--- a/tests/Unit/Framework/ClientMock.php
+++ b/tests/Unit/Framework/ClientMock.php
@@ -104,6 +104,13 @@ final class ClientMock implements ClientInterface
         $request->reject($reason);
     }
 
+    public function fork(): self
+    {
+        return new self($this->queue);
+    }
+
+    public function destroy(): void {}
+
     private function fetch(int $id): Deferred
     {
         $request = $this->get($id);

--- a/tests/Unit/Framework/ClientMock.php
+++ b/tests/Unit/Framework/ClientMock.php
@@ -106,7 +106,7 @@ final class ClientMock implements ClientInterface
 
     public function fork(): self
     {
-        return new self($this->queue);
+        return $this;
     }
 
     public function destroy(): void {}

--- a/tests/Unit/Framework/ClientMock.php
+++ b/tests/Unit/Framework/ClientMock.php
@@ -9,6 +9,7 @@ use React\Promise\PromiseInterface;
 use Temporal\Exception\Failure\CanceledFailure;
 use Temporal\Internal\Queue\QueueInterface;
 use Temporal\Internal\Transport\ClientInterface;
+use Temporal\Internal\Transport\DetachedClient;
 use Temporal\Internal\Transport\Request\UndefinedResponse;
 use Temporal\Worker\Transport\Command\CommandInterface;
 use Temporal\Worker\Transport\Command\FailureResponseInterface;
@@ -25,7 +26,6 @@ final class ClientMock implements ClientInterface
     private const ERROR_REQUEST_ID_DUPLICATION =
         'Unable to create a new request because a ' .
         'request with id %d has already been sent';
-
     private const ERROR_REQUEST_NOT_FOUND =
         'Unable to receive a request with id %d because ' .
         'a request with that identifier was not sent';
@@ -104,9 +104,13 @@ final class ClientMock implements ClientInterface
         $request->reject($reason);
     }
 
-    public function fork(): self
+    public function fork(): ClientInterface
     {
-        return $this;
+        return new DetachedClient($this, function (array $ids): void {
+            foreach ($ids as $id) {
+                unset($this->requests[$id]);
+            }
+        });
     }
 
     public function destroy(): void {}

--- a/tests/Unit/Framework/Expectation/WorkflowResult.php
+++ b/tests/Unit/Framework/Expectation/WorkflowResult.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Unit\Framework\Expectation;
 
-use DateTimeImmutable;
 use Temporal\DataConverter\EncodedValues;
 use Temporal\Internal\Transport\Request\CompleteWorkflow;
 use Temporal\Worker\Transport\Command\CommandInterface;
@@ -38,7 +37,7 @@ final class WorkflowResult implements ExpectationInterface
 
     public function run(CommandInterface $command): CommandInterface
     {
-        return new SuccessResponse(EncodedValues::empty(), $command->getID(), new TickInfo(new DateTimeImmutable()));
+        return new SuccessResponse(EncodedValues::empty(), $command->getID(), new TickInfo(new \DateTimeImmutable()));
     }
 
     public function fail(): void

--- a/tests/Unit/Framework/Server/ServerMock.php
+++ b/tests/Unit/Framework/Server/ServerMock.php
@@ -44,7 +44,7 @@ final class ServerMock
 
     public function addCommand(CommandInterface ...$commands): void
     {
-        $this->queue = array_merge($this->queue, $commands);
+        $this->queue = \array_merge($this->queue, $commands);
     }
 
     public function handleCommand(CommandInterface $command): ?CommandInterface

--- a/tests/Unit/Router/StartWorkflowTestCase.php
+++ b/tests/Unit/Router/StartWorkflowTestCase.php
@@ -132,7 +132,7 @@ final class StartWorkflowTestCase extends AbstractUnit
         $this->router = new StartWorkflow($this->services);
         $this->workflowContext = new WorkflowContext(
             $this->services,
-            $this->services->client,
+            $this->services->client->fork(),
             $this->createMockForIntersectionOfInterfaces([WorkflowInstanceInterface::class, Destroyable::class]),
             new Input(),
             EncodedValues::empty(),

--- a/tests/Unit/WorkflowContext/GetVersionTestCase.php
+++ b/tests/Unit/WorkflowContext/GetVersionTestCase.php
@@ -15,16 +15,9 @@ use Temporal\Workflow\WorkflowMethod;
 final class GetVersionTestCase extends AbstractUnit
 {
     private WorkerFactoryInterface $factory;
+
     /** @var WorkerMock|WorkerInterface */
     private $worker;
-
-    protected function setUp(): void
-    {
-        $this->factory = WorkerFactoryMock::create();
-        $this->worker = $this->factory->newWorker();
-
-        parent::setUp();
-    }
 
     public function testVersionIsRetrieved(): void
     {
@@ -50,11 +43,19 @@ final class GetVersionTestCase extends AbstractUnit
 
                     return 'ERROR';
                 }
-            }
+            },
         );
 
         $this->worker->runWorkflow('VersionWorkflow');
         $this->worker->assertWorkflowReturns('OK');
         $this->factory->run($this->worker);
+    }
+
+    protected function setUp(): void
+    {
+        $this->factory = WorkerFactoryMock::create();
+        $this->worker = $this->factory->newWorker();
+
+        parent::setUp();
     }
 }


### PR DESCRIPTION
## What was changed

- Remove internal annotation from WorkflowExecutionDescription
- Now the internal Client is forked for each Workflow. Each Client fork will remove its requests from the parent one when the related Workflow context is destroying.

## Checklist
1. Closes #597 
2. How was this tested: added autotest
