### PR TITLE
Remove experimental note from updateWithStart client method

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -250,11 +250,6 @@
       <code><![CDATA[valueUnset]]></code>
     </ImpureMethodCall>
   </file>
-  <file src="src/Common/SearchAttributes/SearchAttributeKey/KeywordListValue.php">
-    <MismatchingDocblockParamType>
-      <code><![CDATA[iterable<string|\Stringable>]]></code>
-    </MismatchingDocblockParamType>
-  </file>
   <file src="src/Common/TypedSearchAttributes.php">
     <InvalidArgument>
       <code><![CDATA[$key]]></code>

--- a/src/Client/WorkflowClientInterface.php
+++ b/src/Client/WorkflowClientInterface.php
@@ -71,7 +71,6 @@ interface WorkflowClientInterface extends ClientContextInterface
      * @param object|WorkflowStubInterface $workflow
      * @param non-empty-string|UpdateOptions $update Name of the update handler or update options.
      *
-     * @note Experimental feature.
      * @since SDK 2.12.0
      */
     public function updateWithStart(


### PR DESCRIPTION
## What was changed

This pull request makes a minor change to the `src/Client/WorkflowClientInterface.php` file by removing the `@note Experimental feature.` annotation from the `updateWithStart` method's PHPDoc block.
