### PR TITLE
Refactor: rename `CloneWith::with` to `CloneWith::cloneWith`

### DIFF
--- a/src/Client/Schedule/Action/StartWorkflowAction.php
+++ b/src/Client/Schedule/Action/StartWorkflowAction.php
@@ -145,7 +145,7 @@ final class StartWorkflowAction extends ScheduleAction
         $workflowId !== '' or throw new \InvalidArgumentException('Workflow ID cannot be empty.');
 
         /** @see self::$workflowId */
-        return $this->with('workflowId', $workflowId);
+        return $this->cloneWith('workflowId', $workflowId);
     }
 
     public function withWorkflowType(string|WorkflowType $workflowType): self
@@ -153,7 +153,7 @@ final class StartWorkflowAction extends ScheduleAction
         \is_string($workflowType) and $workflowType = self::createWorkflowType($workflowType);
 
         /** @see self::$workflowType */
-        return $this->with('workflowType', $workflowType);
+        return $this->cloneWith('workflowType', $workflowType);
     }
 
     public function withTaskQueue(string|TaskQueue $taskQueue): self
@@ -161,7 +161,7 @@ final class StartWorkflowAction extends ScheduleAction
         \is_string($taskQueue) and $taskQueue = TaskQueue::new($taskQueue);
 
         /** @see self::$taskQueue */
-        return $this->with('taskQueue', $taskQueue);
+        return $this->cloneWith('taskQueue', $taskQueue);
     }
 
     /**
@@ -174,7 +174,7 @@ final class StartWorkflowAction extends ScheduleAction
         $values instanceof ValuesInterface or $values = EncodedValues::fromValues($values);
 
         /** @see self::$input */
-        return $this->with('input', $values);
+        return $this->cloneWith('input', $values);
     }
 
     /**
@@ -189,7 +189,7 @@ final class StartWorkflowAction extends ScheduleAction
             : DateInterval::parse($timeout, DateInterval::FORMAT_SECONDS);
 
         /** @see self::$workflowExecutionTimeout */
-        return $this->with('workflowExecutionTimeout', $timeout);
+        return $this->cloneWith('workflowExecutionTimeout', $timeout);
     }
 
     /**
@@ -204,7 +204,7 @@ final class StartWorkflowAction extends ScheduleAction
             : DateInterval::parse($timeout, DateInterval::FORMAT_SECONDS);
 
         /** @see self::$workflowRunTimeout */
-        return $this->with('workflowRunTimeout', $timeout);
+        return $this->cloneWith('workflowRunTimeout', $timeout);
     }
 
     /**
@@ -219,13 +219,13 @@ final class StartWorkflowAction extends ScheduleAction
             : DateInterval::parse($timeout, DateInterval::FORMAT_SECONDS);
 
         /** @see self::$workflowTaskTimeout */
-        return $this->with('workflowTaskTimeout', $timeout);
+        return $this->cloneWith('workflowTaskTimeout', $timeout);
     }
 
     public function withWorkflowIdReusePolicy(IdReusePolicy $policy): self
     {
         /** @see self::$workflowIdReusePolicy */
-        return $this->with('workflowIdReusePolicy', $policy);
+        return $this->cloneWith('workflowIdReusePolicy', $policy);
     }
 
     /**
@@ -234,7 +234,7 @@ final class StartWorkflowAction extends ScheduleAction
     public function withRetryPolicy(RetryOptions $retryPolicy): self
     {
         /** @see self::$retryPolicy */
-        return $this->with('retryPolicy', $retryPolicy);
+        return $this->cloneWith('retryPolicy', $retryPolicy);
     }
 
     /**
@@ -247,7 +247,7 @@ final class StartWorkflowAction extends ScheduleAction
         $values instanceof EncodedCollection or $values = EncodedCollection::fromValues($values);
 
         /** @see self::$memo */
-        return $this->with('memo', $values);
+        return $this->cloneWith('memo', $values);
     }
 
     /**
@@ -260,7 +260,7 @@ final class StartWorkflowAction extends ScheduleAction
         $values instanceof EncodedCollection or $values = EncodedCollection::fromValues($values);
 
         /** @see self::$searchAttributes */
-        return $this->with('searchAttributes', $values);
+        return $this->cloneWith('searchAttributes', $values);
     }
 
     /**
@@ -273,7 +273,7 @@ final class StartWorkflowAction extends ScheduleAction
         $values instanceof HeaderInterface or $values = \Temporal\Interceptor\Header::fromValues($values);
 
         /** @see self::$header */
-        return $this->with('header', $values);
+        return $this->cloneWith('header', $values);
     }
 
     /**
@@ -286,7 +286,7 @@ final class StartWorkflowAction extends ScheduleAction
     public function withStaticSummary(string $summary): self
     {
         /** @see self::$userMetadata */
-        return $this->with('userMetadata', $this->userMetadata->withSummary($summary));
+        return $this->cloneWith('userMetadata', $this->userMetadata->withSummary($summary));
     }
 
     /**
@@ -300,7 +300,7 @@ final class StartWorkflowAction extends ScheduleAction
     public function withStaticDetails(string $details): self
     {
         /** @see self::$userMetadata */
-        return $this->with('userMetadata', $this->userMetadata->withDetails($details));
+        return $this->cloneWith('userMetadata', $this->userMetadata->withDetails($details));
     }
 
     private static function createWorkflowType(string $name): WorkflowType

--- a/src/Client/Schedule/BackfillPeriod.php
+++ b/src/Client/Schedule/BackfillPeriod.php
@@ -51,7 +51,7 @@ final class BackfillPeriod
     public function withStartTime(\DateTimeInterface|string $dateTime): self
     {
         /** @see self::$startTime */
-        return $this->with('startTime', DateTime::parse($dateTime, class: \DateTimeImmutable::class));
+        return $this->cloneWith('startTime', DateTime::parse($dateTime, class: \DateTimeImmutable::class));
     }
 
     /**
@@ -60,7 +60,7 @@ final class BackfillPeriod
     public function withEndTime(\DateTimeInterface|string $dateTime): self
     {
         /** @see self::$endTime */
-        return $this->with('endTime', DateTime::parse($dateTime, class: \DateTimeImmutable::class));
+        return $this->cloneWith('endTime', DateTime::parse($dateTime, class: \DateTimeImmutable::class));
     }
 
     /**
@@ -69,6 +69,6 @@ final class BackfillPeriod
     public function withOverlapPolicy(ScheduleOverlapPolicy $overlapPolicy): self
     {
         /** @see self::$overlapPolicy */
-        return $this->with('overlapPolicy', $overlapPolicy);
+        return $this->cloneWith('overlapPolicy', $overlapPolicy);
     }
 }

--- a/src/Client/Schedule/Policy/SchedulePolicies.php
+++ b/src/Client/Schedule/Policy/SchedulePolicies.php
@@ -67,7 +67,7 @@ final class SchedulePolicies
      */
     public function withOverlapPolicy(ScheduleOverlapPolicy $overlapPolicy): self
     {
-        return $this->with('overlapPolicy', $overlapPolicy);
+        return $this->cloneWith('overlapPolicy', $overlapPolicy);
     }
 
     /**
@@ -86,7 +86,7 @@ final class SchedulePolicies
         // Can't be less than 10 seconds.
         \assert($interval->totalSeconds >= 10);
 
-        return $this->with('catchupWindow', $interval);
+        return $this->cloneWith('catchupWindow', $interval);
     }
 
     /**
@@ -96,6 +96,6 @@ final class SchedulePolicies
      */
     public function withPauseOnFailure(bool $pauseOnFailure = true): self
     {
-        return $this->with('pauseOnFailure', $pauseOnFailure);
+        return $this->cloneWith('pauseOnFailure', $pauseOnFailure);
     }
 }

--- a/src/Client/Schedule/Schedule.php
+++ b/src/Client/Schedule/Schedule.php
@@ -60,24 +60,24 @@ final class Schedule
     public function withAction(?ScheduleAction $action): self
     {
         /** @see self::$action */
-        return $this->with('action', $action);
+        return $this->cloneWith('action', $action);
     }
 
     public function withSpec(ScheduleSpec $spec): self
     {
         /** @see self::$spec */
-        return $this->with('spec', $spec);
+        return $this->cloneWith('spec', $spec);
     }
 
     public function withPolicies(SchedulePolicies $policies): self
     {
         /** @see self::$policies */
-        return $this->with('policies', $policies);
+        return $this->cloneWith('policies', $policies);
     }
 
     public function withState(ScheduleState $state): self
     {
         /** @see self::$state */
-        return $this->with('state', $state);
+        return $this->cloneWith('state', $state);
     }
 }

--- a/src/Client/Schedule/ScheduleOptions.php
+++ b/src/Client/Schedule/ScheduleOptions.php
@@ -51,7 +51,7 @@ final class ScheduleOptions
     public function withNamespace(string $namespace): self
     {
         /** @see self::$namespace */
-        return $this->with('namespace', $namespace);
+        return $this->cloneWith('namespace', $namespace);
     }
 
     /**
@@ -60,7 +60,7 @@ final class ScheduleOptions
     public function withTriggerImmediately(bool $value): self
     {
         /** @see self::$triggerImmediately */
-        return $this->with('triggerImmediately', $value);
+        return $this->cloneWith('triggerImmediately', $value);
     }
 
     /**
@@ -72,7 +72,7 @@ final class ScheduleOptions
     public function withBackfills(BackfillPeriod ...$values): self
     {
         /** @see self::$backfills */
-        return $this->with('backfills', $values);
+        return $this->cloneWith('backfills', $values);
     }
 
     /**
@@ -84,7 +84,7 @@ final class ScheduleOptions
     public function withAddedBackfill(BackfillPeriod $value): self
     {
         /** @see self::$backfills */
-        return $this->with('backfills', [...$this->backfills, $value]);
+        return $this->cloneWith('backfills', [...$this->backfills, $value]);
     }
 
     /**
@@ -97,7 +97,7 @@ final class ScheduleOptions
         $values instanceof EncodedCollection or $values = EncodedCollection::fromValues($values);
 
         /** @see self::$memo */
-        return $this->with('memo', $values);
+        return $this->cloneWith('memo', $values);
     }
 
     /**
@@ -113,6 +113,6 @@ final class ScheduleOptions
         $values instanceof EncodedCollection or $values = EncodedCollection::fromValues($values);
 
         /** @see self::$searchAttributes */
-        return $this->with('searchAttributes', $values);
+        return $this->cloneWith('searchAttributes', $values);
     }
 }

--- a/src/Client/Schedule/Spec/CalendarSpec.php
+++ b/src/Client/Schedule/Spec/CalendarSpec.php
@@ -88,42 +88,42 @@ final class CalendarSpec
 
     public function withSecond(string|int $second): self
     {
-        return $this->with('second', (string) $second);
+        return $this->cloneWith('second', (string) $second);
     }
 
     public function withMinute(string|int $minute): self
     {
-        return $this->with('minute', (string) $minute);
+        return $this->cloneWith('minute', (string) $minute);
     }
 
     public function withHour(string|int $hour): self
     {
-        return $this->with('hour', (string) $hour);
+        return $this->cloneWith('hour', (string) $hour);
     }
 
     public function withDayOfMonth(string|int $dayOfMonth): self
     {
-        return $this->with('dayOfMonth', (string) $dayOfMonth);
+        return $this->cloneWith('dayOfMonth', (string) $dayOfMonth);
     }
 
     public function withMonth(string|int $month): self
     {
-        return $this->with('month', (string) $month);
+        return $this->cloneWith('month', (string) $month);
     }
 
     public function withYear(string|int $year): self
     {
-        return $this->with('year', (string) $year);
+        return $this->cloneWith('year', (string) $year);
     }
 
     public function withDayOfWeek(string|int $dayOfWeek): self
     {
-        return $this->with('dayOfWeek', (string) $dayOfWeek);
+        return $this->cloneWith('dayOfWeek', (string) $dayOfWeek);
     }
 
     public function withComment(string $comment): self
     {
         /** @see self::$comment */
-        return $this->with('comment', $comment);
+        return $this->cloneWith('comment', $comment);
     }
 }

--- a/src/Client/Schedule/Spec/IntervalSpec.php
+++ b/src/Client/Schedule/Spec/IntervalSpec.php
@@ -50,7 +50,7 @@ final class IntervalSpec
         \assert(DateInterval::assert($interval));
         $interval = DateInterval::parse($interval, DateInterval::FORMAT_SECONDS);
 
-        return $this->with('interval', $interval);
+        return $this->cloneWith('interval', $interval);
     }
 
     public function withPhase(mixed $phase): self
@@ -58,6 +58,6 @@ final class IntervalSpec
         \assert(DateInterval::assert($phase));
         $phase = DateInterval::parse($phase, DateInterval::FORMAT_SECONDS);
 
-        return $this->with('phase', $phase);
+        return $this->cloneWith('phase', $phase);
     }
 }

--- a/src/Client/Schedule/Spec/Range.php
+++ b/src/Client/Schedule/Spec/Range.php
@@ -50,7 +50,7 @@ final class Range
      */
     public function withStart(int $start): self
     {
-        return $this->with('start', $start);
+        return $this->cloneWith('start', $start);
     }
 
     /**
@@ -59,7 +59,7 @@ final class Range
     public function withEnd(int $end): self
     {
         \assert($end >= $this->start, 'End must be greater than or equal to start.');
-        return $this->with('end', $end);
+        return $this->cloneWith('end', $end);
     }
 
     /**
@@ -68,6 +68,6 @@ final class Range
     public function withStep(int $step): self
     {
         \assert($step > 0, 'Step must be greater than 0.');
-        return $this->with('step', $step);
+        return $this->cloneWith('step', $step);
     }
 }

--- a/src/Client/Schedule/Spec/ScheduleSpec.php
+++ b/src/Client/Schedule/Spec/ScheduleSpec.php
@@ -145,7 +145,7 @@ final class ScheduleSpec
     public function withStructuredCalendarList(StructuredCalendarSpec ...$structuredCalendar): self
     {
         /** @see self::$structuredCalendarList */
-        return $this->with('structuredCalendarList', $structuredCalendar);
+        return $this->cloneWith('structuredCalendarList', $structuredCalendar);
     }
 
     /**
@@ -157,7 +157,7 @@ final class ScheduleSpec
         $value[] = $structuredCalendar;
 
         /** @see self::$structuredCalendarList */
-        return $this->with('structuredCalendarList', $value);
+        return $this->cloneWith('structuredCalendarList', $value);
     }
 
     /**
@@ -166,7 +166,7 @@ final class ScheduleSpec
     public function withCronStringList(\Stringable|string ...$cron): self
     {
         /** @see self::$cronStringList */
-        return $this->with('cronStringList', \array_map(static fn($item) => (string) $item, $cron));
+        return $this->cloneWith('cronStringList', \array_map(static fn($item) => (string) $item, $cron));
     }
 
     /**
@@ -182,7 +182,7 @@ final class ScheduleSpec
         $value[] = (string) $cron;
 
         /** @see self::$cronStringList */
-        return $this->with('cronStringList', $value);
+        return $this->cloneWith('cronStringList', $value);
     }
 
     /**
@@ -191,7 +191,7 @@ final class ScheduleSpec
     public function withCalendarList(CalendarSpec ...$calendar): self
     {
         /** @see self::$calendarList */
-        return $this->with('calendarList', \array_values($calendar));
+        return $this->cloneWith('calendarList', \array_values($calendar));
     }
 
     /**
@@ -203,7 +203,7 @@ final class ScheduleSpec
         $value[] = $calendar;
 
         /** @see self::$calendarList */
-        return $this->with('calendarList', $value);
+        return $this->cloneWith('calendarList', $value);
     }
 
     /**
@@ -223,7 +223,7 @@ final class ScheduleSpec
         }
 
         /** @see self::$intervalList */
-        return $this->with('intervalList', $interval);
+        return $this->cloneWith('intervalList', $interval);
     }
 
     /**
@@ -242,7 +242,7 @@ final class ScheduleSpec
         }
 
         /** @see self::$intervalList */
-        return $this->with('intervalList', $value);
+        return $this->cloneWith('intervalList', $value);
     }
 
     /**
@@ -255,7 +255,7 @@ final class ScheduleSpec
         @\trigger_error('ScheduleSpec::withExcludeCalendarList() is deprecated', E_USER_DEPRECATED);
 
         /** @see self::$excludeCalendarList */
-        return $this->with('excludeCalendarList', $calendar);
+        return $this->cloneWith('excludeCalendarList', $calendar);
     }
 
     /**
@@ -270,7 +270,7 @@ final class ScheduleSpec
         $value[] = $calendar;
 
         /** @see self::$excludeCalendarList */
-        return $this->with('excludeCalendarList', $value);
+        return $this->cloneWith('excludeCalendarList', $value);
     }
 
     /**
@@ -279,7 +279,7 @@ final class ScheduleSpec
     public function withExcludeStructuredCalendarList(StructuredCalendarSpec ...$structuredCalendar): self
     {
         /** @see self::$excludeStructuredCalendarList */
-        return $this->with('excludeStructuredCalendarList', $structuredCalendar);
+        return $this->cloneWith('excludeStructuredCalendarList', $structuredCalendar);
     }
 
     /**
@@ -291,7 +291,7 @@ final class ScheduleSpec
         $value[] = $structuredCalendar;
 
         /** @see self::$excludeStructuredCalendarList */
-        return $this->with('excludeStructuredCalendarList', $value);
+        return $this->cloneWith('excludeStructuredCalendarList', $value);
     }
 
     /**
@@ -301,7 +301,7 @@ final class ScheduleSpec
     public function withStartTime(\DateTimeInterface|string|null $dateTime): self
     {
         /** @see self::$startTime */
-        return $this->with('startTime', $dateTime === null ? null : DateTime::parse($dateTime));
+        return $this->cloneWith('startTime', $dateTime === null ? null : DateTime::parse($dateTime));
     }
 
     /**
@@ -310,7 +310,7 @@ final class ScheduleSpec
     public function withEndTime(\DateTimeInterface|string|null $dateTime): self
     {
         /** @see self::$endTime */
-        return $this->with('endTime', $dateTime === null ? null : DateTime::parse($dateTime));
+        return $this->cloneWith('endTime', $dateTime === null ? null : DateTime::parse($dateTime));
     }
 
     /**
@@ -324,14 +324,14 @@ final class ScheduleSpec
         /** @psalm-suppress RiskyTruthyFalsyComparison */
         if (empty($interval)) {
             /** @see self::$jitter */
-            return $this->with('jitter', new \DateInterval('PT0S'));
+            return $this->cloneWith('jitter', new \DateInterval('PT0S'));
         }
 
         \assert(DateInterval::assert($interval));
         $interval = DateInterval::parse($interval, DateInterval::FORMAT_SECONDS);
 
         /** @see self::$jitter */
-        return $this->with('jitter', $interval);
+        return $this->cloneWith('jitter', $interval);
     }
 
     /**
@@ -356,12 +356,12 @@ final class ScheduleSpec
     public function withTimezoneName(string $timezoneName): self
     {
         /** @see self::$timezoneName */
-        return $this->with('timezoneName', $timezoneName);
+        return $this->cloneWith('timezoneName', $timezoneName);
     }
 
     public function withTimezoneData(string $timezoneData): self
     {
         /** @see self::$timezoneData */
-        return $this->with('timezoneData', $timezoneData);
+        return $this->cloneWith('timezoneData', $timezoneData);
     }
 }

--- a/src/Client/Schedule/Spec/ScheduleState.php
+++ b/src/Client/Schedule/Spec/ScheduleState.php
@@ -68,7 +68,7 @@ final class ScheduleState
      */
     public function withNotes(string $notes): self
     {
-        return $this->with('notes', $notes);
+        return $this->cloneWith('notes', $notes);
     }
 
     /**
@@ -76,7 +76,7 @@ final class ScheduleState
      */
     public function withPaused(bool $paused): self
     {
-        return $this->with('paused', $paused);
+        return $this->cloneWith('paused', $paused);
     }
 
     /**
@@ -90,7 +90,7 @@ final class ScheduleState
      */
     public function withLimitedActions(bool $limitedActions): self
     {
-        return $this->with('limitedActions', $limitedActions);
+        return $this->cloneWith('limitedActions', $limitedActions);
     }
 
     /**
@@ -98,6 +98,6 @@ final class ScheduleState
      */
     public function withRemainingActions(int $remainingActions): self
     {
-        return $this->with('remainingActions', $remainingActions);
+        return $this->cloneWith('remainingActions', $remainingActions);
     }
 }

--- a/src/Client/Schedule/Spec/StructuredCalendarSpec.php
+++ b/src/Client/Schedule/Spec/StructuredCalendarSpec.php
@@ -90,90 +90,90 @@ final class StructuredCalendarSpec
 
     public function withSeconds(Range ...$seconds): self
     {
-        return $this->with('seconds', $seconds);
+        return $this->cloneWith('seconds', $seconds);
     }
 
     public function withAddedSecond(Range $second): self
     {
         $value = $this->seconds;
         $value[] = $second;
-        return $this->with('seconds', $value);
+        return $this->cloneWith('seconds', $value);
     }
 
     public function withMinutes(Range ...$minutes): self
     {
-        return $this->with('minutes', $minutes);
+        return $this->cloneWith('minutes', $minutes);
     }
 
     public function withAddedMinute(Range $minute): self
     {
         $value = $this->minutes;
         $value[] = $minute;
-        return $this->with('minutes', $value);
+        return $this->cloneWith('minutes', $value);
     }
 
     public function withHours(Range ...$hours): self
     {
-        return $this->with('hours', $hours);
+        return $this->cloneWith('hours', $hours);
     }
 
     public function withAddedHour(Range $hour): self
     {
         $value = $this->hours;
         $value[] = $hour;
-        return $this->with('hours', $value);
+        return $this->cloneWith('hours', $value);
     }
 
     public function withDaysOfMonth(Range ...$daysOfMonth): self
     {
-        return $this->with('daysOfMonth', $daysOfMonth);
+        return $this->cloneWith('daysOfMonth', $daysOfMonth);
     }
 
     public function withAddedDayOfMonth(Range $dayOfMonth): self
     {
         $value = $this->daysOfMonth;
         $value[] = $dayOfMonth;
-        return $this->with('daysOfMonth', $value);
+        return $this->cloneWith('daysOfMonth', $value);
     }
 
     public function withMonths(Range ...$months): self
     {
-        return $this->with('months', $months);
+        return $this->cloneWith('months', $months);
     }
 
     public function withAddedMonth(Range $month): self
     {
         $value = $this->months;
         $value[] = $month;
-        return $this->with('months', $value);
+        return $this->cloneWith('months', $value);
     }
 
     public function withYears(Range ...$years): self
     {
-        return $this->with('years', $years);
+        return $this->cloneWith('years', $years);
     }
 
     public function withAddedYear(Range $year): self
     {
         $value = $this->years;
         $value[] = $year;
-        return $this->with('years', $value);
+        return $this->cloneWith('years', $value);
     }
 
     public function withDaysOfWeek(Range ...$daysOfWeek): self
     {
-        return $this->with('daysOfWeek', $daysOfWeek);
+        return $this->cloneWith('daysOfWeek', $daysOfWeek);
     }
 
     public function withAddedDayOfWeek(Range $dayOfWeek): self
     {
         $value = $this->daysOfWeek;
         $value[] = $dayOfWeek;
-        return $this->with('daysOfWeek', $value);
+        return $this->cloneWith('daysOfWeek', $value);
     }
 
     public function withComment(string $comment): self
     {
-        return $this->with('comment', $comment);
+        return $this->cloneWith('comment', $comment);
     }
 }

--- a/src/Client/Schedule/Update/ScheduleUpdate.php
+++ b/src/Client/Schedule/Update/ScheduleUpdate.php
@@ -44,7 +44,7 @@ final class ScheduleUpdate
     public function withSchedule(Schedule $schedule): self
     {
         /** @see self::$schedule */
-        return $this->with('schedule', $schedule);
+        return $this->cloneWith('schedule', $schedule);
     }
 
     /**
@@ -54,6 +54,6 @@ final class ScheduleUpdate
     public function withSearchAttributes(?EncodedCollection $searchAttributes = null): self
     {
         /** @see self::$searchAttributes */
-        return $this->with('searchAttributes', $searchAttributes);
+        return $this->cloneWith('searchAttributes', $searchAttributes);
     }
 }

--- a/src/Client/Update/UpdateOptions.php
+++ b/src/Client/Update/UpdateOptions.php
@@ -46,7 +46,7 @@ final class UpdateOptions
     public function withUpdateName(string $name): self
     {
         /** @see self::$updateName */
-        return $this->with('updateName', $name);
+        return $this->cloneWith('updateName', $name);
     }
 
     /**
@@ -55,7 +55,7 @@ final class UpdateOptions
     public function withWaitPolicy(WaitPolicy $policy): self
     {
         /** @see self::$waitPolicy */
-        return $this->with('waitPolicy', $policy);
+        return $this->cloneWith('waitPolicy', $policy);
     }
 
     /**
@@ -65,7 +65,7 @@ final class UpdateOptions
     public function withUpdateId(?string $id): self
     {
         /** @see self::$updateId */
-        return $this->with('updateId', $id);
+        return $this->cloneWith('updateId', $id);
     }
 
     /**
@@ -75,7 +75,7 @@ final class UpdateOptions
     public function withFirstExecutionRunId(?string $runId): self
     {
         /** @see self::$firstExecutionRunId */
-        return $this->with('firstExecutionRunId', $runId);
+        return $this->cloneWith('firstExecutionRunId', $runId);
     }
 
     /**
@@ -84,6 +84,6 @@ final class UpdateOptions
     public function withResultType(mixed $type): self
     {
         /** @see self::$resultType */
-        return $this->with('resultType', $type);
+        return $this->cloneWith('resultType', $type);
     }
 }

--- a/src/Client/Update/WaitPolicy.php
+++ b/src/Client/Update/WaitPolicy.php
@@ -39,6 +39,6 @@ final class WaitPolicy
     public function withLifecycleStage(LifecycleStage $value): self
     {
         /** @see self::$lifecycleStage */
-        return $this->with('lifecycleStage', $value);
+        return $this->cloneWith('lifecycleStage', $value);
     }
 }

--- a/src/Client/Workflow/UserMetadata.php
+++ b/src/Client/Workflow/UserMetadata.php
@@ -38,12 +38,12 @@ final class UserMetadata
     public function withSummary(string $summary): self
     {
         /** @see self::$summary */
-        return $this->with('summary', $summary);
+        return $this->cloneWith('summary', $summary);
     }
 
     public function withDetails(string $details): self
     {
         /** @see self::$details */
-        return $this->with('details', $details);
+        return $this->cloneWith('details', $details);
     }
 }

--- a/src/Common/TaskQueue/TaskQueue.php
+++ b/src/Common/TaskQueue/TaskQueue.php
@@ -31,7 +31,7 @@ final class TaskQueue implements \Stringable
     public function withName(string $name): self
     {
         /** @see self::$name */
-        return $this->with('name', $name);
+        return $this->cloneWith('name', $name);
     }
 
     public function __toString(): string

--- a/src/Internal/Traits/CloneWith.php
+++ b/src/Internal/Traits/CloneWith.php
@@ -12,7 +12,7 @@ trait CloneWith
     /**
      * Return a new immutable instance with the specified property value.
      */
-    private function with(string $key, mixed $value): static
+    private function cloneWith(string $key, mixed $value): static
     {
         $new = (new \ReflectionClass($this))->newInstanceWithoutConstructor();
         $new->{$key} = $value;

--- a/src/Worker/ServiceCredentials.php
+++ b/src/Worker/ServiceCredentials.php
@@ -44,6 +44,6 @@ final class ServiceCredentials
     public function withApiKey(string $key): static
     {
         /** @see self::$apiKey */
-        return $this->with('apiKey', $key);
+        return $this->cloneWith('apiKey', $key);
     }
 }

--- a/src/Worker/WorkerDeploymentOptions.php
+++ b/src/Worker/WorkerDeploymentOptions.php
@@ -53,7 +53,7 @@ class WorkerDeploymentOptions
     public function withUseVersioning(bool $value): self
     {
         /** @see self::$useVersioning */
-        return $this->with('useVersioning', $value);
+        return $this->cloneWith('useVersioning', $value);
     }
 
     /**
@@ -64,7 +64,7 @@ class WorkerDeploymentOptions
     public function withVersion(string|WorkerDeploymentVersion $version): self
     {
         /** @see self::$version */
-        return $this->with('version', \is_string($version) ? WorkerDeploymentVersion::fromString($version) : $version);
+        return $this->cloneWith('version', \is_string($version) ? WorkerDeploymentVersion::fromString($version) : $version);
     }
 
     /**
@@ -74,6 +74,6 @@ class WorkerDeploymentOptions
     public function withDefaultVersioningBehavior(VersioningBehavior $behavior): self
     {
         /** @see self::$defaultVersioningBehavior */
-        return $this->with('defaultVersioningBehavior', $behavior);
+        return $this->cloneWith('defaultVersioningBehavior', $behavior);
     }
 }

--- a/src/Workflow/TimerOptions.php
+++ b/src/Workflow/TimerOptions.php
@@ -42,6 +42,6 @@ final class TimerOptions
     public function withSummary(string $summary): self
     {
         /** @see self::$summary */
-        return $this->with('summary', $summary);
+        return $this->cloneWith('summary', $summary);
     }
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Renamed `CloneWith::with` to `CloneWith::cloneWith`
Separated from #661 