### PR TITLE
Add env ROADRUNNER_BINARY in testing module

### DIFF
--- a/testing/src/SystemInfo.php
+++ b/testing/src/SystemInfo.php
@@ -67,7 +67,7 @@ final class SystemInfo
             self::PLATFORM_MAPPINGS[$os],
             self::ARCHITECTURE_MAPPINGS[Architecture::createFromGlobals()],
             self::TEMPORAL_EXECUTABLE_MAP[$os],
-            self::RR_EXECUTABLE_MAP[$os],
+            \getenv('ROADRUNNER_BINARY') ?: self::RR_EXECUTABLE_MAP[$os],
             self::TEMPORAL_CLI_EXECUTABLE_MAP[$os],
         );
     }


### PR DESCRIPTION
## What was changed

Added env `ROADRUNNER_BINARY` into testing environment.

## Why?

We need to have an ability to configure RR executable in RoadRunner-Temporal plugin acceptance tests

## Checklist
<!--- add/delete as needed --->

2. How was this tested: tested manually
