### PR TITLE
Fix php 8.4 deprecations in unit tests

### DIFF
--- a/tests/Unit/Declaration/Fixture/FixedReader.php
+++ b/tests/Unit/Declaration/Fixture/FixedReader.php
@@ -18,7 +18,7 @@ use Temporal\Activity\LocalActivityInterface;
 
 class FixedReader implements ReaderInterface
 {
-    public function getClassMetadata(\ReflectionClass $class, string $name = null): iterable
+    public function getClassMetadata(\ReflectionClass $class, ?string $name = null): iterable
     {
         return [];
     }
@@ -36,7 +36,7 @@ class FixedReader implements ReaderInterface
         return null;
     }
 
-    public function getFunctionMetadata(\ReflectionFunctionAbstract $function, string $name = null): iterable
+    public function getFunctionMetadata(\ReflectionFunctionAbstract $function, ?string $name = null): iterable
     {
         return [];
     }
@@ -50,7 +50,7 @@ class FixedReader implements ReaderInterface
         return null;
     }
 
-    public function getPropertyMetadata(\ReflectionProperty $property, string $name = null): iterable
+    public function getPropertyMetadata(\ReflectionProperty $property, ?string $name = null): iterable
     {
         return [];
     }
@@ -60,7 +60,7 @@ class FixedReader implements ReaderInterface
         return null;
     }
 
-    public function getConstantMetadata(\ReflectionClassConstant $constant, string $name = null): iterable
+    public function getConstantMetadata(\ReflectionClassConstant $constant, ?string $name = null): iterable
     {
         return [];
     }
@@ -70,7 +70,7 @@ class FixedReader implements ReaderInterface
         return null;
     }
 
-    public function getParameterMetadata(\ReflectionParameter $parameter, string $name = null): iterable
+    public function getParameterMetadata(\ReflectionParameter $parameter, ?string $name = null): iterable
     {
         return [];
     }

--- a/tests/Unit/Worker/AutowiringTestCase.php
+++ b/tests/Unit/Worker/AutowiringTestCase.php
@@ -42,7 +42,7 @@ class AutowiringTestCase extends AbstractWorker
             static::class . '->instanceMethod' => [new \ReflectionMethod($instance, 'instanceMethod')],
 
             // Static Method
-            static::class . '::staticMethod' => [new \ReflectionMethod(static::class . '::staticMethod')],
+            static::class . '::staticMethod' => [new \ReflectionMethod(static::class, 'staticMethod')],
 
             // Function
             __NAMESPACE__ . '\\global_function' => [new \ReflectionFunction(__NAMESPACE__ . '\\global_function')],


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

removed deprecations from php 8.4 such as "types of nullable parameters must be nullable"

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
