### PR TITLE
fix issue 689: require grpc-extension in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "php": ">=8.1",
         "ext-curl": "*",
         "ext-json": "*",
+        "ext-grpc": "*",
         "google/common-protos": "^4.9",
         "google/protobuf": "^4.31.1",
         "grpc/grpc": "^1.57",

--- a/src/Client/GRPC/BaseClient.php
+++ b/src/Client/GRPC/BaseClient.php
@@ -68,10 +68,6 @@ abstract class BaseClient implements ServiceClientInterface
      */
     public static function create(string $address): static
     {
-        if (!\extension_loaded('grpc')) {
-            throw new \RuntimeException('The gRPC extension is required to use Temporal Client.');
-        }
-
         return new static(static fn(): WorkflowServiceClient => new WorkflowServiceClient(
             $address,
             ['credentials' => \Grpc\ChannelCredentials::createInsecure()],
@@ -96,10 +92,6 @@ abstract class BaseClient implements ServiceClientInterface
         ?string $clientPem = null,
         ?string $overrideServerName = null,
     ): static {
-        if (!\extension_loaded('grpc')) {
-            throw new \RuntimeException('The gRPC extension is required to use Temporal Client.');
-        }
-
         $loadCert = static function (?string $cert): ?string {
             return match (true) {
                 $cert === null, $cert === '' => null,


### PR DESCRIPTION
## What was changed

Availability of PHP's `grpc` extension is enforced in `composer.json` and not by using `extension_loaded` in the code.

## Why?

See https://github.com/temporalio/sdk-php/issues/689 for details.