### PR TITLE
fix: upgrade symfony/process lowest version to 5.4.51

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "symfony/filesystem": "^5.4.45 || ^6.4.13 || ^7.0 || ^8.0",
         "symfony/http-client": "^5.4.49 || ^6.4.17 || ^7.0 || ^8.0",
         "symfony/polyfill-php83": "^1.31.0",
-        "symfony/process": "^5.4.47 || ^6.4.15 || ^7.0 || ^8.0"
+        "symfony/process": "^5.4.51 || ^6.4.15 || ^7.0 || ^8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

## Why?
<!-- Tell your future self why have you made these changes -->

Fixes
```
1 error (make sure you ran `composer update --prefer-lowest` before):
 - symfony/process: Defined `5.4.47.0` as minimum, but is `5.4.51.0`
```

E.g. https://github.com/temporalio/sdk-php/actions/runs/21472795424/job/61849269894?pr=705

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
