### PR TITLE
fix: broken testing environment start due to changes in startTemporalServer

### DIFF
--- a/testing/src/Environment.php
+++ b/testing/src/Environment.php
@@ -123,7 +123,7 @@ final class Environment
         $this->temporalServerProcess->start();
 
         $deadline = \microtime(true) + $commandTimeout;
-        while (!$temporalStarted && \microtime(true) < $deadline) {
+        while ($this->temporalServerProcess->isRunning() && !$temporalStarted && \microtime(true) < $deadline) {
             \usleep(10_000);
             $check = new Process([
                 $this->systemInfo->temporalCliExecutable,
@@ -192,7 +192,7 @@ final class Environment
     /**
      * @param array<string, mixed> $envs
      */
-    public function startRoadRunner(?string $rrCommand = null, int $commandTimeout = 10, array $envs = [], string $configFile = '.rr.yaml'): void
+    public function startRoadRunner(string|array|null $rrCommand = null, int $commandTimeout = 10, array $envs = [], string $configFile = '.rr.yaml'): void
     {
         if (!$this->isTemporalRunning() && !$this->isTemporalTestRunning()) {
             $this->io->error([
@@ -201,8 +201,14 @@ final class Environment
             exit(1);
         }
 
+        if (is_string($rrCommand)) {
+            $rrCommand = \explode(' ', $rrCommand);
+        }
+
+        $rrCommand ??= [$this->systemInfo->rrExecutable, 'serve', '-c', $configFile];
+
         $this->roadRunnerProcess = new Process(
-            command: $rrCommand ? \explode(' ', $rrCommand) : [$this->systemInfo->rrExecutable, 'serve'],
+            command: $rrCommand,
             env: $envs,
         );
         $this->roadRunnerProcess->setTimeout($commandTimeout);
@@ -214,16 +220,16 @@ final class Environment
 
         // wait for roadrunner to start
         $deadline = \microtime(true) + $commandTimeout;
-        while (!$roadRunnerStarted && \microtime(true) < $deadline) {
+        while ($this->roadRunnerProcess->isRunning() && !$roadRunnerStarted && \microtime(true) < $deadline) {
             \usleep(10_000);
-            $check = new Process([$this->systemInfo->rrExecutable, 'workers', '-c', $configFile]);
+            $check = new Process(array_map(static fn ($arg) => $arg === 'serve' ? 'workers' : $arg, $rrCommand));
             $check->run();
             if (\str_contains($check->getOutput(), 'Workers of')) {
                 $roadRunnerStarted = true;
             }
         }
 
-        if (!$roadRunnerStarted) {
+        if (!$roadRunnerStarted || !$this->roadRunnerProcess->isRunning()) {
             $this->io->error(\sprintf(
                 'Failed to start until RoadRunner is ready. Status: "%s". Stderr: "%s". Stdout: "%s".',
                 $this->roadRunnerProcess->getStatus(),


### PR DESCRIPTION
## What was changed
Changed `Temporal\Testing\Environment::startRoadRunner` to accept array for `$rrCommand` and to use it also in its check loop.

## Why?
There are two new issues in version 2.17 of the testing environment that were not present in 2.15.

1. In `Temporal\Testing\Environment` the `start` method only accepts `array|null` for its `$rrCommand` parameter, but this parameter is passed as-is to `startRoadRunner`, which instead only accepts `string|null`, making this effectively only work when `$rrCommand === null`.

2. `startRoadRunner` completely disregards the passed-in `$rrCommand` for executing the `workers` command when checking the status of the server. This may work sometimes but depending on the specific custom command used it's likely wrong.

I kind of fixed this by replacing the `serve` command with `workers` but I don't particularly like this either.

While fixing this I changed the while loop that tests the server to quickly exit the loop if the command is not running anymore, instead of waiting for the timeout, and I did the same in `startTemporalServer`.

## Checklist
- How was this tested: I made this changes to fix my project that broke due to the wrong type signatures, the fix is confirmed by testing it on that same project.