### PR TITLE
test: remove unused TemporalStarter dependency from DeploymentTest causing temporal server reboot

### DIFF
--- a/testing/src/Environment.php
+++ b/testing/src/Environment.php
@@ -256,6 +256,9 @@ final class Environment
 
         $process = new Process($command);
         $process->setTimeout($timeout);
+
+        $this->io->info('Executing Temporal Command: ' . $this->serializeProcess($process));
+
         $process->run();
     }
 
@@ -304,7 +307,7 @@ final class Environment
         return $this->temporalTestServerProcess?->isRunning() === true;
     }
 
-    private function serializeProcess(?Process $temporalServerProcess): string|array
+    private function serializeProcess(?Process $temporalServerProcess): string
     {
         $reflection = new \ReflectionClass($temporalServerProcess);
         $reflectionProperty = $reflection->getProperty('commandline');

--- a/tests/Acceptance/Extra/Versioning/DeploymentTest.php
+++ b/tests/Acceptance/Extra/Versioning/DeploymentTest.php
@@ -30,14 +30,12 @@ class DeploymentTest extends TestCase
     public function defaultBehaviorAuto(
         Environment $environment,
         RRStarter $roadRunnerStarter,
-        TemporalStarter $starter,
         WorkflowClientInterface $client,
         Feature $feature,
     ): void {
         $behavior = self::executeWorkflow(
             $environment,
             $roadRunnerStarter,
-            $starter,
             $client,
             $feature,
             /** @see DefaultWorkflow */
@@ -51,7 +49,6 @@ class DeploymentTest extends TestCase
     public function customBehaviorPinned(
         Environment $environment,
         RRStarter $roadRunnerStarter,
-        TemporalStarter $starter,
         WorkflowClientInterface $client,
         Feature $feature,
     ): void {
@@ -59,7 +56,6 @@ class DeploymentTest extends TestCase
         self::executeWorkflow(
             $environment,
             $roadRunnerStarter,
-            $starter,
             $client,
             $feature,
             /** @see PinnedWorkflow */
@@ -86,7 +82,6 @@ class DeploymentTest extends TestCase
     public function versionBehaviorOverrideAutoUpgrade(
         Environment $environment,
         RRStarter $roadRunnerStarter,
-        TemporalStarter $starter,
         WorkflowClientInterface $client,
         Feature $feature,
     ): void {
@@ -94,7 +89,6 @@ class DeploymentTest extends TestCase
         self::executeWorkflow(
             $environment,
             $roadRunnerStarter,
-            $starter,
             $client,
             $feature,
             /** @see PinnedWorkflow */
@@ -121,14 +115,12 @@ class DeploymentTest extends TestCase
     public function versionBehaviorOverridePinned(
         Environment $environment,
         RRStarter $roadRunnerStarter,
-        TemporalStarter $starter,
         WorkflowClientInterface $client,
         Feature $feature,
     ): void {
         $behavior = self::executeWorkflow(
             $environment,
             $roadRunnerStarter,
-            $starter,
             $client,
             $feature,
             /** @see PinnedWorkflow */
@@ -151,7 +143,6 @@ class DeploymentTest extends TestCase
     private static function executeWorkflow(
         Environment $environment,
         RRStarter $roadRunnerStarter,
-        TemporalStarter $temporalStarter,
         WorkflowClientInterface $client,
         Feature $feature,
         string $workflowType,
@@ -200,8 +191,7 @@ class DeploymentTest extends TestCase
             $postAction === null or $postAction($behavior);
             return $behavior;
         } finally {
-            $temporalStarter->stop();
-            $temporalStarter->start();
+            $roadRunnerStarter->stop();
             $roadRunnerStarter->start();
         }
     }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

- Removed Temporal server restart

## Why?
<!-- Tell your future self why have you made these changes -->

- Temporal server restart took too long and code timers didn't fire on time
- Although they pass locally, it seems GitHub workers become overloaded and cannot process at regular speed

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
