### PR TITLE
chore: Update and pin all GHA actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,9 @@ permissions:
 
 jobs:
   docs:
+    permissions:
+      contents: read
+      actions: write
     name: Generating API documentation
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - "master"
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   docs:
     name: Generating API documentation

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,11 +10,11 @@ jobs:
     name: Generating API documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           submodules: recursive
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 20
 
@@ -23,7 +23,7 @@ jobs:
 
       - name: Cache phpDocumentor build files
         id: phpdocumentor-cache
-        uses: actions/cache@v3
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: .phpdoc/cache
           key: ${{ runner.os }}-phpdocumentor-${{ github.sha }}

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -43,6 +43,8 @@ permissions:
 
 jobs:
   test:
+    permissions:
+      contents: read
     name: PHP${{ matrix.php }}${{ matrix.extensions-suffix }}, ${{ matrix.os }}, ${{ matrix.dependencies }} deps
     runs-on: ${{ matrix.os }}
     timeout-minutes: ${{ inputs.test-timeout }}

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -65,10 +65,10 @@ jobs:
           git config --global core.eol lf
 
       - name: Check Out Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup PHP ${{ matrix.php }}
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, sockets, grpc, curl ${{ matrix.extensions-suffix }}
@@ -77,7 +77,7 @@ jobs:
         run: composer validate --strict
 
       - name: Install dependencies with composer
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@5c2bcf28d7b060ef3c601d7b476d5430a7b46c27 # v4
         with:
           dependency-versions: ${{ matrix.dependencies }}
 

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -38,6 +38,9 @@ on:
       - 'psalm-baseline.xml'
       - '.editorconfig'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: PHP${{ matrix.php }}${{ matrix.extensions-suffix }}, ${{ matrix.os }}, ${{ matrix.dependencies }} deps

--- a/.github/workflows/security-check.yml
+++ b/.github/workflows/security-check.yml
@@ -11,6 +11,8 @@ concurrency:
 
 jobs:
   security:
+    permissions:
+      contents: read
     name: Security Checks (PHP ${{ matrix.php }}, OS ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/security-check.yml
+++ b/.github/workflows/security-check.yml
@@ -18,16 +18,16 @@ jobs:
         os: [ ubuntu-latest ]
     steps:
       - name: Set up PHP ${{ matrix.php }}
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, sockets, grpc, curl
 
       - name: Check Out Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install dependencies with composer
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@5c2bcf28d7b060ef3c601d7b476d5430a7b46c27 # v4
         with:
           dependency-versions: ${{ matrix.dependencies }}
 

--- a/.github/workflows/security-check.yml
+++ b/.github/workflows/security-check.yml
@@ -2,6 +2,9 @@ name: Security
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 concurrency:
   cancel-in-progress: ${{ !contains(github.ref, 'release/')}}
   group: tests-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -2,6 +2,9 @@ name: Static Analysis
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 concurrency:
   cancel-in-progress: ${{ !contains(github.ref, 'release/')}}
   group: tests-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -18,16 +18,16 @@ jobs:
         os: [ubuntu-latest]
     steps:
       - name: Set up PHP ${{ matrix.php }}
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
         with:
           php-version: ${{ matrix.php }}
           extensions: dom
 
       - name: Check Out Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install dependencies with composer
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@5c2bcf28d7b060ef3c601d7b476d5430a7b46c27 # v4
         with:
           dependency-versions: ${{ matrix.dependencies }}
 
@@ -45,18 +45,18 @@ jobs:
         os: [ubuntu-latest]
     steps:
       - name: Set up PHP ${{ matrix.php }}
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
         with:
           php-version: ${{ matrix.php }}
           extensions: dom
 
       - name: Check Out Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
 
       - name: Install dependencies with composer
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@5c2bcf28d7b060ef3c601d7b476d5430a7b46c27 # v4
         with:
           dependency-versions: ${{ matrix.dependencies }}
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -11,6 +11,8 @@ concurrency:
 
 jobs:
   psalm:
+    permissions:
+      contents: read
     name: Psalm Validation (PHP ${{ matrix.php }}, OS ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     continue-on-error: true
@@ -38,6 +40,8 @@ jobs:
         run: vendor/bin/psalm
 
   arch:
+    permissions:
+      contents: read
     name: Architecture tests
     runs-on: ${{ matrix.os }}
     continue-on-error: true

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -11,6 +11,8 @@ concurrency:
 
 jobs:
   unit:
+    permissions:
+      contents: read
     name: Unit Testing
     uses: ./.github/workflows/run-test-suite.yml
     with:
@@ -18,6 +20,8 @@ jobs:
       test-command: composer test:unit
 
   functional:
+    permissions:
+      contents: read
     name: Functional Testing
     uses: ./.github/workflows/run-test-suite.yml
     with:
@@ -26,6 +30,8 @@ jobs:
       download-binaries: true
 
   acceptance-slow:
+    permissions:
+      contents: read
     name: Acceptance Testing (Slow)
     uses: ./.github/workflows/run-test-suite.yml
     with:
@@ -34,6 +40,8 @@ jobs:
       download-binaries: true
 
   acceptance-fast:
+    permissions:
+      contents: read
     name: Acceptance Testing (Fast)
     uses: ./.github/workflows/run-test-suite.yml
     with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -2,6 +2,9 @@ name: Testing
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 concurrency:
   cancel-in-progress: ${{ !contains(github.ref, 'release/')}}
   group: tests-${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## What changed

- Bump all GitHub Actions workflows to use latest "safe" releases.
  "Safe" is defined as the latest published release that is at least 2 weeks old (cooldown period).
- Pin all GHA actions usage to full SHA1, with a version comment.
- Add explicit GITHUB_TOKEN permissions in workflows

## Why

- Improved security.
