### PR TITLE
feat: collapse task queues to default by TaskQueueResolver

### DIFF
--- a/tests/Acceptance/App/RuntimeBuilder.php
+++ b/tests/Acceptance/App/RuntimeBuilder.php
@@ -91,7 +91,7 @@ final class RuntimeBuilder
             $feature = new Feature(
                 testClass: $class,
                 testNamespace: $namespace,
-                taskQueue: $namespace,
+                taskQueue: TaskQueueResolver::resolve($class, $namespace),
             );
 
             yield $feature => \array_filter(

--- a/tests/Acceptance/App/TaskQueueResolver.php
+++ b/tests/Acceptance/App/TaskQueueResolver.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Acceptance\App;
+
+use Temporal\Tests\Acceptance\App\Attribute\Worker;
+
+final class TaskQueueResolver
+{
+    public const DEFAULT_TASK_QUEUE = 'default';
+
+    /**
+     * @var list<class-string>
+     */
+    private const SHARED_QUEUE_EXCLUSIONS = [
+        \Temporal\Tests\Acceptance\Extra\Workflow\WorkflowA\WorkflowATest::class,
+        \Temporal\Tests\Acceptance\Extra\Workflow\WorkflowB\WorkflowBTest::class,
+        \Temporal\Tests\Acceptance\Harness\Activity\RetryOnError\RetryOnErrorTest::class,
+        \Temporal\Tests\Acceptance\Harness\Update\Self\SelfTest::class,
+        \Temporal\Tests\Acceptance\Harness\Update\Activities\ActivitiesTest::class,
+        \Temporal\Tests\Acceptance\Harness\Signal\Activities\ActivitiesTest::class,
+        \Temporal\Tests\Acceptance\Extra\Versioning\Classic\ClassicTest::class,
+        \Temporal\Tests\Acceptance\Extra\Versioning\Deployment\DeploymentTest::class,
+    ];
+
+    /**
+     * @param class-string $class
+     * @param non-empty-string $namespace
+     * @return non-empty-string
+     */
+    public static function resolve(string $class, string $namespace): string
+    {
+        if (\in_array($class, self::SHARED_QUEUE_EXCLUSIONS, true)) {
+            return $namespace;
+        }
+
+        $reflection = new \ReflectionClass($class);
+        foreach ($reflection->getAttributes(Worker::class) as $attribute) {
+            $worker = $attribute->newInstance();
+            if ($worker->pipelineProvider !== null
+                || $worker->logger !== null
+                || $worker->plugins !== null
+            ) {
+                return $namespace;
+            }
+        }
+
+        return self::DEFAULT_TASK_QUEUE;
+    }
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Let tests engine not create a new task queue on each test file

## Why?
<!-- Tell your future self why have you made these changes -->

This simplifies RR pollers job by reducing number of pollers.
Less task queues, less stream context switch

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
