### PR TITLE
fix: bump symfony/http-client dependency to ^5.4.53

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "spiral/roadrunner-kv": "^4.3.1",
         "spiral/roadrunner-worker": "^3.6.2",
         "symfony/filesystem": "^5.4.45 || ^6.4.13 || ^7.0 || ^8.0",
-        "symfony/http-client": "^5.4.49 || ^6.4.17 || ^7.0 || ^8.0",
+        "symfony/http-client": "^5.4.53 || ^6.4.17 || ^7.0 || ^8.0",
         "symfony/polyfill-php83": "^1.31.0",
         "symfony/process": "^5.4.51 || ^6.4.15 || ^7.0 || ^8.0"
     },


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
