### PR TITLE
feat: support typed results and pass firstExecutionRunId for update handlers

### DIFF
--- a/src/Internal/Client/WorkflowStarter.php
+++ b/src/Internal/Client/WorkflowStarter.php
@@ -158,7 +158,8 @@ final class WorkflowStarter
                     ->setWaitPolicy(
                         (new \Temporal\Api\Update\V1\WaitPolicy())
                             ->setLifecycleStage($input->updateInput->waitPolicy->lifecycleStage->value),
-                    );
+                    )
+                    ->setFirstExecutionRunId($input->updateInput->firstExecutionRunId);
 
                 // Configure Meta
                 $meta = new \Temporal\Api\Update\V1\Meta();
@@ -268,8 +269,8 @@ final class WorkflowStarter
                     Header::empty(),
                     $update->waitPolicy,
                     $update->updateId ?? Uuid::v4(),
-                    '',
-                    null, // todo?
+                    $update->firstExecutionRunId ?? '',
+                    $update->resultType,
                 ),
             ),
         );

--- a/tests/Acceptance/Extra/Update/UpdateWithStartTest.php
+++ b/tests/Acceptance/Extra/Update/UpdateWithStartTest.php
@@ -6,10 +6,13 @@ namespace Temporal\Tests\Acceptance\Extra\Update\UpdateWithStart;
 
 use PHPUnit\Framework\Attributes\Test;
 use Ramsey\Uuid\Uuid;
+use Temporal\Client\Update\LifecycleStage;
+use Temporal\Client\Update\UpdateOptions;
 use Temporal\Client\WorkflowClientInterface;
 use Temporal\Client\WorkflowOptions;
 use Temporal\Exception\Client\WorkflowExecutionAlreadyStartedException;
 use Temporal\Exception\Client\WorkflowFailedException;
+use Temporal\Exception\Client\WorkflowServiceException;
 use Temporal\Exception\Client\WorkflowUpdateException;
 use Temporal\Tests\Acceptance\App\Runtime\Feature;
 use Temporal\Tests\Acceptance\App\TestCase;
@@ -39,6 +42,49 @@ class UpdateWithStartTest extends TestCase
 
         $this->assertSame(['key' => null], (array)$result);
         $this->assertFalse($handle->hasResult());
+    }
+
+    #[Test]
+    public function returnsTypedUpdateResult(
+        WorkflowClientInterface $client,
+        Feature $feature,
+    ): void {
+        $stub = $client->newUntypedWorkflowStub(
+            'Extra_Update_UpdateWithStart',
+            WorkflowOptions::new()->withTaskQueue($feature->taskQueue),
+        );
+
+        $options = UpdateOptions::new('echo', LifecycleStage::StageCompleted)
+            ->withResultType(UpdateResult::class);
+
+        /** @see TestWorkflow::echo */
+        $handle = $client->updateWithStart($stub, $options, ['hello']);
+
+        $result = $handle->getResult();
+        $this->assertInstanceOf(UpdateResult::class, $result);
+        $this->assertSame('hello', $result->name);
+        $this->assertSame(5, $result->length);
+
+        $stub->signal('exit');
+        $stub->getResult();
+    }
+
+    #[Test]
+    public function rejectsFirstExecutionRunId(
+        WorkflowClientInterface $client,
+        Feature $feature,
+    ): void {
+        $stub = $client->newUntypedWorkflowStub(
+            'Extra_Update_UpdateWithStart',
+            WorkflowOptions::new()->withTaskQueue($feature->taskQueue),
+        );
+
+        $options = UpdateOptions::new('await', LifecycleStage::StageAccepted)
+            ->withFirstExecutionRunId(Uuid::uuid7()->__toString());
+
+        $this->expectException(WorkflowServiceException::class);
+        $this->expectExceptionMessage('FirstExecutionRunId is not allowed');
+        $client->updateWithStart($stub, $options, ['key']);
     }
 
     #[Test]
@@ -128,9 +174,24 @@ class TestWorkflow
         empty($name) and throw new \InvalidArgumentException('Name must not be empty');
     }
 
+    #[Workflow\UpdateMethod(name: 'echo')]
+    public function echo(string $name): UpdateResult
+    {
+        $this->updateStarted = true;
+        return new UpdateResult($name, \strlen($name));
+    }
+
     #[Workflow\SignalMethod]
     public function exit(): void
     {
         $this->exit = true;
     }
+}
+
+class UpdateResult
+{
+    public function __construct(
+        public string $name = '',
+        public int $length = 0,
+    ) {}
 }


### PR DESCRIPTION


<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

FirstExecutionRunId is now passed to Temporal server and it will cause `WorkflowServiceException` error if pass the id there

## Why?
<!-- Tell your future self why have you made these changes -->

Caller-side may use typed results instead of `stdClass`

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
