### PR TITLE
refactor: add TickInfo::applyTo and adopt it in command routers

### DIFF
--- a/src/Internal/Transport/Client.php
+++ b/src/Internal/Transport/Client.php
@@ -60,13 +60,7 @@ final class Client implements ClientInterface
 
         $info = $context->getInfo();
         if ($info !== null && $response->getTickInfo()->historyLength > $info->historyLength) {
-            $tickInfo = $response->getTickInfo();
-            /** @psalm-suppress InaccessibleProperty */
-            $info->historyLength = $tickInfo->historyLength;
-            /** @psalm-suppress InaccessibleProperty */
-            $info->historySize = $tickInfo->historySize;
-            /** @psalm-suppress InaccessibleProperty */
-            $info->shouldContinueAsNew = $tickInfo->continueAsNewSuggested;
+            $response->getTickInfo()->applyTo($info);
         }
 
         // Bind workflow context for promise resolution

--- a/src/Internal/Transport/Router/InvokeQuery.php
+++ b/src/Internal/Transport/Router/InvokeQuery.php
@@ -80,13 +80,7 @@ final class InvokeQuery extends WorkflowProcessAwareRoute
                     Workflow::setCurrentContext($context);
 
                     $info = $context->getInfo();
-                    $tickInfo = $request->getTickInfo();
-                    /** @psalm-suppress InaccessibleProperty */
-                    $info->historyLength = $tickInfo->historyLength;
-                    /** @psalm-suppress InaccessibleProperty */
-                    $info->historySize = $tickInfo->historySize;
-                    /** @psalm-suppress InaccessibleProperty */
-                    $info->shouldContinueAsNew = $tickInfo->continueAsNewSuggested;
+                    $request->getTickInfo()->applyTo($info);
 
                     $result = $handler(new QueryInput($name, $request->getPayloads(), $info));
                     $resolver->resolve(EncodedValues::fromValues([$result]));

--- a/src/Internal/Transport/Router/InvokeSignal.php
+++ b/src/Internal/Transport/Router/InvokeSignal.php
@@ -35,13 +35,7 @@ final class InvokeSignal extends WorkflowProcessAwareRoute
         $context = $this->findProcessOrFail($requestId)->getContext();
 
         $info = $context->getInfo();
-        $tickInfo = $request->getTickInfo();
-        /** @psalm-suppress InaccessibleProperty */
-        $info->historyLength = $tickInfo->historyLength;
-        /** @psalm-suppress InaccessibleProperty */
-        $info->historySize = $tickInfo->historySize;
-        /** @psalm-suppress InaccessibleProperty */
-        $info->shouldContinueAsNew = $tickInfo->continueAsNewSuggested;
+        $request->getTickInfo()->applyTo($info);
 
         $handler($request->getPayloads());
 

--- a/src/Internal/Transport/Router/InvokeUpdate.php
+++ b/src/Internal/Transport/Router/InvokeUpdate.php
@@ -38,13 +38,7 @@ final class InvokeUpdate extends WorkflowProcessAwareRoute
             $handler = $this->getUpdateHandler($updateDispatcher, $name);
 
             $info = $context->getInfo();
-            $tickInfo = $request->getTickInfo();
-            /** @psalm-suppress InaccessibleProperty */
-            $info->historyLength = $tickInfo->historyLength;
-            /** @psalm-suppress InaccessibleProperty */
-            $info->historySize = $tickInfo->historySize;
-            /** @psalm-suppress InaccessibleProperty */
-            $info->shouldContinueAsNew = $tickInfo->continueAsNewSuggested;
+            $request->getTickInfo()->applyTo($info);
 
             $input = new UpdateInput(
                 updateName: $name,

--- a/src/Internal/Transport/Router/StartWorkflow.php
+++ b/src/Internal/Transport/Router/StartWorkflow.php
@@ -70,13 +70,7 @@ final class StartWorkflow extends Route
         $input->header = $request->getHeader();
 
         $info = $input->info;
-        $tickInfo = $request->getTickInfo();
-        /** @psalm-suppress InaccessibleProperty */
-        $info->historyLength = $tickInfo->historyLength;
-        /** @psalm-suppress InaccessibleProperty */
-        $info->historySize = $tickInfo->historySize;
-        /** @psalm-suppress InaccessibleProperty */
-        $info->shouldContinueAsNew = $tickInfo->continueAsNewSuggested;
+        $request->getTickInfo()->applyTo($info);
 
         $instance = $this->instantiator->instantiate($this->findWorkflowOrFail($input->info));
 

--- a/src/Worker/Transport/Command/Server/TickInfo.php
+++ b/src/Worker/Transport/Command/Server/TickInfo.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace Temporal\Worker\Transport\Command\Server;
 
+use Temporal\Workflow\WorkflowInfo;
+
 final class TickInfo
 {
     /**
@@ -24,4 +26,14 @@ final class TickInfo
         public readonly bool $continueAsNewSuggested = false,
         public readonly bool $isReplaying = false,
     ) {}
+
+    /**
+     * @psalm-suppress InaccessibleProperty
+     */
+    public function applyTo(WorkflowInfo $info): void
+    {
+        $info->historyLength = $this->historyLength;
+        $info->historySize = $this->historySize;
+        $info->shouldContinueAsNew = $this->continueAsNewSuggested;
+    }
 }

--- a/tests/Unit/Worker/Transport/Command/Server/TickInfoTestCase.php
+++ b/tests/Unit/Worker/Transport/Command/Server/TickInfoTestCase.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\Worker\Transport\Command\Server;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use Temporal\Tests\Unit\AbstractUnit;
+use Temporal\Worker\Transport\Command\Server\TickInfo;
+use Temporal\Workflow\WorkflowInfo;
+
+#[CoversClass(TickInfo::class)]
+final class TickInfoTestCase extends AbstractUnit
+{
+    public function testApplyToCopiesHistoryAndContinueAsNew(): void
+    {
+        $info = new WorkflowInfo();
+        $tick = new TickInfo(
+            time: new \DateTimeImmutable('2026-01-01T00:00:00+00:00'),
+            historyLength: 42,
+            historySize: 1024,
+            continueAsNewSuggested: true,
+        );
+
+        $tick->applyTo($info);
+
+        self::assertSame(42, $info->historyLength);
+        self::assertSame(1024, $info->historySize);
+        self::assertTrue($info->shouldContinueAsNew);
+    }
+
+    public function testApplyToOverwritesPreviousValues(): void
+    {
+        $info = new WorkflowInfo();
+        $info->historyLength = 99;
+        $info->historySize = 99;
+        $info->shouldContinueAsNew = true;
+
+        (new TickInfo(time: new \DateTimeImmutable('2026-01-01T00:00:00+00:00')))->applyTo($info);
+
+        self::assertSame(0, $info->historyLength);
+        self::assertSame(0, $info->historySize);
+        self::assertFalse($info->shouldContinueAsNew);
+    }
+}


### PR DESCRIPTION

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

## Why?
<!-- Tell your future self why have you made these changes -->

Replace manual historyLength/historySize/shouldContinueAsNew assignments across Client and the Invoke*/StartWorkflow routers with a single TickInfo::applyTo(WorkflowInfo)

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
