### PR TITLE
VLN-1494: remediate unpinned-github-actions

### DIFF
--- a/.github/workflows/cs-fix.yml
+++ b/.github/workflows/cs-fix.yml
@@ -9,4 +9,4 @@ jobs:
   cs-fix:
     permissions:
       contents: write
-    uses: spiral/gh-actions/.github/workflows/cs-fix.yml@master
+    uses: spiral/gh-actions/.github/workflows/cs-fix.yml@aae1d25ea7303eeee3bf96a439388650fa2dbce9 # master


### PR DESCRIPTION
> 🏕️ This pull request was created by [camper](https://github.com/temporalio/camper), an automated security campaign tool.

## Finding

<table>
  <tr><td><strong>Rule</strong></td><td><code>unpinned-github-actions</code></td></tr>
  <tr><td><strong>Severity</strong></td><td>MEDIUM</td></tr>
  <tr><td><strong>Repository</strong></td><td><code>temporalio/sdk-php</code></td></tr>
  <tr><td><strong>Ticket</strong></td><td><a href="https://temporalio.atlassian.net/browse/VLN-1494">VLN-1494</a></td></tr>
</table>

## Summary

🤠 [Deputy](https://github.com/temporalio/deputy) pinned dependencies to immutable references.

- Total refs: 16
- Pinned refs: 1
- Already pinned: 15

Changed references:
- `spiral/gh-actions/.github/workflows/cs-fix.yml`: `master` -> `aae1d25ea7303eeee3bf96a439388650fa2dbce9 # master`

## Instructions

- **Approve** to merge this fix
- **Request changes** to trigger a new remediation attempt
- `/camper rebase` — rebase onto the base branch
- `/camper close` — close this PR without merging
- `/camper retry` — close and retry with a new fix