### PR TITLE
fix(client): generate update id client-side when not provided

### DIFF
--- a/src/Internal/Client/WorkflowStub.php
+++ b/src/Internal/Client/WorkflowStub.php
@@ -330,7 +330,7 @@ final class WorkflowStub implements WorkflowStubInterface, HeaderCarrier
             arguments: EncodedValues::fromValues($args, $this->converter),
             header: Header::empty(),
             waitPolicy: $nameOrOptions->waitPolicy,
-            updateId: $nameOrOptions->updateId ?? '',
+            updateId: $nameOrOptions->updateId ?? Uuid::v4(),
             firstExecutionRunId: $nameOrOptions->firstExecutionRunId ?? '',
             resultType: $nameOrOptions->resultType,
         ));

--- a/tests/Functional/Client/UpdateOnTimeSkippingServerTestCase.php
+++ b/tests/Functional/Client/UpdateOnTimeSkippingServerTestCase.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Functional\Client;
+
+use Temporal\Testing\WithoutTimeSkipping;
+use Temporal\Tests\Workflow\UpdateWorkflow;
+
+/**
+ * @group functional
+ * @group client
+ */
+class UpdateOnTimeSkippingServerTestCase extends AbstractClient
+{
+    use WithoutTimeSkipping;
+
+    public function testUpdateResolvesOnTimeSkippingServer(): void
+    {
+        $client = $this->createClient();
+        $workflow = $client->newWorkflowStub(UpdateWorkflow::class);
+
+        $client->start($workflow);
+
+        /** @see UpdateWorkflow::addNameWithoutValidation */
+        $result = $workflow->__getUntypedStub()
+            ->startUpdate('addNameWithoutValidation', 'Test')
+            ->getResult(5);
+
+        self::assertSame('Hello, Test!', $result);
+
+        $workflow->exit();
+    }
+}


### PR DESCRIPTION


<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

- Adds a functional regression test that runs an update against the time-skipping test server (WithoutTimeSkipping).
- Client-side UUID generation

## Why?
<!-- Tell your future self why have you made these changes -->

Generate the id client-side via Common\Uuid::v4() when the caller did not supply one, matching sdk-go, sdk-java and sdk-typescript.

## Checklist
<!--- add/delete as needed --->

1. Closes #577

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
