### PR TITLE
Support dynamic (catch-all) workflows

### DIFF
--- a/src/Internal/Declaration/Prototype/WorkflowCollection.php
+++ b/src/Internal/Declaration/Prototype/WorkflowCollection.php
@@ -12,8 +12,37 @@ declare(strict_types=1);
 namespace Temporal\Internal\Declaration\Prototype;
 
 use Temporal\Internal\Repository\ArrayRepository;
+use Temporal\Internal\Repository\Identifiable;
 
 /**
  * @template-extends ArrayRepository<WorkflowPrototype>
  */
-final class WorkflowCollection extends ArrayRepository {}
+final class WorkflowCollection extends ArrayRepository
+{
+    /**
+     * A dynamic (catch-all) workflow is the single fallback used when no
+     * statically registered workflow matches the requested type. As in the
+     * other SDKs (Go panics, Python raises), at most one may be registered per
+     * worker — a second would make dispatch ambiguous.
+     */
+    public function add(Identifiable $entry, bool $overwrite = false): void
+    {
+        if ($entry instanceof WorkflowPrototype && $entry->isDynamic()) {
+            foreach ($this as $existing) {
+                if ($existing instanceof WorkflowPrototype
+                    && $existing->isDynamic()
+                    && $existing->getID() !== $entry->getID()
+                ) {
+                    throw new \LogicException(\sprintf(
+                        'Cannot register dynamic workflow "%s": a dynamic (catch-all) workflow "%s" is '
+                        . 'already registered. At most one dynamic workflow is allowed per worker.',
+                        $entry->getID(),
+                        $existing->getID(),
+                    ));
+                }
+            }
+        }
+
+        parent::add($entry, $overwrite);
+    }
+}

--- a/src/Internal/Declaration/Prototype/WorkflowPrototype.php
+++ b/src/Internal/Declaration/Prototype/WorkflowPrototype.php
@@ -44,6 +44,7 @@ final class WorkflowPrototype extends Prototype
     private ?MethodRetry $methodRetry = null;
     private ?ReturnType $returnType = null;
     private bool $hasInitializer = false;
+    private bool $dynamic = false;
     private VersioningBehavior $versioningBehavior;
 
     /**
@@ -70,6 +71,20 @@ final class WorkflowPrototype extends Prototype
     public function setHasInitializer(bool $hasInitializer): void
     {
         $this->hasInitializer = $hasInitializer;
+    }
+
+    /**
+     * Whether this is the dynamic (catch-all) workflow, invoked when no
+     * statically registered workflow matches the requested type name.
+     */
+    public function isDynamic(): bool
+    {
+        return $this->dynamic;
+    }
+
+    public function setDynamic(bool $dynamic): void
+    {
+        $this->dynamic = $dynamic;
     }
 
     public function getCronSchedule(): ?CronSchedule

--- a/src/Internal/Declaration/Reader/WorkflowReader.php
+++ b/src/Internal/Declaration/Reader/WorkflowReader.php
@@ -432,6 +432,9 @@ class WorkflowReader extends Reader
 
         $name = $info->name ?? $interface->getShortName();
 
-        return new WorkflowPrototype($name, $handler, $class);
+        $prototype = new WorkflowPrototype($name, $handler, $class);
+        $prototype->setDynamic($info->dynamic);
+
+        return $prototype;
     }
 }

--- a/src/Internal/Transport/Router/GetWorkerInfo.php
+++ b/src/Internal/Transport/Router/GetWorkerInfo.php
@@ -51,6 +51,9 @@ final class GetWorkerInfo extends Route
             'queries' => \array_keys($workflow->getQueryHandlers()),
             'signals' => \array_keys($workflow->getSignalHandlers()),
             'versioning_behavior' => $workflow->getVersioningBehavior()->value,
+            // Advertise the dynamic (catch-all) workflow so the RoadRunner
+            // temporal plugin registers a Go dynamic-workflow proxy for it.
+            'dynamic' => $workflow->isDynamic(),
         ];
 
         $activityMap = static fn(ActivityPrototype $activity): array => [

--- a/src/Internal/Transport/Router/StartWorkflow.php
+++ b/src/Internal/Transport/Router/StartWorkflow.php
@@ -91,7 +91,21 @@ final class StartWorkflow extends Route
 
     private function findWorkflowOrFail(WorkflowInfo $info): WorkflowPrototype
     {
-        return $this->services->workflows->find($info->type->name) ?? throw new \OutOfRangeException(
+        $found = $this->services->workflows->find($info->type->name);
+
+        if ($found instanceof WorkflowPrototype) {
+            return $found;
+        }
+
+        // Fall back to the dynamic (catch-all) workflow, if one is registered.
+        // The handler reads the real type name via Workflow::getInfo()->type.
+        foreach ($this->services->workflows as $prototype) {
+            if ($prototype instanceof WorkflowPrototype && $prototype->isDynamic()) {
+                return $prototype;
+            }
+        }
+
+        throw new \OutOfRangeException(
             \sprintf(self::ERROR_NOT_FOUND, $info->type->name),
         );
     }

--- a/src/Internal/Workflow/Process/Process.php
+++ b/src/Internal/Workflow/Process/Process.php
@@ -186,6 +186,7 @@ class Process extends Scope implements ProcessInterface
         bool $deferred,
     ): void {
         $handler = $instance->getHandler();
+        $dynamic = $instance->getPrototype()->isDynamic();
         $instance = $context->getWorkflowInstance();
         $arguments = null;
         $values = [];
@@ -220,9 +221,13 @@ class Process extends Scope implements ProcessInterface
             $this->services->interceptorProvider
                 ->getPipeline(WorkflowInboundCallsInterceptor::class)
                 ->with(
-                    function (WorkflowInput $input) use ($context, $arguments, $handler, $deferred): void {
+                    function (WorkflowInput $input) use ($context, $arguments, $handler, $deferred, $dynamic): void {
                         // Prepare typed input if values have been changed
-                        if ($arguments === null || $input->arguments !== $context->getInput()) {
+                        if ($dynamic) {
+                            // Dynamic workflows receive the untouched argument collection so
+                            // they can interpret types that are unknown at registration time.
+                            $arguments = EncodedValues::fromValues([$input->arguments]);
+                        } elseif ($arguments === null || $input->arguments !== $context->getInput()) {
                             $arguments = EncodedValues::fromValues($handler->resolveArguments($input->arguments));
                         }
 

--- a/src/Workflow/WorkflowMethod.php
+++ b/src/Workflow/WorkflowMethod.php
@@ -36,10 +36,22 @@ final class WorkflowMethod
     public ?string $name = null;
 
     /**
+     * Marks this as a dynamic (catch-all) workflow: it is invoked when the
+     * worker receives a workflow whose type name is not statically registered.
+     * At most one dynamic workflow may be registered per worker. The handler
+     * reads the actual type name via {@see \Temporal\Workflow::getInfo()} and
+     * receives the raw arguments (declare a {@see \Temporal\DataConverter\ValuesInterface}
+     * parameter to access them).
+     */
+    #[Immutable]
+    public bool $dynamic = false;
+
+    /**
      * @param non-empty-string|null $name
      */
-    public function __construct(?string $name = null)
+    public function __construct(?string $name = null, bool $dynamic = false)
     {
         $this->name = $name;
+        $this->dynamic = $dynamic;
     }
 }

--- a/tests/Unit/Declaration/Fixture/WorkflowWithAnotherDynamic.php
+++ b/tests/Unit/Declaration/Fixture/WorkflowWithAnotherDynamic.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\Declaration\Fixture;
+
+use Temporal\Workflow\WorkflowInterface;
+use Temporal\Workflow\WorkflowMethod;
+
+/** @WorkflowInterface */
+#[WorkflowInterface]
+class WorkflowWithAnotherDynamic
+{
+    /** @WorkflowMethod(dynamic=true) */
+    #[WorkflowMethod(dynamic: true)]
+    public function handler(): void
+    {
+    }
+}

--- a/tests/Unit/Declaration/Fixture/WorkflowWithDynamic.php
+++ b/tests/Unit/Declaration/Fixture/WorkflowWithDynamic.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\Declaration\Fixture;
+
+use Temporal\Workflow\WorkflowInterface;
+use Temporal\Workflow\WorkflowMethod;
+
+/** @WorkflowInterface */
+#[WorkflowInterface]
+class WorkflowWithDynamic
+{
+    /** @WorkflowMethod(dynamic=true) */
+    #[WorkflowMethod(dynamic: true)]
+    public function handler(): void
+    {
+    }
+}

--- a/tests/Unit/Declaration/WorkflowDeclarationTestCase.php
+++ b/tests/Unit/Declaration/WorkflowDeclarationTestCase.php
@@ -17,14 +17,17 @@ use PHPUnit\Framework\Attributes\TestDox;
 use Spiral\Attributes\AttributeReader;
 use Temporal\Common\CronSchedule;
 use Temporal\Internal\Declaration\Instantiator\WorkflowInstantiator;
+use Temporal\Internal\Declaration\Prototype\WorkflowCollection;
 use Temporal\Internal\Declaration\Prototype\WorkflowPrototype;
 use Temporal\Internal\Declaration\Reader\WorkflowReader;
 use Temporal\Tests\Unit\Declaration\Fixture\Inheritance\ExtendingWorkflow;
 use Temporal\Tests\Unit\Declaration\Fixture\SimpleWorkflow;
+use Temporal\Tests\Unit\Declaration\Fixture\WorkflowWithAnotherDynamic;
 use Temporal\Tests\Unit\Declaration\Fixture\WorkflowWithConstructor;
 use Temporal\Tests\Unit\Declaration\Fixture\WorkflowWithCron;
 use Temporal\Tests\Unit\Declaration\Fixture\WorkflowWithCronAndRetry;
 use Temporal\Tests\Unit\Declaration\Fixture\WorkflowWithCustomName;
+use Temporal\Tests\Unit\Declaration\Fixture\WorkflowWithDynamic;
 use Temporal\Tests\Unit\Declaration\Fixture\WorkflowWithoutHandler;
 use Temporal\Tests\Unit\Declaration\Fixture\WorkflowWithQueries;
 use Temporal\Tests\Unit\Declaration\Fixture\WorkflowWithRetry;
@@ -49,6 +52,33 @@ class WorkflowDeclarationTestCase extends AbstractDeclaration
         $prototype = $reader->fromClass(WorkflowWithoutHandler::class);
 
         $this->assertNull($prototype->getHandler());
+    }
+
+    /**
+     * @param WorkflowReader $reader
+     * @throws \ReflectionException
+     */
+    #[TestDox("Reading a dynamic (catch-all) workflow sets the dynamic flag")]
+    #[DataProvider('workflowReaderDataProvider')]
+    public function testDynamicWorkflow(WorkflowReader $reader): void
+    {
+        $this->assertTrue($reader->fromClass(WorkflowWithDynamic::class)->isDynamic());
+        $this->assertFalse($reader->fromClass(SimpleWorkflow::class)->isDynamic());
+    }
+
+    /**
+     * @param WorkflowReader $reader
+     * @throws \ReflectionException
+     */
+    #[TestDox("At most one dynamic workflow may be registered per worker")]
+    #[DataProvider('workflowReaderDataProvider')]
+    public function testMultipleDynamicWorkflowsAreRejected(WorkflowReader $reader): void
+    {
+        $collection = new WorkflowCollection();
+        $collection->add($reader->fromClass(WorkflowWithDynamic::class));
+
+        $this->expectException(\LogicException::class);
+        $collection->add($reader->fromClass(WorkflowWithAnotherDynamic::class));
     }
 
     /**

--- a/tests/Unit/Framework/WorkerTestCase.php
+++ b/tests/Unit/Framework/WorkerTestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Unit\Framework;
 
+use Temporal\DataConverter\ValuesInterface;
 use Temporal\Tests\Unit\AbstractUnit;
 use Temporal\Worker\WorkerFactoryInterface;
 use Temporal\Worker\WorkerInterface;
@@ -18,16 +19,9 @@ use function PHPUnit\Framework\assertFalse;
 final class WorkerTestCase extends AbstractUnit
 {
     private WorkerFactoryInterface $factory;
+
     /** @var WorkerMock|WorkerInterface */
     private $worker;
-
-    protected function setUp(): void
-    {
-        $this->factory = WorkerFactoryMock::create();
-        $this->worker = $this->factory->newWorker();
-
-        parent::setUp();
-    }
 
     public function testRunWorker(): void
     {
@@ -38,15 +32,104 @@ final class WorkerTestCase extends AbstractUnit
                 #[WorkflowMethod(name: 'SimpleWorkflow')]
                 public function handler(): iterable
                 {
-                    $result = yield Workflow::awaitWithTimeout(5, fn() => false);
+                    $result = yield Workflow::awaitWithTimeout(5, static fn() => false);
                     assertFalse($result);
                     return $result;
                 }
-            }
+            },
         );
 
         $this->worker->runWorkflow('SimpleWorkflow');
         $this->worker->expectTimer(5);
         $this->factory->run($this->worker);
     }
+
+    public function testDynamicWorkflowReceivesActualTypeAndRawArguments(): void
+    {
+        $this->worker->registerWorkflowObject(
+            new
+            #[Workflow\WorkflowInterface]
+            class {
+                #[WorkflowMethod(name: 'DynamicWorkflow', dynamic: true)]
+                public function handler(ValuesInterface $arguments): array
+                {
+                    return [
+                        Workflow::getInfo()->type->name,
+                        $arguments->getValues(),
+                    ];
+                }
+            },
+        );
+
+        $this->worker->runWorkflow('RuntimeDefinedWorkflow', 'alpha', 42);
+        $this->worker->assertWorkflowReturns(['RuntimeDefinedWorkflow', ['alpha', 42]]);
+
+        $this->factory->run($this->worker);
+        self::assertCount(1, $this->worker->getWorkflows());
+    }
+
+    public function testNamedWorkflowTakesPrecedenceOverDynamicWorkflow(): void
+    {
+        $this->worker->registerWorkflowObject(
+            new
+            #[Workflow\WorkflowInterface]
+            class {
+                #[WorkflowMethod(name: 'DynamicWorkflow', dynamic: true)]
+                public function handler(ValuesInterface $arguments): string
+                {
+                    return 'dynamic';
+                }
+            },
+        );
+        $this->worker->registerWorkflowObject(
+            new
+            #[Workflow\WorkflowInterface]
+            class {
+                #[WorkflowMethod(name: 'NamedWorkflow')]
+                public function handler(): string
+                {
+                    return 'named';
+                }
+            },
+        );
+
+        $this->worker->runWorkflow('NamedWorkflow');
+        $this->worker->assertWorkflowReturns('named');
+
+        $this->factory->run($this->worker);
+        self::assertCount(2, $this->worker->getWorkflows());
+    }
+
+    public function testEachWorkerCanRegisterOneDynamicWorkflow(): void
+    {
+        $secondWorker = $this->factory->newWorker('other-task-queue');
+
+        $this->worker->registerWorkflowObject(
+            new
+            #[Workflow\WorkflowInterface]
+            class {
+                #[WorkflowMethod(name: 'DynamicWorkflow', dynamic: true)]
+                public function handler(): void {}
+            },
+        );
+        $secondWorker->registerWorkflowTypes(PerWorkerDynamicWorkflow::class);
+
+        self::assertCount(1, $this->worker->getWorkflows());
+        self::assertCount(1, $secondWorker->getWorkflows());
+    }
+
+    protected function setUp(): void
+    {
+        $this->factory = WorkerFactoryMock::create();
+        $this->worker = $this->factory->newWorker();
+
+        parent::setUp();
+    }
+}
+
+#[Workflow\WorkflowInterface]
+final class PerWorkerDynamicWorkflow
+{
+    #[WorkflowMethod(name: 'DynamicWorkflow', dynamic: true)]
+    public function handler(): void {}
 }

--- a/tests/Unit/Router/GetWorkerInfoTestCase.php
+++ b/tests/Unit/Router/GetWorkerInfoTestCase.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\Router;
+
+use React\Promise\Deferred;
+use Spiral\Attributes\AttributeReader;
+use Temporal\DataConverter\EncodedValues;
+use Temporal\Internal\Declaration\Reader\WorkflowReader;
+use Temporal\Internal\Marshaller\MarshallerInterface;
+use Temporal\Internal\Repository\ArrayRepository;
+use Temporal\Internal\Transport\Router\GetWorkerInfo;
+use Temporal\Plugin\PluginRegistry;
+use Temporal\Tests\Unit\AbstractUnit;
+use Temporal\Tests\Unit\Declaration\Fixture\SimpleWorkflow;
+use Temporal\Tests\Unit\Declaration\Fixture\WorkflowWithDynamic;
+use Temporal\Tests\Unit\Framework\Requests\GetWorkerInfo as Request;
+use Temporal\Worker\ServiceCredentials;
+use Temporal\Worker\WorkerInterface;
+use Temporal\Worker\WorkerOptions;
+
+final class GetWorkerInfoTestCase extends AbstractUnit
+{
+    public function testDynamicWorkflowFlagIsAdvertised(): void
+    {
+        $reader = new WorkflowReader(new AttributeReader());
+        $worker = $this->createMock(WorkerInterface::class);
+        $options = WorkerOptions::new();
+
+        $worker->method('getID')->willReturn('test-queue');
+        $worker->method('getOptions')->willReturn($options);
+        $worker->method('getWorkflows')->willReturn([
+            $reader->fromClass(WorkflowWithDynamic::class),
+            $reader->fromClass(SimpleWorkflow::class),
+        ]);
+        $worker->method('getActivities')->willReturn([]);
+
+        $marshaller = $this->createMock(MarshallerInterface::class);
+        $marshaller->expects($this->once())
+            ->method('marshal')
+            ->with($options)
+            ->willReturn([]);
+
+        $router = new GetWorkerInfo(
+            new ArrayRepository([$worker]),
+            $marshaller,
+            ServiceCredentials::create(),
+            new PluginRegistry(),
+        );
+        $resolver = new Deferred();
+        $response = null;
+        $resolver->promise()->then(static function (EncodedValues $values) use (&$response): void {
+            $response = $values->getValues();
+        });
+
+        $router->handle(new Request(), [], $resolver);
+
+        self::assertNotNull($response);
+        self::assertSame(true, $response[0]['Workflows'][0]['dynamic']);
+        self::assertSame(false, $response[0]['Workflows'][1]['dynamic']);
+    }
+}

--- a/tests/Unit/Router/StartWorkflowTestCase.php
+++ b/tests/Unit/Router/StartWorkflowTestCase.php
@@ -86,6 +86,24 @@ final class StartWorkflowTestCase extends AbstractUnit
         $this->router->handle($request, [], new Deferred());
     }
 
+    public function testUnknownWorkflowWithoutDynamicWorkflowThrows(): void
+    {
+        $request = new Request($runId = Uuid::v4(), 'UnknownWorkflow', EncodedValues::fromValues([]));
+
+        $workflowInfo = new WorkflowInfo();
+        $workflowInfo->type->name = 'UnknownWorkflow';
+        $workflowInfo->execution = new WorkflowExecution('123', $runId);
+
+        $this->marshaller->expects($this->once())
+            ->method('unmarshal')
+            ->willReturn(new Input($workflowInfo));
+
+        $this->expectException(\OutOfRangeException::class);
+        $this->expectExceptionMessage('Workflow with the specified name "UnknownWorkflow" was not registered');
+
+        $this->router->handle($request, [], new Deferred());
+    }
+
     protected function setUp(): void
     {
         $workflow = new \stdClass();


### PR DESCRIPTION
## What

Adds **Dynamic (catch-all) Workflow** support — a workflow invoked when the worker receives a type name that is not statically registered. PHP and TypeScript are the only SDKs without it (Go/Java/Python/.NET/Ruby all have it).

- **`#[WorkflowMethod(dynamic: true)]`** — declares the dynamic workflow. The handler reads the real type via `Workflow::getInfo()` and receives the raw args.
- **`WorkflowPrototype::isDynamic()`** — set by `WorkflowReader` from the attribute.
- **`StartWorkflow`** — when `workflows->find($type)` misses, falls back to the registered dynamic prototype (mirrors Python's `self._workflows.get(type, self._dynamic_workflow)`).
- **`GetWorkerInfo`** — advertises `dynamic` per workflow, so the RoadRunner temporal plugin can register a Go dynamic-workflow proxy.
- **`WorkflowCollection`** — enforces **at most one** dynamic workflow per worker (Go panics, Python raises `TypeError`; here a `LogicException`), since a second catch-all would make dispatch ambiguous.

## Why

Enables applications that author workflows at runtime (e.g. UI-driven pipeline/automation builders) to give each workflow its own type name — real identity in the Web UI — while one PHP handler interprets it, with no codegen or per-workflow deploy.

## Integration status

The host-side dependencies are complete:

- [temporalio/sdk-go#2449](https://github.com/temporalio/sdk-go/pull/2449) fixed factory-registered dynamic workflow execution and shipped in `go.temporal.io/sdk v1.47.0`.
- [temporalio/roadrunner-temporal#784](https://github.com/temporalio/roadrunner-temporal/pull/784) registers the shared factory proxy via `RegisterDynamicWorkflow` when this `dynamic` field is set. It merged on August 6, 2026, and pins Go SDK v1.47.0. The change is not yet included in a tagged `roadrunner-temporal` release or released RoadRunner binary.

This PR (the PHP declaration + dispatch) remains self-contained and unit-tested independently of the RoadRunner release cycle.

## Testing

- New `tests/Unit/Declaration` coverage, run against **both** the attribute and annotation readers:
  - `testDynamicWorkflow` — `#[WorkflowMethod(dynamic: true)]` sets `isDynamic()`.
  - `testMultipleDynamicWorkflowsAreRejected` — a second dynamic workflow on a worker throws.
- Full unit suite green (`composer run test:unit`, 692 tests). `composer run cs:diff` clean. `composer run psalm` reports no new issues in the changed files.
- Validated end-to-end with a custom `rr` containing the now-merged roadrunner-temporal#784 implementation and Go SDK v1.47.0: starting an unregistered type (`pipeline-blog-publish`) is caught by the dynamic handler, which reads the real type via `Workflow::getInfo()` and completes.

Automated end-to-end coverage can use the standard test binary once a RoadRunner release includes the merged plugin change.

## Backwards compatibility

Additive. `dynamic` defaults to `false`, so existing workflows and workers behave exactly as before.
