### PR TITLE
Defer schedule catchup window default to server

### DIFF
--- a/src/Client/Schedule/Policy/SchedulePolicies.php
+++ b/src/Client/Schedule/Policy/SchedulePolicies.php
@@ -6,6 +6,7 @@ namespace Temporal\Client\Schedule\Policy;
 
 use Google\Protobuf\Duration;
 use Temporal\Internal\Marshaller\Meta\Marshal;
+use Temporal\Internal\Marshaller\Type\DateIntervalType;
 use Temporal\Internal\Support\DateInterval;
 use Temporal\Internal\Traits\CloneWith;
 
@@ -34,10 +35,12 @@ final class SchedulePolicies
      * If the Temporal server misses an action due to one or more components
      * being down, and comes back up, the action will be run if the scheduled
      * time is within this window from the current time.
-     * This value defaults to 60 seconds, and can't be less than 10 seconds.
+     * When unset, this value is omitted so the Temporal Server applies its
+     * default (currently one year). An explicitly set value can't be less than
+     * 10 seconds.
      */
-    #[Marshal(name: 'catchup_window', of: Duration::class)]
-    public readonly \DateInterval $catchupWindow;
+    #[Marshal(name: 'catchup_window', type: DateIntervalType::class, of: Duration::class, nullable: true)]
+    public readonly ?\DateInterval $catchupWindow;
 
     /**
      * If true, and a Workflow run fails or times out, pause the Schedule.
@@ -50,7 +53,7 @@ final class SchedulePolicies
     private function __construct()
     {
         $this->overlapPolicy = ScheduleOverlapPolicy::Unspecified;
-        $this->catchupWindow = new \DateInterval('PT60S');
+        $this->catchupWindow = null;
         $this->pauseOnFailure = false;
     }
 
@@ -75,7 +78,9 @@ final class SchedulePolicies
      * If the Temporal server misses an action due to one or more components
      * being down, and comes back up, the action will be run if the scheduled
      * time is within this window from the current time.
-     * This value defaults to 60 seconds, and can't be less than 10 seconds.
+     * When unset, this value is omitted so the Temporal Server applies its
+     * default (currently one year). An explicitly set value can't be less than
+     * 10 seconds.
      *
      * @param DateIntervalValue $interval
      */

--- a/src/Internal/Mapper/ScheduleMapper.php
+++ b/src/Internal/Mapper/ScheduleMapper.php
@@ -41,7 +41,7 @@ final class ScheduleMapper
         $array = $this->marshaller->marshal($dto);
         $array['policies']['overlap_policy'] = $dto->policies->overlapPolicy->value;
 
-        $array['policies'] = new SchedulePolicies($array['policies'] ?? []);
+        $array['policies'] = new SchedulePolicies(self::cleanArray($array['policies'] ?? []));
         $array['spec'] = $this->prepareSpec($array['spec'] ?? []);
         $array['state'] = new ScheduleState($array['state'] ?? []);
         isset($array['action']) and $array['action'] = $this->prepareAction($dto->action, $array['action']);

--- a/src/Internal/Marshaller/ProtoToArrayConverter.php
+++ b/src/Internal/Marshaller/ProtoToArrayConverter.php
@@ -52,7 +52,10 @@ final class ProtoToArrayConverter
                 \sprintf('%d.%d', $input->getSeconds(), $input->getNanos() / 1000),
             ),
             Duration::class => static fn(Duration $input): \DateInterval =>
-                \Temporal\Internal\Support\DateInterval::parse($input),
+                \Temporal\Internal\Support\DateInterval::parse(
+                    $input->getSeconds() * 1e6 + $input->getNanos() / 1e3,
+                    \Temporal\Internal\Support\DateInterval::FORMAT_MICROSECONDS,
+                ),
             SearchAttributes::class => fn(SearchAttributes $input): EncodedCollection =>
                 EncodedCollection::fromPayloadCollection(
                     $input->getIndexedFields(),

--- a/src/Internal/Marshaller/ProtoToArrayConverter.php
+++ b/src/Internal/Marshaller/ProtoToArrayConverter.php
@@ -53,7 +53,7 @@ final class ProtoToArrayConverter
             ),
             Duration::class => static fn(Duration $input): \DateInterval =>
                 \Temporal\Internal\Support\DateInterval::parse(
-                    (int) $input->getSeconds() * 1_000_000 + \intdiv((int) $input->getNanos(), 1_000),
+                    (int) $input->getSeconds() * 1_000_000 + \intdiv($input->getNanos(), 1_000),
                     \Temporal\Internal\Support\DateInterval::FORMAT_MICROSECONDS,
                 ),
             SearchAttributes::class => fn(SearchAttributes $input): EncodedCollection =>

--- a/src/Internal/Marshaller/ProtoToArrayConverter.php
+++ b/src/Internal/Marshaller/ProtoToArrayConverter.php
@@ -51,14 +51,8 @@ final class ProtoToArrayConverter
                 'U.u',
                 \sprintf('%d.%d', $input->getSeconds(), $input->getNanos() / 1000),
             ),
-            Duration::class => static function (Duration $input): \DateInterval {
-                $now = new \DateTimeImmutable('@0');
-                return $now->diff(
-                    $now->modify(
-                        \sprintf('+%d seconds +%d microseconds', $input->getSeconds(), $input->getNanos() / 1000),
-                    ),
-                );
-            },
+            Duration::class => static fn(Duration $input): \DateInterval =>
+                \Temporal\Internal\Support\DateInterval::parse($input),
             SearchAttributes::class => fn(SearchAttributes $input): EncodedCollection =>
                 EncodedCollection::fromPayloadCollection(
                     $input->getIndexedFields(),

--- a/src/Internal/Marshaller/ProtoToArrayConverter.php
+++ b/src/Internal/Marshaller/ProtoToArrayConverter.php
@@ -53,7 +53,7 @@ final class ProtoToArrayConverter
             ),
             Duration::class => static fn(Duration $input): \DateInterval =>
                 \Temporal\Internal\Support\DateInterval::parse(
-                    $input->getSeconds() * 1e6 + $input->getNanos() / 1e3,
+                    (int) $input->getSeconds() * 1_000_000 + \intdiv((int) $input->getNanos(), 1_000),
                     \Temporal\Internal\Support\DateInterval::FORMAT_MICROSECONDS,
                 ),
             SearchAttributes::class => fn(SearchAttributes $input): EncodedCollection =>

--- a/tests/Acceptance/Harness/Schedule/BasicTest.php
+++ b/tests/Acceptance/Harness/Schedule/BasicTest.php
@@ -16,6 +16,7 @@ use Temporal\Client\Schedule\ScheduleOptions;
 use Temporal\Client\Schedule\Spec\ScheduleSpec;
 use Temporal\Client\ScheduleClientInterface;
 use Temporal\Client\WorkflowClientInterface;
+use Temporal\Internal\Support\DateInterval;
 use Temporal\Tests\Acceptance\App\Runtime\Feature;
 use Temporal\Tests\Acceptance\App\Runtime\State;
 use Temporal\Tests\Acceptance\App\TestCase;
@@ -65,6 +66,12 @@ class BasicTest extends TestCase
             $action = $description->schedule->action;
             self::assertInstanceOf(StartWorkflowAction::class, $action);
             self::assertSame($workflowId, $action->workflowId);
+            $catchupWindow = $description->schedule->policies->catchupWindow;
+            self::assertNotNull($catchupWindow);
+            self::assertSame(
+                365 * 24 * 60 * 60,
+                (int) DateInterval::parse($catchupWindow)->totalSeconds,
+            );
 
             // Confirm simple list
             $found = false;

--- a/tests/Unit/Internal/Marshaller/ProtoToArrayConverterTestCase.php
+++ b/tests/Unit/Internal/Marshaller/ProtoToArrayConverterTestCase.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\Internal\Marshaller;
+
+use Google\Protobuf\Duration;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Temporal\DataConverter\DataConverter;
+use Temporal\Internal\Marshaller\ProtoToArrayConverter;
+use Temporal\Internal\Support\DateInterval;
+
+#[CoversClass(ProtoToArrayConverter::class)]
+final class ProtoToArrayConverterTestCase extends TestCase
+{
+    public function testDurationPreservesExactSeconds(): void
+    {
+        $converter = new ProtoToArrayConverter(DataConverter::createDefault());
+
+        $interval = $converter->convert(
+            (new Duration())->setSeconds(365 * 24 * 60 * 60),
+        );
+
+        self::assertInstanceOf(\DateInterval::class, $interval);
+        self::assertSame(
+            365 * 24 * 60 * 60,
+            (int) DateInterval::parse($interval)->totalSeconds,
+        );
+    }
+}

--- a/tests/Unit/Schedule/Mapper/WorkflowExecutionInfoMapperTestCase.php
+++ b/tests/Unit/Schedule/Mapper/WorkflowExecutionInfoMapperTestCase.php
@@ -221,7 +221,7 @@ final class WorkflowExecutionInfoMapperTestCase extends TestCase
         $this->assertEmpty($spec->getTimezoneName());
 
         // Test Policies
-        $this->assertEquals(60, $policies->getCatchupWindow()->getSeconds());
+        $this->assertNull($policies->getCatchupWindow());
         $this->assertFalse($policies->getPauseOnFailure());
         $this->assertEquals(ScheduleOverlapPolicy::SCHEDULE_OVERLAP_POLICY_UNSPECIFIED, $policies->getOverlapPolicy());
 


### PR DESCRIPTION
## What changed
- Make the default catch-up window nullable instead of assigning 60 seconds.
- Remove null policy fields during protobuf mapping.
- Preserve exact protobuf duration values when decoding server responses.
- Correct the public documentation.
- Add omission, exact-duration decoding, and server-backed one-year default coverage.

## Why
The SDK was sending a historical 60-second default, preventing the server’s one-year default from taking effect. Its protobuf decoder also converted long fixed durations through a calendar diff, which changed the reported total seconds.

## Validation
- GitHub Actions static analysis
- Unit coverage for exact protobuf duration decoding
- Server-backed schedule coverage confirms the 365-day default
- Tests were not run locally because PHP and Composer are unavailable.

## Breaking changes
`SchedulePolicies::$catchupWindow` is nullable until the schedule is resolved by the server.