### PR TITLE
feat: mock activities and child workflows in the testing framework

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1118,17 +1118,6 @@
       <code><![CDATA[$reduce($c, $value, $i++, $total)]]></code>
     </TooManyArguments>
   </file>
-  <file src="src/Worker/ActivityInvocationCache/ActivityInvocationResult.php">
-    <MissingReturnType>
-      <code><![CDATA[toValue]]></code>
-    </MissingReturnType>
-    <PossiblyNullArgument>
-      <code><![CDATA[$dataConverter]]></code>
-    </PossiblyNullArgument>
-    <PossiblyUndefinedStringArrayOffset>
-      <code><![CDATA[$data['payloads']]]></code>
-    </PossiblyUndefinedStringArrayOffset>
-  </file>
   <file src="src/Worker/ActivityInvocationCache/InMemoryActivityInvocationCache.php">
     <PossiblyUndefinedStringArrayOffset>
       <code><![CDATA[$request->getOptions()['name']]]></code>
@@ -1141,6 +1130,20 @@
     </ArgumentTypeCoercion>
     <PossiblyUndefinedStringArrayOffset>
       <code><![CDATA[$request->getOptions()['name']]]></code>
+    </PossiblyUndefinedStringArrayOffset>
+  </file>
+  <file src="src/Worker/ChildWorkflowInvocationCache/RoadRunnerChildWorkflowInvocationCache.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$cacheName]]></code>
+      <code><![CDATA[$host]]></code>
+    </ArgumentTypeCoercion>
+  </file>
+  <file src="src/Worker/InvocationResult.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$dataConverter]]></code>
+    </PossiblyNullArgument>
+    <PossiblyUndefinedStringArrayOffset>
+      <code><![CDATA[$data['payloads']]]></code>
     </PossiblyUndefinedStringArrayOffset>
   </file>
   <file src="src/Worker/LoopInterface.php">

--- a/resources/testing.meta-storm.xml
+++ b/resources/testing.meta-storm.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<meta-storm xmlns="meta-storm">
+    <definitions>
+        <classMethod
+            class="\Temporal\Testing\WorkflowMocker"
+            method="expectCompletion"
+            argument="0"
+        >
+            <collection name="temporal/sdk:workflow-type" argument="0" />
+            <stopCompletion />
+        </classMethod>
+        <classMethod
+            class="\Temporal\Testing\WorkflowMocker"
+            method="expectFailure"
+            argument="0"
+        >
+            <collection name="temporal/sdk:workflow-type" argument="0" />
+            <stopCompletion />
+        </classMethod>
+        <classMethod
+            class="\Temporal\Testing\WorkflowMocker"
+            method="expectCompletionWhen"
+            argument="0"
+        >
+            <collection name="temporal/sdk:workflow-type" argument="0" />
+            <stopCompletion />
+        </classMethod>
+        <classMethod
+            class="\Temporal\Testing\Interactions\WorkflowInteractions"
+            method="childWorkflow"
+            argument="0"
+        >
+            <collection name="temporal/sdk:workflow-type" argument="0" />
+            <stopCompletion />
+        </classMethod>
+    </definitions>
+</meta-storm>

--- a/src/DataConverter/PayloadComparator.php
+++ b/src/DataConverter/PayloadComparator.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\DataConverter;
+
+use Temporal\Api\Common\V1\Payloads;
+
+final class PayloadComparator
+{
+    public static function equals(?Payloads $left, ?Payloads $right): bool
+    {
+        if ($left === null || $right === null) {
+            return $left === $right;
+        }
+
+        return $left->serializeToString() === $right->serializeToString();
+    }
+}

--- a/src/Worker/ActivityInvocationCache/ActivityInvocationCacheInterface.php
+++ b/src/Worker/ActivityInvocationCache/ActivityInvocationCacheInterface.php
@@ -1,5 +1,12 @@
 <?php
 
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Temporal\Worker\ActivityInvocationCache;
@@ -13,6 +20,7 @@ interface ActivityInvocationCacheInterface
 
     /**
      * @param non-empty-string $activityMethodName
+     * @param mixed $value Activity result: anything the DataConverter can encode, or an EncodedValues.
      */
     public function saveCompletion(string $activityMethodName, mixed $value): void;
 
@@ -20,6 +28,19 @@ interface ActivityInvocationCacheInterface
      * @param non-empty-string $activityMethodName
      */
     public function saveFailure(string $activityMethodName, \Throwable $error): void;
+
+    /**
+     * @param non-empty-string $activityMethodName
+     * @param list<mixed> $values Per-call results, each anything the DataConverter can encode.
+     */
+    public function saveConsecutiveCompletions(string $activityMethodName, array $values): void;
+
+    /**
+     * @param non-empty-string $activityMethodName
+     * @param list<mixed> $args Call arguments to byte-match against, encoded via the DataConverter.
+     * @param mixed $value Result returned on a match: anything the DataConverter can encode, or an EncodedValues.
+     */
+    public function saveCompletionWhen(string $activityMethodName, array $args, mixed $value): void;
 
     public function canHandle(ServerRequestInterface $request): bool;
 

--- a/src/Worker/ActivityInvocationCache/ActivityInvocationFailure.php
+++ b/src/Worker/ActivityInvocationCache/ActivityInvocationFailure.php
@@ -1,34 +1,19 @@
 <?php
 
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Temporal\Worker\ActivityInvocationCache;
 
-final class ActivityInvocationFailure
-{
-    /** @var class-string<\Throwable> */
-    public string $errorClass;
+use Temporal\Worker\InvocationFailure;
 
-    public string $errorMessage;
-
-    /**
-     * @param class-string<\Throwable> $exceptionClass
-     */
-    public function __construct(
-        string $exceptionClass,
-        string $exceptionMessage,
-    ) {
-        $this->errorClass = $exceptionClass;
-        $this->errorMessage = $exceptionMessage;
-    }
-
-    public static function fromThrowable(\Throwable $error): self
-    {
-        return new self($error::class, $error->getMessage());
-    }
-
-    public function toThrowable(): \Throwable
-    {
-        return new ($this->errorClass)($this->errorMessage);
-    }
-}
+/**
+ * @deprecated Use {@see \Temporal\Worker\InvocationFailure} instead.
+ */
+final class ActivityInvocationFailure extends InvocationFailure {}

--- a/src/Worker/ActivityInvocationCache/ActivityInvocationResult.php
+++ b/src/Worker/ActivityInvocationCache/ActivityInvocationResult.php
@@ -1,45 +1,19 @@
 <?php
 
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Temporal\Worker\ActivityInvocationCache;
 
-use Temporal\Api\Common\V1\Payloads;
-use Temporal\DataConverter\DataConverterInterface;
-use Temporal\DataConverter\EncodedValues;
-use Temporal\DataConverter\Type;
+use Temporal\Worker\InvocationResult;
 
-final class ActivityInvocationResult
-{
-    public function __construct(protected Payloads $payloads) {}
-
-    public static function fromValue(mixed $value, ?DataConverterInterface $dataConverter = null): ActivityInvocationResult
-    {
-        $value = $value instanceof EncodedValues ? $value : EncodedValues::fromValues([$value], $dataConverter);
-
-        return new self($value->toPayloads());
-    }
-
-    public function toValue(Type|string|null $type = null, ?DataConverterInterface $dataConverter = null)
-    {
-        return $this->toEncodedValues($dataConverter)->getValue(0, $type);
-    }
-
-    public function toEncodedValues(?DataConverterInterface $dataConverter = null): EncodedValues
-    {
-        return EncodedValues::fromPayloads($this->payloads, $dataConverter);
-    }
-
-    public function __serialize(): array
-    {
-        return [
-            'payloads' => $this->payloads->serializeToJsonString(),
-        ];
-    }
-
-    public function __unserialize(array $data): void
-    {
-        $this->payloads = new Payloads();
-        $this->payloads->mergeFromJsonString($data['payloads']);
-    }
-}
+/**
+ * @deprecated Use {@see \Temporal\Worker\InvocationResult} instead.
+ */
+final class ActivityInvocationResult extends InvocationResult {}

--- a/src/Worker/ActivityInvocationCache/InMemoryActivityInvocationCache.php
+++ b/src/Worker/ActivityInvocationCache/InMemoryActivityInvocationCache.php
@@ -1,12 +1,25 @@
 <?php
 
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Temporal\Worker\ActivityInvocationCache;
 
+use Temporal\Worker\InvocationResult;
+use Temporal\Worker\InvocationFailure;
+use Temporal\Worker\InvocationMatched;
+use Temporal\Worker\InvocationResultQueue;
 use React\Promise\PromiseInterface;
 use Temporal\DataConverter\DataConverter;
 use Temporal\DataConverter\DataConverterInterface;
+use Temporal\DataConverter\EncodedValues;
+use Temporal\Exception\InvalidArgumentException;
 use Temporal\Worker\Transport\Command\ServerRequestInterface;
 
 use function React\Promise\reject;
@@ -15,7 +28,7 @@ use function React\Promise\resolve;
 final class InMemoryActivityInvocationCache implements ActivityInvocationCacheInterface
 {
     /**
-     * @var array<non-empty-string, ActivityInvocationFailure|ActivityInvocationResult>
+     * @var array<non-empty-string, InvocationFailure|InvocationResult|InvocationResultQueue|InvocationMatched>
      */
     private array $cache = [];
 
@@ -33,17 +46,42 @@ final class InMemoryActivityInvocationCache implements ActivityInvocationCacheIn
 
     public function saveCompletion(string $activityMethodName, mixed $value): void
     {
-        $this->cache[$activityMethodName] = ActivityInvocationResult::fromValue($value, $this->dataConverter);
+        $this->cache[$activityMethodName] = InvocationResult::fromValue($value, $this->dataConverter);
     }
 
     public function saveFailure(string $activityMethodName, \Throwable $error): void
     {
-        $this->cache[$activityMethodName] = ActivityInvocationFailure::fromThrowable($error);
+        $this->cache[$activityMethodName] = InvocationFailure::fromThrowable($error, $this->dataConverter);
+    }
+
+    public function saveConsecutiveCompletions(string $activityMethodName, array $values): void
+    {
+        $items = [];
+        foreach ($values as $value) {
+            $items[] = InvocationResult::fromValue($value, $this->dataConverter);
+        }
+
+        $this->cache[$activityMethodName] = new InvocationResultQueue($items);
+    }
+
+    public function saveCompletionWhen(string $activityMethodName, array $args, mixed $value): void
+    {
+        $matched = $this->cache[$activityMethodName] ?? null;
+        if (!$matched instanceof InvocationMatched) {
+            $matched = new InvocationMatched();
+        }
+
+        $matched->addCase(
+            EncodedValues::fromValues($args, $this->dataConverter)->toPayloads(),
+            InvocationResult::fromValue($value, $this->dataConverter),
+        );
+
+        $this->cache[$activityMethodName] = $matched;
     }
 
     public function canHandle(ServerRequestInterface $request): bool
     {
-        if ($request->getName() !== 'InvokeActivity') {
+        if (!\in_array($request->getName(), ['InvokeActivity', 'InvokeLocalActivity'], true)) {
             return false;
         }
 
@@ -57,8 +95,24 @@ final class InMemoryActivityInvocationCache implements ActivityInvocationCacheIn
         $activityMethodName = $request->getOptions()['name'];
         $value = $this->cache[$activityMethodName];
 
-        return $value instanceof ActivityInvocationFailure
-            ? reject($value->toThrowable())
+        if ($value instanceof InvocationMatched) {
+            $matched = $value->match($request->getPayloads()->toPayloads());
+            if ($matched === null) {
+                return reject(new InvalidArgumentException(
+                    \sprintf('No matching expectation for activity "%s"', $activityMethodName),
+                ));
+            }
+            $value = $matched;
+        }
+
+        if ($value instanceof InvocationResultQueue) {
+            $current = $value->current();
+            $value->advance();
+            $value = $current;
+        }
+
+        return $value instanceof InvocationFailure
+            ? reject($value->toThrowable($this->dataConverter))
             : resolve($value->toEncodedValues($this->dataConverter));
     }
 }

--- a/src/Worker/ActivityInvocationCache/RoadRunnerActivityInvocationCache.php
+++ b/src/Worker/ActivityInvocationCache/RoadRunnerActivityInvocationCache.php
@@ -1,9 +1,20 @@
 <?php
 
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Temporal\Worker\ActivityInvocationCache;
 
+use Temporal\Worker\InvocationResult;
+use Temporal\Worker\InvocationFailure;
+use Temporal\Worker\InvocationMatched;
+use Temporal\Worker\InvocationResultQueue;
 use React\Promise\PromiseInterface;
 use Spiral\Goridge\RPC\RPC;
 use Spiral\RoadRunner\Environment;
@@ -11,6 +22,7 @@ use Spiral\RoadRunner\KeyValue\Factory;
 use Spiral\RoadRunner\KeyValue\StorageInterface;
 use Temporal\DataConverter\DataConverter;
 use Temporal\DataConverter\DataConverterInterface;
+use Temporal\DataConverter\EncodedValues;
 use Temporal\Exception\InvalidArgumentException;
 use Temporal\Worker\Transport\Command\ServerRequestInterface;
 
@@ -43,17 +55,42 @@ final class RoadRunnerActivityInvocationCache implements ActivityInvocationCache
 
     public function saveCompletion(string $activityMethodName, mixed $value): void
     {
-        $this->cache->set($activityMethodName, ActivityInvocationResult::fromValue($value, $this->dataConverter));
+        $this->cache->set($activityMethodName, InvocationResult::fromValue($value, $this->dataConverter));
     }
 
     public function saveFailure(string $activityMethodName, \Throwable $error): void
     {
-        $this->cache->set($activityMethodName, ActivityInvocationFailure::fromThrowable($error));
+        $this->cache->set($activityMethodName, InvocationFailure::fromThrowable($error, $this->dataConverter));
+    }
+
+    public function saveConsecutiveCompletions(string $activityMethodName, array $values): void
+    {
+        $items = [];
+        foreach ($values as $value) {
+            $items[] = InvocationResult::fromValue($value, $this->dataConverter);
+        }
+
+        $this->cache->set($activityMethodName, new InvocationResultQueue($items));
+    }
+
+    public function saveCompletionWhen(string $activityMethodName, array $args, mixed $value): void
+    {
+        $matched = $this->cache->get($activityMethodName);
+        if (!$matched instanceof InvocationMatched) {
+            $matched = new InvocationMatched();
+        }
+
+        $matched->addCase(
+            EncodedValues::fromValues($args, $this->dataConverter)->toPayloads(),
+            InvocationResult::fromValue($value, $this->dataConverter),
+        );
+
+        $this->cache->set($activityMethodName, $matched);
     }
 
     public function canHandle(ServerRequestInterface $request): bool
     {
-        if ($request->getName() !== 'InvokeActivity') {
+        if (!\in_array($request->getName(), ['InvokeActivity', 'InvokeLocalActivity'], true)) {
             return false;
         }
 
@@ -67,11 +104,28 @@ final class RoadRunnerActivityInvocationCache implements ActivityInvocationCache
         $activityMethodName = $request->getOptions()['name'];
         $value = $this->cache->get($activityMethodName);
 
-        if ($value instanceof ActivityInvocationFailure) {
-            return reject($value->toThrowable());
+        if ($value instanceof InvocationMatched) {
+            $matched = $value->match($request->getPayloads()->toPayloads());
+            if ($matched === null) {
+                return reject(new InvalidArgumentException(
+                    \sprintf('No matching expectation for activity "%s"', $activityMethodName),
+                ));
+            }
+            $value = $matched;
         }
 
-        if ($value instanceof ActivityInvocationResult) {
+        if ($value instanceof InvocationResultQueue) {
+            $item = $value->current();
+            $value->advance();
+            $this->cache->set($activityMethodName, $value);
+            $value = $item;
+        }
+
+        if ($value instanceof InvocationFailure) {
+            return reject($value->toThrowable($this->dataConverter));
+        }
+
+        if ($value instanceof InvocationResult) {
             return resolve($value->toEncodedValues($this->dataConverter));
         }
 

--- a/src/Worker/ChildWorkflowInvocationCache/ChildWorkflowInvocationCacheInterface.php
+++ b/src/Worker/ChildWorkflowInvocationCache/ChildWorkflowInvocationCacheInterface.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Worker\ChildWorkflowInvocationCache;
+
+use Temporal\Worker\InvocationResult;
+use Temporal\Worker\InvocationFailure;
+use Temporal\Worker\InvocationMatched;
+
+interface ChildWorkflowInvocationCacheInterface
+{
+    public function clear(): void;
+
+    /**
+     * @param non-empty-string $workflowType
+     * @param mixed $value Child workflow result: anything the DataConverter can encode, or an EncodedValues.
+     */
+    public function saveCompletion(string $workflowType, mixed $value): void;
+
+    /**
+     * @param non-empty-string $workflowType
+     */
+    public function saveFailure(string $workflowType, \Throwable $error): void;
+
+    /**
+     * @param non-empty-string $workflowType
+     * @param array<array-key, mixed> $args Start arguments to byte-match against, encoded via the DataConverter.
+     * @param mixed $value Result returned on a match: anything the DataConverter can encode, or an EncodedValues.
+     */
+    public function saveCompletionWhen(string $workflowType, array $args, mixed $value): void;
+
+    /**
+     * @param non-empty-string $workflowType
+     */
+    public function has(string $workflowType): bool;
+
+    /**
+     * @param non-empty-string $workflowType
+     */
+    public function get(string $workflowType): InvocationResult|InvocationFailure|InvocationMatched;
+
+    /**
+     * @param non-empty-string $workflowType
+     */
+    public function recordInvoked(string $workflowType): void;
+
+    /**
+     * @param non-empty-string $workflowType
+     */
+    public function wasInvoked(string $workflowType): bool;
+
+    public function saveVersion(string $changeId, int $version): void;
+
+    public function hasVersion(string $changeId): bool;
+
+    public function getVersion(string $changeId): int;
+
+    /**
+     * @param mixed $value Side-effect result: anything the DataConverter can encode.
+     */
+    public function saveSideEffect(mixed $value): void;
+
+    public function hasSideEffect(): bool;
+
+    public function nextSideEffect(): mixed;
+}

--- a/src/Worker/ChildWorkflowInvocationCache/InMemoryChildWorkflowInvocationCache.php
+++ b/src/Worker/ChildWorkflowInvocationCache/InMemoryChildWorkflowInvocationCache.php
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Worker\ChildWorkflowInvocationCache;
+
+use Temporal\Worker\InvocationResult;
+use Temporal\Worker\InvocationFailure;
+use Temporal\Worker\InvocationMatched;
+use Temporal\DataConverter\DataConverter;
+use Temporal\DataConverter\DataConverterInterface;
+use Temporal\DataConverter\EncodedValues;
+
+final class InMemoryChildWorkflowInvocationCache implements ChildWorkflowInvocationCacheInterface
+{
+    /**
+     * @var array<non-empty-string, InvocationFailure|InvocationResult|InvocationMatched>
+     */
+    private array $cache = [];
+
+    /** @var array<string, int> */
+    private array $versions = [];
+
+    /** @var array<string, true> */
+    private array $invoked = [];
+
+    /** @var list<InvocationResult> */
+    private array $sideEffects = [];
+
+    private int $sideEffectCursor = 0;
+    private DataConverterInterface $dataConverter;
+
+    public function __construct(?DataConverterInterface $dataConverter = null)
+    {
+        $this->dataConverter = $dataConverter ?? DataConverter::createDefault();
+    }
+
+    public function clear(): void
+    {
+        $this->cache = [];
+        $this->versions = [];
+        $this->invoked = [];
+        $this->sideEffects = [];
+        $this->sideEffectCursor = 0;
+    }
+
+    public function recordInvoked(string $workflowType): void
+    {
+        $this->invoked[$workflowType] = true;
+    }
+
+    public function wasInvoked(string $workflowType): bool
+    {
+        return isset($this->invoked[$workflowType]);
+    }
+
+    public function saveCompletion(string $workflowType, mixed $value): void
+    {
+        $this->cache[$workflowType] = InvocationResult::fromValue($value, $this->dataConverter);
+    }
+
+    public function saveFailure(string $workflowType, \Throwable $error): void
+    {
+        $this->cache[$workflowType] = InvocationFailure::fromThrowable($error, $this->dataConverter);
+    }
+
+    public function saveCompletionWhen(string $workflowType, array $args, mixed $value): void
+    {
+        $matched = $this->cache[$workflowType] ?? null;
+        if (!$matched instanceof InvocationMatched) {
+            $matched = new InvocationMatched();
+        }
+
+        $matched->addCase(
+            EncodedValues::fromValues($args, $this->dataConverter)->toPayloads(),
+            InvocationResult::fromValue($value, $this->dataConverter),
+        );
+
+        $this->cache[$workflowType] = $matched;
+    }
+
+    public function has(string $workflowType): bool
+    {
+        return isset($this->cache[$workflowType]);
+    }
+
+    public function get(string $workflowType): InvocationResult|InvocationFailure|InvocationMatched
+    {
+        if (!isset($this->cache[$workflowType])) {
+            throw new \LogicException(\sprintf('No mock stored for child workflow "%s"', $workflowType));
+        }
+
+        return $this->cache[$workflowType];
+    }
+
+    public function saveVersion(string $changeId, int $version): void
+    {
+        $this->versions[$changeId] = $version;
+    }
+
+    public function hasVersion(string $changeId): bool
+    {
+        return isset($this->versions[$changeId]);
+    }
+
+    public function getVersion(string $changeId): int
+    {
+        return $this->versions[$changeId];
+    }
+
+    public function saveSideEffect(mixed $value): void
+    {
+        $this->sideEffects[] = InvocationResult::fromValue($value, $this->dataConverter);
+    }
+
+    public function hasSideEffect(): bool
+    {
+        return $this->sideEffectCursor < \count($this->sideEffects);
+    }
+
+    public function nextSideEffect(): mixed
+    {
+        $index = \min($this->sideEffectCursor, \count($this->sideEffects) - 1);
+        ++$this->sideEffectCursor;
+
+        return $this->sideEffects[$index]->toValue(null, $this->dataConverter);
+    }
+}

--- a/src/Worker/ChildWorkflowInvocationCache/RoadRunnerChildWorkflowInvocationCache.php
+++ b/src/Worker/ChildWorkflowInvocationCache/RoadRunnerChildWorkflowInvocationCache.php
@@ -1,0 +1,157 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Worker\ChildWorkflowInvocationCache;
+
+use Temporal\Worker\InvocationResult;
+use Temporal\Worker\InvocationFailure;
+use Temporal\Worker\InvocationMatched;
+use Spiral\Goridge\RPC\RPC;
+use Spiral\RoadRunner\Environment;
+use Spiral\RoadRunner\KeyValue\Factory;
+use Spiral\RoadRunner\KeyValue\StorageInterface;
+use Temporal\DataConverter\DataConverter;
+use Temporal\DataConverter\DataConverterInterface;
+use Temporal\DataConverter\EncodedValues;
+
+final class RoadRunnerChildWorkflowInvocationCache implements ChildWorkflowInvocationCacheInterface
+{
+    private const CACHE_NAME = 'test';
+    private const KEY_PREFIX = 'childWorkflow.';
+    private const INVOKED_PREFIX = 'childWorkflowInvoked.';
+    private const VERSION_PREFIX = 'workflowVersion.';
+    private const SIDE_EFFECT_LIST = 'sideEffect.list';
+    private const SIDE_EFFECT_CURSOR = 'sideEffect.cursor';
+
+    private StorageInterface $cache;
+    private DataConverterInterface $dataConverter;
+
+    public function __construct(string $host, string $cacheName, ?DataConverterInterface $dataConverter = null)
+    {
+        $this->cache = (new Factory(RPC::create($host)))->select($cacheName);
+        $this->dataConverter = $dataConverter ?? DataConverter::createDefault();
+    }
+
+    public static function create(?DataConverterInterface $dataConverter = null): self
+    {
+        $env = Environment::fromGlobals();
+        return new self($env->getRPCAddress(), self::CACHE_NAME, $dataConverter);
+    }
+
+    public function clear(): void
+    {
+        $this->cache->clear();
+    }
+
+    public function saveCompletion(string $workflowType, mixed $value): void
+    {
+        $this->cache->set(
+            self::KEY_PREFIX . $workflowType,
+            InvocationResult::fromValue($value, $this->dataConverter),
+        );
+    }
+
+    public function saveFailure(string $workflowType, \Throwable $error): void
+    {
+        $this->cache->set(
+            self::KEY_PREFIX . $workflowType,
+            InvocationFailure::fromThrowable($error, $this->dataConverter),
+        );
+    }
+
+    public function saveCompletionWhen(string $workflowType, array $args, mixed $value): void
+    {
+        $key = self::KEY_PREFIX . $workflowType;
+        $matched = $this->cache->has($key) ? $this->cache->get($key) : null;
+        if (!$matched instanceof InvocationMatched) {
+            $matched = new InvocationMatched();
+        }
+
+        $matched->addCase(
+            EncodedValues::fromValues($args, $this->dataConverter)->toPayloads(),
+            InvocationResult::fromValue($value, $this->dataConverter),
+        );
+
+        $this->cache->set($key, $matched);
+    }
+
+    public function has(string $workflowType): bool
+    {
+        return $this->cache->has(self::KEY_PREFIX . $workflowType);
+    }
+
+    public function get(string $workflowType): InvocationResult|InvocationFailure|InvocationMatched
+    {
+        $key = self::KEY_PREFIX . $workflowType;
+        if (!$this->cache->has($key)) {
+            throw new \LogicException(\sprintf('No mock stored for child workflow "%s"', $workflowType));
+        }
+
+        return $this->cache->get($key);
+    }
+
+    public function recordInvoked(string $workflowType): void
+    {
+        $this->cache->set(self::INVOKED_PREFIX . $workflowType, true);
+    }
+
+    public function wasInvoked(string $workflowType): bool
+    {
+        return $this->cache->has(self::INVOKED_PREFIX . $workflowType);
+    }
+
+    public function saveVersion(string $changeId, int $version): void
+    {
+        $this->cache->set(self::VERSION_PREFIX . $changeId, $version);
+    }
+
+    public function hasVersion(string $changeId): bool
+    {
+        return $this->cache->has(self::VERSION_PREFIX . $changeId);
+    }
+
+    public function getVersion(string $changeId): int
+    {
+        return (int) $this->cache->get(self::VERSION_PREFIX . $changeId);
+    }
+
+    public function saveSideEffect(mixed $value): void
+    {
+        $list = $this->cache->has(self::SIDE_EFFECT_LIST) ? $this->cache->get(self::SIDE_EFFECT_LIST) : [];
+        $list[] = InvocationResult::fromValue($value, $this->dataConverter);
+        $this->cache->set(self::SIDE_EFFECT_LIST, $list);
+    }
+
+    public function hasSideEffect(): bool
+    {
+        if (!$this->cache->has(self::SIDE_EFFECT_LIST)) {
+            return false;
+        }
+
+        return $this->sideEffectCursor() < \count($this->cache->get(self::SIDE_EFFECT_LIST));
+    }
+
+    public function nextSideEffect(): mixed
+    {
+        /** @var list<InvocationResult> $list */
+        $list = $this->cache->get(self::SIDE_EFFECT_LIST);
+        $cursor = $this->sideEffectCursor();
+        $index = \min($cursor, \count($list) - 1);
+        $this->cache->set(self::SIDE_EFFECT_CURSOR, $cursor + 1);
+
+        return $list[$index]->toValue(null, $this->dataConverter);
+    }
+
+    private function sideEffectCursor(): int
+    {
+        return $this->cache->has(self::SIDE_EFFECT_CURSOR) ? (int) $this->cache->get(self::SIDE_EFFECT_CURSOR) : 0;
+    }
+}

--- a/src/Worker/InvocationFailure.php
+++ b/src/Worker/InvocationFailure.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Worker;
+
+use Temporal\Api\Failure\V1\Failure;
+use Temporal\DataConverter\DataConverterInterface;
+use Temporal\Exception\Failure\FailureConverter;
+
+class InvocationFailure
+{
+    private ?string $failureJson = null;
+
+    /**
+     * @param class-string<\Throwable> $errorClass
+     */
+    public function __construct(
+        public string $errorClass,
+        public string $errorMessage,
+    ) {}
+
+    public static function fromThrowable(\Throwable $error, ?DataConverterInterface $dataConverter = null): static
+    {
+        /** @psalm-suppress UnsafeInstantiation */
+        $self = new static($error::class, $error->getMessage());
+
+        if ($dataConverter !== null) {
+            $self->failureJson = FailureConverter::mapExceptionToFailure($error, $dataConverter)
+                ->serializeToJsonString();
+        }
+
+        return $self;
+    }
+
+    public function toThrowable(?DataConverterInterface $dataConverter = null): \Throwable
+    {
+        if ($this->failureJson !== null && $dataConverter !== null) {
+            $failure = new Failure();
+            $failure->mergeFromJsonString($this->failureJson);
+
+            return FailureConverter::mapFailureToException($failure, $dataConverter);
+        }
+
+        return new ($this->errorClass)($this->errorMessage);
+    }
+
+    public function __serialize(): array
+    {
+        return [
+            'errorClass' => $this->errorClass,
+            'errorMessage' => $this->errorMessage,
+            'failureJson' => $this->failureJson,
+        ];
+    }
+
+    /**
+     * @param array{errorClass: class-string<\Throwable>, errorMessage: string, failureJson?: string|null} $data
+     */
+    public function __unserialize(array $data): void
+    {
+        $this->errorClass = $data['errorClass'];
+        $this->errorMessage = $data['errorMessage'];
+        $this->failureJson = $data['failureJson'] ?? null;
+    }
+}

--- a/src/Worker/InvocationMatched.php
+++ b/src/Worker/InvocationMatched.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Worker;
+
+use Temporal\Api\Common\V1\Payloads;
+use Temporal\DataConverter\PayloadComparator;
+
+class InvocationMatched
+{
+    /** @var list<array{args: string, result: InvocationResult|InvocationFailure}> */
+    private array $cases = [];
+
+    public function addCase(Payloads $args, InvocationResult|InvocationFailure $result): void
+    {
+        $this->cases[] = ['args' => $args->serializeToJsonString(), 'result' => $result];
+    }
+
+    public function match(Payloads $input): InvocationResult|InvocationFailure|null
+    {
+        foreach ($this->cases as $case) {
+            $expected = new Payloads();
+            $expected->mergeFromJsonString($case['args']);
+
+            if (PayloadComparator::equals($input, $expected)) {
+                return $case['result'];
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Worker/InvocationResult.php
+++ b/src/Worker/InvocationResult.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Worker;
+
+use Temporal\Api\Common\V1\Payloads;
+use Temporal\DataConverter\DataConverterInterface;
+use Temporal\DataConverter\EncodedValues;
+use Temporal\DataConverter\Type;
+
+class InvocationResult
+{
+    public function __construct(protected Payloads $payloads) {}
+
+    public static function fromValue(mixed $value, ?DataConverterInterface $dataConverter = null): static
+    {
+        $value = $value instanceof EncodedValues ? $value : EncodedValues::fromValues([$value], $dataConverter);
+
+        /** @psalm-suppress UnsafeInstantiation */
+        return new static($value->toPayloads());
+    }
+
+    public function toValue(Type|string|null $type = null, ?DataConverterInterface $dataConverter = null): mixed
+    {
+        return $this->toEncodedValues($dataConverter)->getValue(0, $type);
+    }
+
+    public function toEncodedValues(?DataConverterInterface $dataConverter = null): EncodedValues
+    {
+        return EncodedValues::fromPayloads($this->payloads, $dataConverter);
+    }
+
+    public function __serialize(): array
+    {
+        return [
+            'payloads' => $this->payloads->serializeToJsonString(),
+        ];
+    }
+
+    public function __unserialize(array $data): void
+    {
+        $this->payloads = new Payloads();
+        $this->payloads->mergeFromJsonString($data['payloads']);
+    }
+}

--- a/src/Worker/InvocationResultQueue.php
+++ b/src/Worker/InvocationResultQueue.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Worker;
+
+final class InvocationResultQueue
+{
+    /**
+     * @param list<InvocationResult> $items
+     */
+    public function __construct(
+        private array $items,
+    ) {
+        if ($this->items === []) {
+            throw new \InvalidArgumentException('Consecutive completions require at least one result.');
+        }
+    }
+
+    public function current(): InvocationResult
+    {
+        $current = \reset($this->items);
+        \assert($current !== false);
+
+        return $current;
+    }
+
+    public function advance(): void
+    {
+        if (\count($this->items) > 1) {
+            \array_shift($this->items);
+        }
+    }
+}

--- a/testing/src/ActivityMocker.php
+++ b/testing/src/ActivityMocker.php
@@ -36,4 +36,22 @@ final class ActivityMocker
     {
         $this->cache->saveFailure($activityMethodName, $error);
     }
+
+    /**
+     * @param non-empty-string $activityMethodName
+     * @param list<mixed> $values
+     */
+    public function expectConsecutiveCompletions(string $activityMethodName, array $values): void
+    {
+        $this->cache->saveConsecutiveCompletions($activityMethodName, $values);
+    }
+
+    /**
+     * @param non-empty-string $activityMethodName
+     * @param list<mixed> $args
+     */
+    public function expectCompletionWhen(string $activityMethodName, array $args, mixed $value): void
+    {
+        $this->cache->saveCompletionWhen($activityMethodName, $args, $value);
+    }
 }

--- a/testing/src/Interactions/ActivityAssertion.php
+++ b/testing/src/Interactions/ActivityAssertion.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Testing\Interactions;
+
+use PHPUnit\Framework\Assert;
+use Temporal\Api\Common\V1\Payloads;
+use Temporal\DataConverter\DataConverterInterface;
+use Temporal\DataConverter\EncodedValues;
+use Temporal\DataConverter\PayloadComparator;
+
+final class ActivityAssertion
+{
+    private ?Payloads $expectedInput = null;
+
+    /**
+     * @param list<RecordedCall> $calls
+     */
+    public function __construct(
+        private readonly string $type,
+        private readonly array $calls,
+        private readonly DataConverterInterface $converter,
+    ) {}
+
+    public function withInput(mixed ...$args): self
+    {
+        $this->expectedInput = EncodedValues::fromValues(\array_values($args), $this->converter)->toPayloads();
+
+        return $this;
+    }
+
+    public function assertCalledTimes(int $times): void
+    {
+        Assert::assertCount(
+            $times,
+            $this->matchingCalls(),
+            \sprintf('Activity "%s" call count mismatch', $this->type),
+        );
+    }
+
+    public function assertCalledOnce(): void
+    {
+        $this->assertCalledTimes(1);
+    }
+
+    public function assertNeverCalled(): void
+    {
+        $this->assertCalledTimes(0);
+    }
+
+    /**
+     * @return list<RecordedCall>
+     */
+    private function matchingCalls(): array
+    {
+        if ($this->expectedInput === null) {
+            return $this->calls;
+        }
+
+        $result = [];
+        foreach ($this->calls as $call) {
+            if (PayloadComparator::equals($call->input, $this->expectedInput)) {
+                $result[] = $call;
+            }
+        }
+
+        return $result;
+    }
+}

--- a/testing/src/Interactions/ChildWorkflowAssertion.php
+++ b/testing/src/Interactions/ChildWorkflowAssertion.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Testing\Interactions;
+
+use PHPUnit\Framework\Assert;
+
+final class ChildWorkflowAssertion
+{
+    /**
+     * @param list<RecordedCall> $calls
+     */
+    public function __construct(
+        private readonly string $type,
+        private readonly array $calls,
+    ) {}
+
+    public function assertStartedTimes(int $times): void
+    {
+        Assert::assertCount(
+            $times,
+            $this->calls,
+            \sprintf('Child workflow "%s" start count mismatch', $this->type),
+        );
+    }
+
+    public function assertStartedOnce(): void
+    {
+        $this->assertStartedTimes(1);
+    }
+
+    public function assertNeverStarted(): void
+    {
+        $this->assertStartedTimes(0);
+    }
+}

--- a/testing/src/Interactions/LocalActivityAssertion.php
+++ b/testing/src/Interactions/LocalActivityAssertion.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Testing\Interactions;
+
+use PHPUnit\Framework\Assert;
+
+final class LocalActivityAssertion
+{
+    /**
+     * @param list<RecordedCall> $calls
+     */
+    public function __construct(
+        private readonly string $type,
+        private readonly array $calls,
+    ) {}
+
+    public function assertCalledTimes(int $times): void
+    {
+        Assert::assertCount(
+            $times,
+            $this->calls,
+            \sprintf('Local activity "%s" call count mismatch', $this->type),
+        );
+    }
+
+    public function assertCalledOnce(): void
+    {
+        $this->assertCalledTimes(1);
+    }
+
+    public function assertNeverCalled(): void
+    {
+        $this->assertCalledTimes(0);
+    }
+}

--- a/testing/src/Interactions/RecordedCall.php
+++ b/testing/src/Interactions/RecordedCall.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Testing\Interactions;
+
+use Temporal\Api\Common\V1\Payloads;
+
+/**
+ * @psalm-immutable
+ */
+final class RecordedCall
+{
+    public function __construct(
+        public readonly RecordedCallKind $kind,
+        public readonly string $name,
+        public readonly ?Payloads $input,
+        public readonly ?int $durationMs,
+    ) {}
+}

--- a/testing/src/Interactions/RecordedCallKind.php
+++ b/testing/src/Interactions/RecordedCallKind.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Testing\Interactions;
+
+enum RecordedCallKind
+{
+    case Activity;
+    case LocalActivity;
+    case ChildWorkflow;
+    case Timer;
+    case Signal;
+}

--- a/testing/src/Interactions/SignalAssertion.php
+++ b/testing/src/Interactions/SignalAssertion.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Testing\Interactions;
+
+use PHPUnit\Framework\Assert;
+
+final class SignalAssertion
+{
+    /**
+     * @param list<RecordedCall> $calls
+     */
+    public function __construct(
+        private readonly string $type,
+        private readonly array $calls,
+    ) {}
+
+    public function assertSentTimes(int $times): void
+    {
+        Assert::assertCount(
+            $times,
+            $this->calls,
+            \sprintf('External signal "%s" sent count mismatch', $this->type),
+        );
+    }
+
+    public function assertSentOnce(): void
+    {
+        $this->assertSentTimes(1);
+    }
+
+    public function assertNeverSent(): void
+    {
+        $this->assertSentTimes(0);
+    }
+}

--- a/testing/src/Interactions/TimerAssertion.php
+++ b/testing/src/Interactions/TimerAssertion.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Testing\Interactions;
+
+use Carbon\CarbonInterval;
+use PHPUnit\Framework\Assert;
+
+final class TimerAssertion
+{
+    /**
+     * @param list<RecordedCall> $calls
+     */
+    public function __construct(
+        private readonly array $calls,
+    ) {}
+
+    public function assertStarted(\DateInterval|int|string $duration): void
+    {
+        $expectedMs = self::toMilliseconds($duration);
+
+        $matching = \array_filter($this->calls, static fn(RecordedCall $call): bool => $call->durationMs === $expectedMs);
+
+        Assert::assertNotEmpty(
+            $matching,
+            \sprintf('No timer was started with duration %d ms', $expectedMs),
+        );
+    }
+
+    public function assertStartedTimes(int $times): void
+    {
+        Assert::assertCount($times, $this->calls, 'Timer start count mismatch');
+    }
+
+    private static function toMilliseconds(\DateInterval|int|string $duration): int
+    {
+        if (\is_int($duration)) {
+            return $duration;
+        }
+
+        return (int) CarbonInterval::make($duration)?->totalMilliseconds;
+    }
+}

--- a/testing/src/Interactions/WorkflowInteractions.php
+++ b/testing/src/Interactions/WorkflowInteractions.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Testing\Interactions;
+
+use Google\Protobuf\Duration;
+use PHPUnit\Framework\Assert;
+use Temporal\Api\Enums\V1\EventType;
+use Temporal\Api\History\V1\HistoryEvent;
+use Temporal\Api\History\V1\MarkerRecordedEventAttributes;
+use Temporal\Client\WorkflowClient;
+use Temporal\DataConverter\DataConverter;
+use Temporal\DataConverter\DataConverterInterface;
+use Temporal\Workflow\WorkflowRunInterface;
+
+final class WorkflowInteractions
+{
+    private const MARKER_LOCAL_ACTIVITY = 'LocalActivity';
+    private const MARKER_DETAIL_DATA = 'data';
+    private const MARKER_ACTIVITY_TYPE_KEY = 'ActivityType';
+
+    /**
+     * @param list<RecordedCall> $calls
+     */
+    private function __construct(
+        private readonly array $calls,
+        private readonly DataConverterInterface $converter,
+        /** @var array<string, true> */
+        private array $queriedActivityTypes = [],
+    ) {}
+
+    public static function of(
+        WorkflowClient $client,
+        WorkflowRunInterface $run,
+        ?DataConverterInterface $converter = null,
+    ): self {
+        $converter ??= DataConverter::createDefault();
+        $history = $client->getWorkflowHistory($run->getExecution());
+
+        return self::fromEvents($history->getEvents(), $converter);
+    }
+
+    /**
+     * @param iterable<HistoryEvent> $events
+     */
+    public static function fromEvents(iterable $events, ?DataConverterInterface $converter = null): self
+    {
+        $converter ??= DataConverter::createDefault();
+        $calls = [];
+        foreach ($events as $event) {
+            $call = self::decode($event);
+            if ($call !== null) {
+                $calls[] = $call;
+            }
+        }
+
+        return new self($calls, $converter);
+    }
+
+    public function activity(string $type): ActivityAssertion
+    {
+        $this->queriedActivityTypes[$type] = true;
+
+        return new ActivityAssertion($type, $this->callsOf(RecordedCallKind::Activity, $type), $this->converter);
+    }
+
+    public function localActivity(string $type): LocalActivityAssertion
+    {
+        return new LocalActivityAssertion($type, $this->callsOf(RecordedCallKind::LocalActivity, $type));
+    }
+
+    public function childWorkflow(string $type): ChildWorkflowAssertion
+    {
+        return new ChildWorkflowAssertion($type, $this->callsOf(RecordedCallKind::ChildWorkflow, $type));
+    }
+
+    public function timer(): TimerAssertion
+    {
+        return new TimerAssertion($this->callsOf(RecordedCallKind::Timer, null));
+    }
+
+    public function signal(string $type): SignalAssertion
+    {
+        return new SignalAssertion($type, $this->callsOf(RecordedCallKind::Signal, $type));
+    }
+
+    public function assertNoOtherActivities(): void
+    {
+        $unexpected = [];
+        foreach ($this->calls as $call) {
+            if ($call->kind === RecordedCallKind::Activity && !isset($this->queriedActivityTypes[$call->name])) {
+                $unexpected[] = $call->name;
+            }
+        }
+
+        Assert::assertSame(
+            [],
+            $unexpected,
+            \sprintf('Unexpected activities scheduled by the workflow: %s', \implode(', ', $unexpected)),
+        );
+    }
+
+    private static function decode(HistoryEvent $event): ?RecordedCall
+    {
+        switch ($event->getEventType()) {
+            case EventType::EVENT_TYPE_ACTIVITY_TASK_SCHEDULED:
+                $attributes = $event->getActivityTaskScheduledEventAttributes();
+                return new RecordedCall(
+                    RecordedCallKind::Activity,
+                    $attributes?->getActivityType()?->getName() ?? '',
+                    $attributes?->getInput(),
+                    null,
+                );
+            case EventType::EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED:
+                $attributes = $event->getStartChildWorkflowExecutionInitiatedEventAttributes();
+                return new RecordedCall(
+                    RecordedCallKind::ChildWorkflow,
+                    $attributes?->getWorkflowType()?->getName() ?? '',
+                    $attributes?->getInput(),
+                    null,
+                );
+            case EventType::EVENT_TYPE_TIMER_STARTED:
+                $attributes = $event->getTimerStartedEventAttributes();
+                return new RecordedCall(
+                    RecordedCallKind::Timer,
+                    '',
+                    null,
+                    self::durationToMs($attributes?->getStartToFireTimeout()),
+                );
+            case EventType::EVENT_TYPE_SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED:
+                $attributes = $event->getSignalExternalWorkflowExecutionInitiatedEventAttributes();
+                return new RecordedCall(
+                    RecordedCallKind::Signal,
+                    $attributes?->getSignalName() ?? '',
+                    $attributes?->getInput(),
+                    null,
+                );
+            case EventType::EVENT_TYPE_MARKER_RECORDED:
+                $attributes = $event->getMarkerRecordedEventAttributes();
+                if ($attributes === null || $attributes->getMarkerName() !== self::MARKER_LOCAL_ACTIVITY) {
+                    return null;
+                }
+                return new RecordedCall(
+                    RecordedCallKind::LocalActivity,
+                    self::localActivityType($attributes),
+                    null,
+                    null,
+                );
+            default:
+                return null;
+        }
+    }
+
+    private static function localActivityType(MarkerRecordedEventAttributes $attributes): string
+    {
+        foreach ($attributes->getDetails() as $key => $payloads) {
+            if ($key !== self::MARKER_DETAIL_DATA) {
+                continue;
+            }
+
+            $items = $payloads->getPayloads();
+            if (\count($items) === 0) {
+                return '';
+            }
+
+            $decoded = \json_decode($items[0]->getData(), true);
+
+            return \is_array($decoded) ? (string) ($decoded[self::MARKER_ACTIVITY_TYPE_KEY] ?? '') : '';
+        }
+
+        return '';
+    }
+
+    private static function durationToMs(?Duration $duration): int
+    {
+        if ($duration === null) {
+            return 0;
+        }
+
+        return (int) ($duration->getSeconds() * 1000 + \intdiv($duration->getNanos(), 1_000_000));
+    }
+
+    /**
+     * @return list<RecordedCall>
+     */
+    private function callsOf(RecordedCallKind $kind, ?string $name): array
+    {
+        $result = [];
+        foreach ($this->calls as $call) {
+            if ($call->kind === $kind && ($name === null || $call->name === $name)) {
+                $result[] = $call;
+            }
+        }
+
+        return $result;
+    }
+}

--- a/testing/src/Interactions/WorkflowInteractions.php
+++ b/testing/src/Interactions/WorkflowInteractions.php
@@ -178,7 +178,7 @@ final class WorkflowInteractions
             return 0;
         }
 
-        return (int) ($duration->getSeconds() * 1000 + \intdiv($duration->getNanos(), 1_000_000));
+        return (int) $duration->getSeconds() * 1000 + \intdiv($duration->getNanos(), 1_000_000);
     }
 
     /**

--- a/testing/src/MockChildWorkflowInterceptor.php
+++ b/testing/src/MockChildWorkflowInterceptor.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Testing;
+
+use React\Promise\PromiseInterface;
+use Temporal\DataConverter\DataConverter;
+use Temporal\DataConverter\DataConverterInterface;
+use Temporal\Api\Enums\V1\RetryState;
+use Temporal\Client\ClientOptions;
+use Temporal\DataConverter\EncodedValues;
+use Temporal\Exception\Failure\ChildWorkflowFailure;
+use Temporal\Interceptor\WorkflowOutboundRequestInterceptor;
+use Temporal\Internal\Transport\Request\ExecuteChildWorkflow;
+use Temporal\Internal\Transport\Request\GetChildWorkflowExecution;
+use Temporal\Internal\Transport\Request\GetVersion;
+use Temporal\Worker\ChildWorkflowInvocationCache\ChildWorkflowInvocationCacheInterface;
+use Temporal\Worker\ChildWorkflowInvocationCache\RoadRunnerChildWorkflowInvocationCache;
+use Temporal\Worker\InvocationFailure;
+use Temporal\Worker\InvocationMatched;
+use Temporal\Worker\Transport\Command\RequestInterface;
+use Temporal\Workflow\WorkflowExecution;
+
+use function React\Promise\reject;
+use function React\Promise\resolve;
+
+final class MockChildWorkflowInterceptor implements WorkflowOutboundRequestInterceptor
+{
+    private ChildWorkflowInvocationCacheInterface $cache;
+    private DataConverterInterface $dataConverter;
+
+    /** @var array<int, true> */
+    private array $mockedRequestIds = [];
+
+    public function __construct(
+        ?ChildWorkflowInvocationCacheInterface $cache = null,
+        ?DataConverterInterface $dataConverter = null,
+    ) {
+        $this->dataConverter = $dataConverter ?? DataConverter::createDefault();
+        $this->cache = $cache ?? RoadRunnerChildWorkflowInvocationCache::create($this->dataConverter);
+    }
+
+    public function handleOutboundRequest(RequestInterface $request, callable $next): PromiseInterface
+    {
+        if ($request instanceof ExecuteChildWorkflow) {
+            return $this->handleExecuteChildWorkflow($request, $next);
+        }
+
+        if ($request instanceof GetChildWorkflowExecution) {
+            return $this->handleGetChildWorkflowExecution($request, $next);
+        }
+
+        if ($request instanceof GetVersion) {
+            return $this->handleGetVersion($request, $next);
+        }
+
+        return $next($request);
+    }
+
+    private function handleGetVersion(GetVersion $request, callable $next): PromiseInterface
+    {
+        $changeId = $request->getChangeId();
+
+        if (!$this->cache->hasVersion($changeId)) {
+            return $next($request);
+        }
+
+        return resolve(EncodedValues::fromValues([$this->cache->getVersion($changeId)]));
+    }
+
+    private function handleExecuteChildWorkflow(ExecuteChildWorkflow $request, callable $next): PromiseInterface
+    {
+        $workflowType = $request->getWorkflowType();
+
+        if (!$this->cache->has($workflowType)) {
+            return $next($request);
+        }
+
+        $value = $this->cache->get($workflowType);
+
+        if ($value instanceof InvocationMatched) {
+            $input = EncodedValues::fromValues($request->getPayloads()->getValues(), $this->dataConverter)->toPayloads();
+            $matched = $value->match($input);
+            if ($matched === null) {
+                return $next($request);
+            }
+            $value = $matched;
+        }
+
+        if ($value instanceof InvocationFailure) {
+            $this->mockedRequestIds[$request->getID()] = true;
+            $this->cache->recordInvoked($workflowType);
+
+            return reject(new ChildWorkflowFailure(
+                0,
+                0,
+                $workflowType,
+                $this->mockedExecution($request->getID()),
+                $request->getOptions()['options']['Namespace'] ?? ClientOptions::DEFAULT_NAMESPACE,
+                RetryState::RETRY_STATE_UNSPECIFIED,
+                $value->toThrowable($this->dataConverter),
+            ));
+        }
+
+        $this->mockedRequestIds[$request->getID()] = true;
+        $this->cache->recordInvoked($workflowType);
+
+        return resolve($value->toEncodedValues($this->dataConverter));
+    }
+
+    private function handleGetChildWorkflowExecution(GetChildWorkflowExecution $request, callable $next): PromiseInterface
+    {
+        $id = $request->getOptions()['id'] ?? null;
+
+        if (!\is_int($id) || !isset($this->mockedRequestIds[$id])) {
+            return $next($request);
+        }
+
+        return resolve(EncodedValues::fromValues([$this->mockedExecution($id)]));
+    }
+
+    private function mockedExecution(int $id): WorkflowExecution
+    {
+        return new WorkflowExecution('mocked-child-' . $id, 'mocked-run-' . $id);
+    }
+}

--- a/testing/src/MockSideEffectInterceptor.php
+++ b/testing/src/MockSideEffectInterceptor.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Testing;
+
+use Temporal\DataConverter\DataConverter;
+use Temporal\DataConverter\DataConverterInterface;
+use Temporal\Interceptor\Trait\WorkflowOutboundCallsInterceptorTrait;
+use Temporal\Interceptor\WorkflowOutboundCalls\SideEffectInput;
+use Temporal\Interceptor\WorkflowOutboundCallsInterceptor;
+use Temporal\Worker\ChildWorkflowInvocationCache\ChildWorkflowInvocationCacheInterface;
+use Temporal\Worker\ChildWorkflowInvocationCache\RoadRunnerChildWorkflowInvocationCache;
+
+final class MockSideEffectInterceptor implements WorkflowOutboundCallsInterceptor
+{
+    use WorkflowOutboundCallsInterceptorTrait;
+
+    private ChildWorkflowInvocationCacheInterface $cache;
+
+    public function __construct(
+        ?ChildWorkflowInvocationCacheInterface $cache = null,
+        ?DataConverterInterface $dataConverter = null,
+    ) {
+        $this->cache = $cache ?? RoadRunnerChildWorkflowInvocationCache::create(
+            $dataConverter ?? DataConverter::createDefault(),
+        );
+    }
+
+    public function sideEffect(SideEffectInput $input, callable $next): mixed
+    {
+        if (!$this->cache->hasSideEffect()) {
+            return $next($input);
+        }
+
+        return $this->cache->nextSideEffect();
+    }
+}

--- a/testing/src/WithoutTimeSkipping.php
+++ b/testing/src/WithoutTimeSkipping.php
@@ -10,16 +10,19 @@ trait WithoutTimeSkipping
 
     protected function setUp(): void
     {
+        parent::setUp();
         $this->testService = TestService::create(
             \getenv('TEMPORAL_ADDRESS') ?: '127.0.0.1:7233',
         );
         $this->testService->lockTimeSkipping();
-        parent::setUp();
     }
 
     protected function tearDown(): void
     {
-        $this->testService->unlockTimeSkipping();
-        parent::tearDown();
+        try {
+            $this->testService->unlockTimeSkipping();
+        } finally {
+            parent::tearDown();
+        }
     }
 }

--- a/testing/src/WorkflowMocker.php
+++ b/testing/src/WorkflowMocker.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Testing;
+
+use PHPUnit\Framework\Assert;
+use Temporal\Worker\ChildWorkflowInvocationCache\ChildWorkflowInvocationCacheInterface;
+use Temporal\Worker\ChildWorkflowInvocationCache\RoadRunnerChildWorkflowInvocationCache;
+
+final class WorkflowMocker
+{
+    private ChildWorkflowInvocationCacheInterface $cache;
+
+    public function __construct(?ChildWorkflowInvocationCacheInterface $cache = null)
+    {
+        $this->cache = $cache ?? RoadRunnerChildWorkflowInvocationCache::create();
+    }
+
+    public function clear(): void
+    {
+        $this->cache->clear();
+    }
+
+    /**
+     * @param non-empty-string $workflowType
+     * @param mixed $value Result the mocked child workflow returns: anything the DataConverter
+     *        can encode (scalar, array, DTO, ...) or an EncodedValues for pre-encoded payloads.
+     */
+    public function expectCompletion(string $workflowType, mixed $value): void
+    {
+        $this->cache->saveCompletion($workflowType, $value);
+    }
+
+    /**
+     * @param non-empty-string $workflowType
+     */
+    public function expectFailure(string $workflowType, \Throwable $error): void
+    {
+        $this->cache->saveFailure($workflowType, $error);
+    }
+
+    /**
+     * @param non-empty-string $workflowType
+     * @param array<array-key, mixed> $args
+     */
+    public function expectCompletionWhen(string $workflowType, array $args, mixed $value): void
+    {
+        $this->cache->saveCompletionWhen($workflowType, $args, $value);
+    }
+
+    /**
+     * @param non-empty-string $workflowType
+     */
+    public function wasInvoked(string $workflowType): bool
+    {
+        return $this->cache->wasInvoked($workflowType);
+    }
+
+    /**
+     * @param non-empty-string $workflowType
+     */
+    public function assertInvoked(string $workflowType): void
+    {
+        Assert::assertTrue(
+            $this->cache->wasInvoked($workflowType),
+            \sprintf('Expected child workflow "%s" mock to be invoked, but it was not.', $workflowType),
+        );
+    }
+
+    /**
+     * @param non-empty-string $workflowType
+     */
+    public function assertNotInvoked(string $workflowType): void
+    {
+        Assert::assertFalse(
+            $this->cache->wasInvoked($workflowType),
+            \sprintf('Expected child workflow "%s" mock NOT to be invoked, but it was.', $workflowType),
+        );
+    }
+
+    /**
+     * @param non-empty-string $changeId
+     */
+    public function expectVersion(string $changeId, int $version): void
+    {
+        $this->cache->saveVersion($changeId, $version);
+    }
+
+    public function expectSideEffect(mixed $value): void
+    {
+        $this->cache->saveSideEffect($value);
+    }
+}

--- a/testing/src/WorkflowTestCase.php
+++ b/testing/src/WorkflowTestCase.php
@@ -7,6 +7,8 @@ namespace Temporal\Testing;
 use PHPUnit\Framework\TestCase;
 use Temporal\Client\GRPC\ServiceClient;
 use Temporal\Client\WorkflowClient;
+use Temporal\Testing\Interactions\WorkflowInteractions;
+use Temporal\Workflow\WorkflowRunInterface;
 
 /**
  * @psalm-suppress PropertyNotSetInConstructor
@@ -15,6 +17,8 @@ class WorkflowTestCase extends TestCase
 {
     protected WorkflowClient $workflowClient;
     protected TestService $testingService;
+    protected ActivityMocker $activityMocks;
+    protected WorkflowMocker $workflowMocks;
 
     protected function setUp(): void
     {
@@ -22,7 +26,22 @@ class WorkflowTestCase extends TestCase
         $temporalAddress = \is_string($temporalAddress) && !empty($temporalAddress) ? $temporalAddress : '127.0.0.1:7233';
         $this->workflowClient = new WorkflowClient(ServiceClient::create($temporalAddress));
         $this->testingService = TestService::create($temporalAddress);
+        $this->activityMocks = new ActivityMocker();
+        $this->workflowMocks = new WorkflowMocker();
 
         parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->activityMocks->clear();
+        $this->workflowMocks->clear();
+
+        parent::tearDown();
+    }
+
+    protected function interactions(WorkflowRunInterface $run): WorkflowInteractions
+    {
+        return WorkflowInteractions::of($this->workflowClient, $run);
     }
 }

--- a/tests/Fixtures/PipelineProvider.php
+++ b/tests/Fixtures/PipelineProvider.php
@@ -14,6 +14,7 @@ namespace Temporal\Tests\Fixtures;
 use Temporal\Interceptor\ActivityInboundInterceptor;
 use Temporal\Interceptor\WorkflowClientCallsInterceptor;
 use Temporal\Interceptor\WorkflowInboundCallsInterceptor;
+use Temporal\Interceptor\WorkflowOutboundCallsInterceptor;
 use Temporal\Interceptor\WorkflowOutboundRequestInterceptor;
 use Temporal\Internal\Interceptor\Interceptor;
 use Temporal\Internal\Interceptor\Pipeline;
@@ -28,6 +29,7 @@ final class PipelineProvider implements \Temporal\Interceptor\PipelineProvider
     private array $classes = [
         WorkflowInboundCallsInterceptor::class => [],
         WorkflowOutboundRequestInterceptor::class => [],
+        WorkflowOutboundCallsInterceptor::class => [],
         ActivityInboundInterceptor::class => [],
         WorkflowClientCallsInterceptor::class => [],
     ];

--- a/tests/Fixtures/src/Workflow/ChildWithLongTimerWorkflow.php
+++ b/tests/Fixtures/src/Workflow/ChildWithLongTimerWorkflow.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Workflow;
+
+use Carbon\CarbonInterval;
+use Temporal\Workflow;
+use Temporal\Workflow\WorkflowMethod;
+
+#[Workflow\WorkflowInterface]
+class ChildWithLongTimerWorkflow
+{
+    #[WorkflowMethod(name: 'ChildWithLongTimerWorkflow')]
+    public function handler(): iterable
+    {
+        yield Workflow::timer(CarbonInterval::minutes(30));
+
+        return 'child done';
+    }
+}

--- a/tests/Fixtures/src/Workflow/FailingChildWorkflow.php
+++ b/tests/Fixtures/src/Workflow/FailingChildWorkflow.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Workflow;
+
+use Temporal\Workflow;
+use Temporal\Workflow\WorkflowMethod;
+
+#[Workflow\WorkflowInterface]
+class FailingChildWorkflow
+{
+    #[WorkflowMethod(name: 'FailingChildWorkflow')]
+    public function handler(string $input): string
+    {
+        throw new \RuntimeException('real child exploded: ' . $input);
+    }
+}

--- a/tests/Fixtures/src/Workflow/LocalActivityReturningWorkflow.php
+++ b/tests/Fixtures/src/Workflow/LocalActivityReturningWorkflow.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Workflow;
+
+use Temporal\Activity\LocalActivityOptions;
+use Temporal\Tests\Activity\JustLocalActivity;
+use Temporal\Workflow;
+use Temporal\Workflow\WorkflowMethod;
+
+#[Workflow\WorkflowInterface]
+class LocalActivityReturningWorkflow
+{
+    #[WorkflowMethod(name: 'LocalActivityReturningWorkflow')]
+    public function handler(string $input): iterable
+    {
+        return yield Workflow::newActivityStub(
+            JustLocalActivity::class,
+            LocalActivityOptions::new()->withStartToCloseTimeout('10 seconds'),
+        )->echo($input);
+    }
+}

--- a/tests/Fixtures/src/Workflow/ParentWithChildAndTimerWorkflow.php
+++ b/tests/Fixtures/src/Workflow/ParentWithChildAndTimerWorkflow.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Workflow;
+
+use Carbon\CarbonInterval;
+use Temporal\Workflow;
+use Temporal\Workflow\ChildWorkflowOptions;
+use Temporal\Workflow\WorkflowMethod;
+
+#[Workflow\WorkflowInterface]
+class ParentWithChildAndTimerWorkflow
+{
+    #[WorkflowMethod(name: 'ParentWithChildAndTimerWorkflow')]
+    public function handler(): iterable
+    {
+        $child = yield Workflow::executeChildWorkflow(
+            'ChildWithLongTimerWorkflow',
+            [],
+            ChildWorkflowOptions::new(),
+        );
+
+        yield Workflow::timer(CarbonInterval::minutes(30));
+
+        return 'parent: ' . $child;
+    }
+}

--- a/tests/Fixtures/src/Workflow/ParentWithStubbableChildWorkflow.php
+++ b/tests/Fixtures/src/Workflow/ParentWithStubbableChildWorkflow.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Workflow;
+
+use Temporal\Common\RetryOptions;
+use Temporal\Workflow;
+use Temporal\Workflow\ChildWorkflowOptions;
+use Temporal\Workflow\WorkflowMethod;
+
+#[Workflow\WorkflowInterface]
+class ParentWithStubbableChildWorkflow
+{
+    #[WorkflowMethod(name: 'ParentWithStubbableChildWorkflow')]
+    public function handler(string $childType, string $input): iterable
+    {
+        try {
+            $result = yield Workflow::executeChildWorkflow(
+                $childType,
+                [$input],
+                ChildWorkflowOptions::new()
+                    ->withRetryOptions(RetryOptions::new()->withMaximumAttempts(1)),
+            );
+        } catch (\Throwable $e) {
+            $chain = ['error'];
+            for ($current = $e; $current !== null; $current = $current->getPrevious()) {
+                $chain[] = $current::class . ': ' . $current->getMessage();
+            }
+
+            return $chain;
+        }
+
+        return ['ok', $result];
+    }
+}

--- a/tests/Fixtures/src/Workflow/RepeatedActivityWorkflow.php
+++ b/tests/Fixtures/src/Workflow/RepeatedActivityWorkflow.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Workflow;
+
+use Temporal\Activity\ActivityOptions;
+use Temporal\Tests\Activity\SimpleActivity;
+use Temporal\Workflow;
+use Temporal\Workflow\WorkflowMethod;
+
+#[Workflow\WorkflowInterface]
+class RepeatedActivityWorkflow
+{
+    #[WorkflowMethod(name: 'RepeatedActivityWorkflow')]
+    public function handler(): iterable
+    {
+        $activity = Workflow::newActivityStub(
+            SimpleActivity::class,
+            ActivityOptions::new()->withStartToCloseTimeout(5),
+        );
+
+        $result = [];
+        $result[] = yield $activity->echo('x');
+        $result[] = yield $activity->echo('x');
+
+        return $result;
+    }
+}

--- a/tests/Fixtures/src/Workflow/StubbableChildWorkflow.php
+++ b/tests/Fixtures/src/Workflow/StubbableChildWorkflow.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Workflow;
+
+use Temporal\Workflow;
+use Temporal\Workflow\WorkflowMethod;
+
+#[Workflow\WorkflowInterface]
+class StubbableChildWorkflow
+{
+    #[WorkflowMethod(name: 'StubbableChildWorkflow')]
+    public function handler(string $input): string
+    {
+        return 'real child: ' . $input;
+    }
+}

--- a/tests/Fixtures/src/Workflow/VersionedWorkflow.php
+++ b/tests/Fixtures/src/Workflow/VersionedWorkflow.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Workflow;
+
+use Temporal\Workflow;
+use Temporal\Workflow\WorkflowMethod;
+
+#[Workflow\WorkflowInterface]
+class VersionedWorkflow
+{
+    #[WorkflowMethod(name: 'VersionedWorkflow')]
+    public function handler(): iterable
+    {
+        return yield Workflow::getVersion('change-1', Workflow::DEFAULT_VERSION, 5);
+    }
+}

--- a/tests/Functional/ActivityInvocationCacheTestCase.php
+++ b/tests/Functional/ActivityInvocationCacheTestCase.php
@@ -8,7 +8,7 @@ use DateTimeImmutable;
 use Exception;
 use Temporal\DataConverter\EncodedValues;
 use Temporal\DataConverter\ValuesInterface;
-use Temporal\Exception\Failure\ActivityFailure;
+use Temporal\Exception\Failure\ApplicationFailure;
 use Temporal\Worker\ActivityInvocationCache\RoadRunnerActivityInvocationCache;
 use Temporal\Worker\Transport\Command\Server\ServerRequest;
 use Temporal\Worker\Transport\Command\Server\TickInfo;
@@ -28,23 +28,43 @@ class ActivityInvocationCacheTestCase extends AbstractFunctional
     {
         $this->cache->saveCompletion('MyActivity.myMethod', 'foo');
         $result = $this->cache->execute($this->makeRequest('InvokeActivity', 'MyActivity.myMethod', EncodedValues::empty()));
+
+        $value = null;
+        $rejected = null;
         $result->then(
-            fn($value) => $this->assertSame('foo', $value),
-            fn(Exception $exception) => $this->fail($exception->getMessage())
+            function ($resolved) use (&$value): void {
+                $value = $resolved;
+            },
+            function (\Throwable $exception) use (&$rejected): void {
+                $rejected = $exception;
+            },
         );
+
+        self::assertNull($rejected, 'Completion should resolve, not reject');
+        self::assertInstanceOf(EncodedValues::class, $value);
+        self::assertSame('foo', $value->getValue(0, 'string'));
     }
 
     public function testActivityFailureIsStoredInCache(): void
     {
         $this->cache->saveFailure('MyActivity.myMethod', new \LogicException('some error'));
         $result = $this->cache->execute($this->makeRequest('InvokeActivity', 'MyActivity.myMethod', EncodedValues::empty()));
+
+        $rejected = null;
+        $resolved = false;
         $result->then(
-            fn(Exception $exception) => $this->fail('Activity should fail'),
-            function (Exception $exception) {
-                $this->assertInstanceOf(ActivityFailure::class, $exception);
-                $this->assertSame('some error', $exception->getMessage());
-            }
+            function ($value) use (&$resolved): void {
+                $resolved = true;
+            },
+            function (\Throwable $exception) use (&$rejected): void {
+                $rejected = $exception;
+            },
         );
+
+        self::assertFalse($resolved, 'Activity should fail, not resolve');
+        self::assertInstanceOf(ApplicationFailure::class, $rejected);
+        self::assertSame('LogicException', $rejected->getType());
+        self::assertSame('some error', $rejected->getOriginalMessage());
     }
 
     public function testCacheCanHandleStoredResult(): void

--- a/tests/Functional/ActivityMockerTestCase.php
+++ b/tests/Functional/ActivityMockerTestCase.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Functional;
+
+use Temporal\Exception\Client\WorkflowFailedException;
+use Temporal\Exception\Failure\ActivityFailure;
+use Temporal\Exception\Failure\ApplicationFailure;
+use Temporal\Testing\WorkflowTestCase;
+use Temporal\Tests\Workflow\LocalActivityReturningWorkflow;
+use Temporal\Tests\Workflow\RepeatedActivityWorkflow;
+use Temporal\Tests\Workflow\SimpleWorkflow;
+
+final class ActivityMockerTestCase extends WorkflowTestCase
+{
+    public function testMockedFailurePreservesTypeAndNonRetryableFlag(): void
+    {
+        $this->activityMocks->expectFailure(
+            'SimpleActivity.echo',
+            new ApplicationFailure('boom', 'MyType', nonRetryable: true),
+        );
+
+        $workflow = $this->workflowClient->newWorkflowStub(SimpleWorkflow::class);
+        $run = $this->workflowClient->start($workflow, 'input');
+
+        try {
+            $run->getResult('string', 10);
+            self::fail('Expected the mocked activity failure to propagate');
+        } catch (WorkflowFailedException $e) {
+            $activityFailure = $e->getPrevious();
+            self::assertInstanceOf(ActivityFailure::class, $activityFailure);
+
+            $cause = $activityFailure->getPrevious();
+            self::assertInstanceOf(ApplicationFailure::class, $cause);
+            self::assertSame('MyType', $cause->getType());
+            self::assertTrue($cause->isNonRetryable());
+            self::assertStringContainsString('boom', $cause->getOriginalMessage());
+        }
+    }
+
+    public function testLocalActivityIsMocked(): void
+    {
+        $this->activityMocks->expectCompletion('JustLocalActivity.echo', 'mocked-local');
+
+        $workflow = $this->workflowClient->newWorkflowStub(LocalActivityReturningWorkflow::class);
+        $run = $this->workflowClient->start($workflow, 'input');
+
+        self::assertSame('mocked-local', $run->getResult('string', 10));
+    }
+
+    public function testConsecutiveCompletionsReturnPerCallInOrder(): void
+    {
+        $this->activityMocks->expectConsecutiveCompletions('SimpleActivity.echo', ['first', 'second']);
+
+        $workflow = $this->workflowClient->newWorkflowStub(RepeatedActivityWorkflow::class);
+        $run = $this->workflowClient->start($workflow);
+
+        self::assertSame(['first', 'second'], $run->getResult('array', 10));
+    }
+
+    public function testCompletionMatchedByInput(): void
+    {
+        $this->activityMocks->expectCompletionWhen('SimpleActivity.echo', ['hello'], 'matched-hello');
+        $this->activityMocks->expectCompletionWhen('SimpleActivity.echo', ['other'], 'matched-other');
+
+        $workflow = $this->workflowClient->newWorkflowStub(SimpleWorkflow::class);
+        $run = $this->workflowClient->start($workflow, 'hello');
+
+        self::assertSame('matched-hello', $run->getResult('string', 10));
+    }
+}

--- a/tests/Functional/ChildWorkflowMockArgMatchTestCase.php
+++ b/tests/Functional/ChildWorkflowMockArgMatchTestCase.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Functional;
+
+use Temporal\Api\Enums\V1\EventType;
+use Temporal\Testing\WorkflowTestCase;
+use Temporal\Tests\Workflow\WithChildWorkflow;
+use Temporal\Workflow\WorkflowExecution;
+
+final class ChildWorkflowMockArgMatchTestCase extends WorkflowTestCase
+{
+    public function testMatchingArgumentsSelectTheirOwnMock(): void
+    {
+        $this->workflowMocks->expectCompletionWhen('SimpleWorkflow', ['child A'], 'result-A');
+        $this->workflowMocks->expectCompletionWhen('SimpleWorkflow', ['child B'], 'result-B');
+
+        $runA = $this->workflowClient->start(
+            $this->workflowClient->newWorkflowStub(WithChildWorkflow::class),
+            'A',
+        );
+        self::assertSame('Child: result-A', $runA->getResult('string', 10));
+        $this->assertNotContainsEvent(
+            $runA->getExecution(),
+            EventType::EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED,
+        );
+
+        $runB = $this->workflowClient->start(
+            $this->workflowClient->newWorkflowStub(WithChildWorkflow::class),
+            'B',
+        );
+        self::assertSame('Child: result-B', $runB->getResult('string', 10));
+    }
+
+    public function testUnmatchedArgumentsRunTheRealChild(): void
+    {
+        $this->workflowMocks->expectCompletionWhen('SimpleWorkflow', ['child A'], 'result-A');
+
+        $run = $this->workflowClient->start(
+            $this->workflowClient->newWorkflowStub(WithChildWorkflow::class),
+            'Z',
+        );
+
+        self::assertSame('Child: CHILD Z', $run->getResult('string', 10));
+        $this->assertContainsEvent(
+            $run->getExecution(),
+            EventType::EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED,
+        );
+    }
+
+    private function assertNotContainsEvent(WorkflowExecution $execution, int $event): void
+    {
+        $history = $this->workflowClient->getWorkflowHistory($execution, pageSize: 50);
+        foreach ($history as $item) {
+            if ($item->getEventType() === $event) {
+                self::fail(\sprintf('Unexpected event %s found in history', EventType::name($event)));
+            }
+        }
+
+        self::assertTrue(true);
+    }
+
+    private function assertContainsEvent(WorkflowExecution $execution, int $event): void
+    {
+        $history = $this->workflowClient->getWorkflowHistory($execution, pageSize: 50);
+        foreach ($history as $item) {
+            if ($item->getEventType() === $event) {
+                self::assertTrue(true);
+                return;
+            }
+        }
+
+        self::fail(\sprintf('Expected event %s not found in history', EventType::name($event)));
+    }
+}

--- a/tests/Functional/ChildWorkflowMockerTestCase.php
+++ b/tests/Functional/ChildWorkflowMockerTestCase.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Functional;
+
+use Temporal\Api\Enums\V1\EventType;
+use Temporal\Exception\Failure\ApplicationFailure;
+use Temporal\Exception\Failure\ChildWorkflowFailure;
+use Temporal\Testing\WorkflowMocker;
+use Temporal\Testing\WorkflowTestCase;
+use Temporal\Tests\Workflow\ParentWithStubbableChildWorkflow;
+use Temporal\Workflow\WorkflowExecution;
+
+final class ChildWorkflowMockerTestCase extends WorkflowTestCase
+{
+    private ?WorkflowMocker $childWorkflowMocks = null;
+
+    public function testControlRealChildRunsWhenNoStubConfigured(): void
+    {
+        [$result, $execution] = $this->runParent('StubbableChildWorkflow', 'hello');
+
+        self::assertSame(['ok', 'real child: hello'], $result);
+        $this->assertContainsEvent($execution, EventType::EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED);
+    }
+
+    public function testControlRealChildFailureIsObservedByParent(): void
+    {
+        [$result, $execution] = $this->runParent('FailingChildWorkflow', 'boom');
+
+        self::assertSame('error', $result[0]);
+        self::assertStringStartsWith(ChildWorkflowFailure::class . ':', $result[1]);
+        self::assertStringContainsString('real child exploded: boom', \implode("\n", $result));
+        $this->assertContainsEvent($execution, EventType::EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED);
+    }
+
+    public function testStubbedChildReturnsConfiguredValueToParent(): void
+    {
+        $this->childWorkflowMocks()->expectCompletion('StubbableChildWorkflow', 'stubbed child value');
+
+        [$result] = $this->runParent('StubbableChildWorkflow', 'hello');
+
+        self::assertSame(['ok', 'stubbed child value'], $result);
+    }
+
+    public function testStubbedChildFailureIsObservedByParent(): void
+    {
+        $this->childWorkflowMocks()->expectFailure(
+            'StubbableChildWorkflow',
+            new \RuntimeException('stubbed child exploded'),
+        );
+
+        [$result] = $this->runParent('StubbableChildWorkflow', 'hello');
+
+        self::assertSame('error', $result[0]);
+        self::assertStringStartsWith(ChildWorkflowFailure::class . ':', $result[1]);
+        self::assertStringContainsString('stubbed child exploded', \implode("\n", $result));
+    }
+
+    public function testStubbedChildFailureWithMultiArgExceptionPreservesCause(): void
+    {
+        $this->childWorkflowMocks()->expectFailure(
+            'StubbableChildWorkflow',
+            new ApplicationFailure('multi-arg boom', 'MyType', nonRetryable: true),
+        );
+
+        [$result] = $this->runParent('StubbableChildWorkflow', 'hello');
+
+        self::assertSame('error', $result[0]);
+        self::assertStringStartsWith(ChildWorkflowFailure::class . ':', $result[1]);
+        $chain = \implode("\n", $result);
+        self::assertStringContainsString(ApplicationFailure::class, $chain);
+        self::assertStringContainsString('MyType', $chain);
+        self::assertStringContainsString('multi-arg boom', $chain);
+    }
+
+    public function testStubbedChildDoesNotStartRealChildExecution(): void
+    {
+        $this->childWorkflowMocks()->expectCompletion('StubbableChildWorkflow', 'stubbed child value');
+
+        [$result, $execution] = $this->runParent('StubbableChildWorkflow', 'hello');
+
+        self::assertSame(['ok', 'stubbed child value'], $result);
+        $this->assertNotContainsEvent($execution, EventType::EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED);
+        $this->assertNotContainsEvent($execution, EventType::EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_STARTED);
+        $this->assertNotContainsEvent($execution, EventType::EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_COMPLETED);
+    }
+
+    public function testStubIsVisibleInTheTestThatConfiguresIt(): void
+    {
+        $this->childWorkflowMocks()->expectCompletion('StubbableChildWorkflow', 'value from the leaking test');
+
+        [$result] = $this->runParent('StubbableChildWorkflow', 'hello');
+
+        self::assertSame(['ok', 'value from the leaking test'], $result);
+    }
+
+    public function testStubFromPreviousTestDoesNotLeakIntoThisOne(): void
+    {
+        [$result, $execution] = $this->runParent('StubbableChildWorkflow', 'hello');
+
+        self::assertSame(['ok', 'real child: hello'], $result);
+        $this->assertContainsEvent($execution, EventType::EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED);
+    }
+
+    public function testMockedChildIsInvisibleToWorkflowInteractions(): void
+    {
+        $this->childWorkflowMocks()->expectCompletion('StubbableChildWorkflow', 'stubbed');
+
+        $parent = $this->workflowClient->newWorkflowStub(ParentWithStubbableChildWorkflow::class);
+        $run = $this->workflowClient->start($parent, 'StubbableChildWorkflow', 'hello');
+
+        self::assertSame(['ok', 'stubbed'], $run->getResult('array', 30));
+
+        $this->interactions($run)->childWorkflow('StubbableChildWorkflow')->assertNeverStarted();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->childWorkflowMocks?->clear();
+        $this->childWorkflowMocks = null;
+
+        parent::tearDown();
+    }
+
+    private function childWorkflowMocks(): WorkflowMocker
+    {
+        return $this->childWorkflowMocks ??= new WorkflowMocker();
+    }
+
+    /**
+     * @return array{0: array, 1: WorkflowExecution}
+     */
+    private function runParent(string $childType, string $input): array
+    {
+        $parent = $this->workflowClient->newWorkflowStub(ParentWithStubbableChildWorkflow::class);
+        $run = $this->workflowClient->start($parent, $childType, $input);
+
+        return [$run->getResult('array', 30), $run->getExecution()];
+    }
+
+    private function assertContainsEvent(WorkflowExecution $execution, int $event): void
+    {
+        if (!$this->hasEvent($execution, $event)) {
+            self::fail(\sprintf('Event %s not found in workflow history', EventType::value($event)));
+        }
+
+        self::assertTrue(true);
+    }
+
+    private function assertNotContainsEvent(WorkflowExecution $execution, int $event): void
+    {
+        if ($this->hasEvent($execution, $event)) {
+            self::fail(\sprintf('Event %s unexpectedly found in workflow history', EventType::value($event)));
+        }
+
+        self::assertTrue(true);
+    }
+
+    private function hasEvent(WorkflowExecution $execution, int $event): bool
+    {
+        foreach ($this->workflowClient->getWorkflowHistory($execution, pageSize: 100) as $item) {
+            if ($item->getEventType() === $event) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Functional/ChildWorkflowMockerTimeSkippingTestCase.php
+++ b/tests/Functional/ChildWorkflowMockerTimeSkippingTestCase.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Functional;
+
+use Temporal\Testing\WorkflowMocker;
+use Temporal\Testing\WorkflowTestCase;
+use Temporal\Tests\Workflow\ChildWithLongTimerWorkflow;
+use Temporal\Tests\Workflow\ParentWithChildAndTimerWorkflow;
+
+final class ChildWorkflowMockerTimeSkippingTestCase extends WorkflowTestCase
+{
+    private const TIMER_SECONDS = 1800;
+    private const MAX_WALL_CLOCK_SECONDS = 60;
+
+    private ?WorkflowMocker $childWorkflowMocks = null;
+
+    public function testParentWithStubbedChildSkipsThirtyMinuteTimerWithoutRealWaiting(): void
+    {
+        $this->childWorkflowMocks()->expectCompletion('ChildWithLongTimerWorkflow', 'stubbed child');
+
+        $serverTimeBefore = $this->testingService->getCurrentTime();
+        $wallClockBefore = \microtime(true);
+
+        $parent = $this->workflowClient->newWorkflowStub(ParentWithChildAndTimerWorkflow::class);
+        $run = $this->workflowClient->start($parent);
+        $result = $run->getResult('string', self::MAX_WALL_CLOCK_SECONDS);
+
+        $wallClockElapsed = \microtime(true) - $wallClockBefore;
+        $serverTimeElapsed = $this->testingService->getCurrentTime()->getTimestamp() - $serverTimeBefore->getTimestamp();
+
+        self::assertSame('parent: stubbed child', $result);
+        self::assertGreaterThanOrEqual(self::TIMER_SECONDS, $serverTimeElapsed);
+        self::assertLessThan(self::MAX_WALL_CLOCK_SECONDS, $wallClockElapsed);
+    }
+
+    public function testChildWorkflowSkipsItsTimerRegardlessOfEarlierTests(): void
+    {
+        $serverTimeBefore = $this->testingService->getCurrentTime();
+        $wallClockBefore = \microtime(true);
+
+        $child = $this->workflowClient->newWorkflowStub(ChildWithLongTimerWorkflow::class);
+        $run = $this->workflowClient->start($child);
+        $result = $run->getResult('string', self::MAX_WALL_CLOCK_SECONDS);
+
+        $wallClockElapsed = \microtime(true) - $wallClockBefore;
+        $serverTimeElapsed = $this->testingService->getCurrentTime()->getTimestamp() - $serverTimeBefore->getTimestamp();
+
+        self::assertSame('child done', $result);
+        self::assertGreaterThanOrEqual(self::TIMER_SECONDS, $serverTimeElapsed);
+        self::assertLessThan(self::MAX_WALL_CLOCK_SECONDS, $wallClockElapsed);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->childWorkflowMocks?->clear();
+        $this->childWorkflowMocks = null;
+
+        parent::tearDown();
+    }
+
+    private function childWorkflowMocks(): WorkflowMocker
+    {
+        return $this->childWorkflowMocks ??= new WorkflowMocker();
+    }
+}

--- a/tests/Functional/GetVersionMockTestCase.php
+++ b/tests/Functional/GetVersionMockTestCase.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Functional;
+
+use Temporal\Testing\WorkflowTestCase;
+use Temporal\Tests\Workflow\VersionedWorkflow;
+
+final class GetVersionMockTestCase extends WorkflowTestCase
+{
+    public function testPinnedVersionOverridesDefault(): void
+    {
+        $this->workflowMocks->expectVersion('change-1', 3);
+
+        $workflow = $this->workflowClient->newWorkflowStub(VersionedWorkflow::class);
+        $run = $this->workflowClient->start($workflow);
+
+        self::assertSame(3, $run->getResult('int', 10));
+    }
+}

--- a/tests/Functional/MockChildWorkflowTestCase.php
+++ b/tests/Functional/MockChildWorkflowTestCase.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Functional;
+
+use Temporal\Api\Enums\V1\EventType;
+use Temporal\Exception\Client\WorkflowFailedException;
+use Temporal\Testing\WorkflowTestCase;
+use Temporal\Tests\Workflow\WithChildStubWorkflow;
+use Temporal\Tests\Workflow\WithChildWorkflow;
+use Temporal\Workflow\WorkflowExecution;
+
+final class MockChildWorkflowTestCase extends WorkflowTestCase
+{
+    public function testMockedChildWorkflowViaExecuteChildWorkflow(): void
+    {
+        $this->workflowMocks->expectCompletion('SimpleWorkflow', 'mocked-child-result');
+
+        $workflow = $this->workflowClient->newWorkflowStub(WithChildWorkflow::class);
+        $run = $this->workflowClient->start($workflow, 'input');
+
+        self::assertSame('Child: mocked-child-result', $run->getResult('string', 10));
+        $this->assertNotContainsEvent(
+            $run->getExecution(),
+            EventType::EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED,
+        );
+        $this->workflowMocks->assertInvoked('SimpleWorkflow');
+    }
+
+    public function testMockedChildWorkflowViaTypedStub(): void
+    {
+        $this->workflowMocks->expectCompletion('SimpleWorkflow', 'typed-stub-mock');
+
+        $workflow = $this->workflowClient->newWorkflowStub(WithChildStubWorkflow::class);
+        $run = $this->workflowClient->start($workflow, 'input');
+
+        self::assertSame('Child: typed-stub-mock', $run->getResult('string', 10));
+        $this->assertNotContainsEvent(
+            $run->getExecution(),
+            EventType::EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED,
+        );
+    }
+
+    public function testUnmockedChildWorkflowRunsForReal(): void
+    {
+        $workflow = $this->workflowClient->newWorkflowStub(WithChildWorkflow::class);
+        $run = $this->workflowClient->start($workflow, 'input');
+
+        self::assertSame('Child: CHILD INPUT', $run->getResult('string', 10));
+        $this->assertContainsEvent(
+            $run->getExecution(),
+            EventType::EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED,
+        );
+        $this->workflowMocks->assertNotInvoked('SimpleWorkflow');
+    }
+
+    public function testMockedChildWorkflowFailurePropagatesToParent(): void
+    {
+        $this->workflowMocks->expectFailure('SimpleWorkflow', new \RuntimeException('mocked child failure'));
+
+        $workflow = $this->workflowClient->newWorkflowStub(WithChildWorkflow::class);
+        $run = $this->workflowClient->start($workflow, 'input');
+
+        $this->expectException(WorkflowFailedException::class);
+        $run->getResult('string', 10);
+    }
+
+    private function assertNotContainsEvent(WorkflowExecution $execution, int $event): void
+    {
+        $history = $this->workflowClient->getWorkflowHistory($execution, pageSize: 50);
+        foreach ($history as $item) {
+            if ($item->getEventType() === $event) {
+                self::fail(\sprintf('Unexpected event %s found in history', EventType::name($event)));
+            }
+        }
+
+        self::assertTrue(true);
+    }
+
+    private function assertContainsEvent(WorkflowExecution $execution, int $event): void
+    {
+        $history = $this->workflowClient->getWorkflowHistory($execution, pageSize: 50);
+        foreach ($history as $item) {
+            if ($item->getEventType() === $event) {
+                self::assertTrue(true);
+                return;
+            }
+        }
+
+        self::fail(\sprintf('Expected event %s not found in history', EventType::name($event)));
+    }
+}

--- a/tests/Functional/SideEffectMockTestCase.php
+++ b/tests/Functional/SideEffectMockTestCase.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Functional;
+
+use Temporal\Testing\WorkflowTestCase;
+use Temporal\Tests\Workflow\SideEffectWorkflow;
+
+final class SideEffectMockTestCase extends WorkflowTestCase
+{
+    public function testMockedSideEffectOverridesClosureResult(): void
+    {
+        $this->workflowMocks->expectSideEffect('OVERRIDDEN');
+
+        $workflow = $this->workflowClient->newWorkflowStub(SideEffectWorkflow::class);
+        $run = $this->workflowClient->start($workflow, 'Hello');
+
+        self::assertSame('overridden', $run->getResult('string', 10));
+    }
+}

--- a/tests/Functional/WorkflowInteractionsTestCase.php
+++ b/tests/Functional/WorkflowInteractionsTestCase.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Functional;
+
+use Temporal\Testing\WorkflowTestCase;
+use Temporal\Tests\Workflow\LocalActivityReturningWorkflow;
+use Temporal\Tests\Workflow\SignalChildViaStubWorkflow;
+use Temporal\Tests\Workflow\SimpleWorkflow;
+use Temporal\Tests\Workflow\TimerWorkflow;
+use Temporal\Tests\Workflow\WithChildWorkflow;
+
+final class WorkflowInteractionsTestCase extends WorkflowTestCase
+{
+    public function testActivityInteractionsOfRealWorkflow(): void
+    {
+        $workflow = $this->workflowClient->newWorkflowStub(SimpleWorkflow::class);
+        $run = $this->workflowClient->start($workflow, 'hello');
+        self::assertSame('HELLO', $run->getResult('string', 10));
+
+        $interactions = $this->interactions($run);
+
+        $interactions->activity('SimpleActivity.echo')->withInput('hello')->assertCalledOnce();
+        $interactions->activity('SimpleActivity.echo')->withInput('nope')->assertNeverCalled();
+        $interactions->activity('SimpleActivity.greet')->assertNeverCalled();
+        $interactions->assertNoOtherActivities();
+    }
+
+    public function testChildWorkflowInteractionsOfRealWorkflow(): void
+    {
+        $workflow = $this->workflowClient->newWorkflowStub(WithChildWorkflow::class);
+        $run = $this->workflowClient->start($workflow, 'input');
+        self::assertSame('Child: CHILD INPUT', $run->getResult('string', 10));
+
+        $interactions = $this->interactions($run);
+
+        $interactions->childWorkflow('SimpleWorkflow')->assertStartedOnce();
+        $interactions->childWorkflow('Other')->assertNeverStarted();
+    }
+
+    public function testTimerInteractionsOfRealWorkflow(): void
+    {
+        $workflow = $this->workflowClient->newWorkflowStub(TimerWorkflow::class);
+        $run = $this->workflowClient->start($workflow, 'INPUT');
+        self::assertSame('input', $run->getResult('string', 10));
+
+        $interactions = $this->interactions($run);
+
+        $interactions->timer()->assertStarted('1 second');
+        $interactions->timer()->assertStarted(1000);
+        $interactions->timer()->assertStartedTimes(1);
+    }
+
+    public function testExternalSignalInteractionsOfRealWorkflow(): void
+    {
+        $workflow = $this->workflowClient->newWorkflowStub(SignalChildViaStubWorkflow::class);
+        $run = $this->workflowClient->start($workflow);
+        self::assertSame(8, $run->getResult('int', 10));
+
+        $interactions = $this->interactions($run);
+
+        $interactions->childWorkflow('SimpleSignalledWorkflow')->assertStartedOnce();
+        $interactions->signal('add')->assertSentOnce();
+        $interactions->signal('nonexistent')->assertNeverSent();
+    }
+
+    public function testLocalActivityInteractionsOfRealWorkflow(): void
+    {
+        $workflow = $this->workflowClient->newWorkflowStub(LocalActivityReturningWorkflow::class);
+        $run = $this->workflowClient->start($workflow, 'input');
+        $run->getResult(null, 10);
+
+        $interactions = $this->interactions($run);
+
+        $interactions->localActivity('JustLocalActivity.echo')->assertCalledOnce();
+        $interactions->localActivity('Nope')->assertNeverCalled();
+    }
+}

--- a/tests/Functional/WorkflowTestCaseInteractionsTestCase.php
+++ b/tests/Functional/WorkflowTestCaseInteractionsTestCase.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Functional;
+
+use Temporal\Testing\WorkflowTestCase;
+use Temporal\Tests\Workflow\SimpleWorkflow;
+
+final class WorkflowTestCaseInteractionsTestCase extends WorkflowTestCase
+{
+    public function testMockedActivityAndInteractionsFromBase(): void
+    {
+        $this->activityMocks->expectCompletion('SimpleActivity.echo', 'mocked');
+
+        $workflow = $this->workflowClient->newWorkflowStub(SimpleWorkflow::class);
+        $run = $this->workflowClient->start($workflow, 'hello');
+
+        self::assertSame('mocked', $run->getResult('string', 10));
+
+        $this->interactions($run)
+            ->activity('SimpleActivity.echo')
+            ->withInput('hello')
+            ->assertCalledOnce();
+    }
+}

--- a/tests/Functional/worker.php
+++ b/tests/Functional/worker.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Temporal\Testing\MockChildWorkflowInterceptor;
+use Temporal\Testing\MockSideEffectInterceptor;
 use Temporal\Testing\WorkerFactory;
 use Temporal\Tests\Fixtures\PipelineProvider;
 use Temporal\Tests\Interceptor\HeaderChanger;
@@ -38,6 +40,8 @@ $factory = WorkerFactory::create();
 $interceptors = [
     InterceptorCallsCounter::class,
     HeaderChanger::class,
+    MockChildWorkflowInterceptor::class,
+    MockSideEffectInterceptor::class,
 ];
 
 $workers = [

--- a/tests/Unit/Testing/ActivityMockerTestCase.php
+++ b/tests/Unit/Testing/ActivityMockerTestCase.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\Testing;
+
+use Temporal\DataConverter\DataConverter;
+use Temporal\DataConverter\EncodedValues;
+use Temporal\Exception\InvalidArgumentException;
+use Temporal\Tests\TestCase;
+use Temporal\Worker\ActivityInvocationCache\InMemoryActivityInvocationCache;
+use Temporal\Worker\Transport\Command\ServerRequestInterface;
+
+final class ActivityMockerTestCase extends TestCase
+{
+    private DataConverter $converter;
+
+    protected function setUp(): void
+    {
+        $this->converter = DataConverter::createDefault();
+        parent::setUp();
+    }
+
+    public function testConsecutiveCompletionsAdvanceAndRepeatLast(): void
+    {
+        $cache = new InMemoryActivityInvocationCache($this->converter);
+        $cache->saveConsecutiveCompletions('SomeActivity.method', ['first', 'second']);
+
+        self::assertSame('first', $this->executeToValue($cache, []));
+        self::assertSame('second', $this->executeToValue($cache, []));
+        self::assertSame('second', $this->executeToValue($cache, []));
+    }
+
+    public function testMatchesByArguments(): void
+    {
+        $cache = new InMemoryActivityInvocationCache($this->converter);
+        $cache->saveCompletionWhen('SomeActivity.method', ['a'], 'result-a');
+        $cache->saveCompletionWhen('SomeActivity.method', ['b'], 'result-b');
+
+        self::assertSame('result-a', $this->executeToValue($cache, ['a']));
+        self::assertSame('result-b', $this->executeToValue($cache, ['b']));
+    }
+
+    public function testUnmatchedArgumentsReject(): void
+    {
+        $cache = new InMemoryActivityInvocationCache($this->converter);
+        $cache->saveCompletionWhen('SomeActivity.method', ['a'], 'result-a');
+
+        $caught = null;
+        $cache->execute($this->invokeActivityRequest(['c']))->then(
+            static fn() => self::fail('unmatched arguments must reject'),
+            static function (\Throwable $error) use (&$caught): void {
+                $caught = $error;
+            },
+        );
+
+        self::assertInstanceOf(InvalidArgumentException::class, $caught);
+        self::assertStringContainsString('No matching expectation', $caught->getMessage());
+    }
+
+    public function testLocalActivityRequestIsHandled(): void
+    {
+        $cache = new InMemoryActivityInvocationCache($this->converter);
+        $cache->saveCompletion('JustLocalActivity.echo', 'mocked');
+
+        $local = $this->createMock(ServerRequestInterface::class);
+        $local->method('getName')->willReturn('InvokeLocalActivity');
+        $local->method('getOptions')->willReturn(['name' => 'JustLocalActivity.echo']);
+
+        self::assertTrue($cache->canHandle($local));
+    }
+
+    /**
+     * @param list<mixed> $args
+     */
+    private function executeToValue(InMemoryActivityInvocationCache $cache, array $args): mixed
+    {
+        $captured = null;
+        EncodedValues::decodePromise($cache->execute($this->invokeActivityRequest($args)), 'string')
+            ->then(static function ($value) use (&$captured): void {
+                $captured = $value;
+            });
+
+        return $captured;
+    }
+
+    /**
+     * @param list<mixed> $args
+     */
+    private function invokeActivityRequest(array $args): ServerRequestInterface
+    {
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getName')->willReturn('InvokeActivity');
+        $request->method('getOptions')->willReturn(['name' => 'SomeActivity.method']);
+        $request->method('getPayloads')->willReturn(EncodedValues::fromValues($args, $this->converter));
+
+        return $request;
+    }
+}

--- a/tests/Unit/Testing/MockChildWorkflowInterceptorTestCase.php
+++ b/tests/Unit/Testing/MockChildWorkflowInterceptorTestCase.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\Testing;
+
+use Temporal\DataConverter\DataConverter;
+use Temporal\DataConverter\EncodedValues;
+use Temporal\Exception\Failure\ApplicationFailure;
+use Temporal\Exception\Failure\ChildWorkflowFailure;
+use Temporal\Interceptor\Header;
+use Temporal\Internal\Transport\Request\ExecuteChildWorkflow;
+use Temporal\Internal\Transport\Request\GetChildWorkflowExecution;
+use Temporal\Testing\MockChildWorkflowInterceptor;
+use Temporal\Testing\WorkflowMocker;
+use Temporal\Tests\TestCase;
+use Temporal\Worker\InvocationResult;
+use Temporal\Worker\ChildWorkflowInvocationCache\InMemoryChildWorkflowInvocationCache;
+use Temporal\Workflow\WorkflowExecution;
+
+use function React\Promise\resolve;
+
+final class MockChildWorkflowInterceptorTestCase extends TestCase
+{
+    private InMemoryChildWorkflowInvocationCache $cache;
+    private WorkflowMocker $mocker;
+    private MockChildWorkflowInterceptor $interceptor;
+
+    protected function setUp(): void
+    {
+        $this->cache = new InMemoryChildWorkflowInvocationCache();
+        $this->mocker = new WorkflowMocker($this->cache);
+        $this->interceptor = new MockChildWorkflowInterceptor($this->cache);
+
+        parent::setUp();
+    }
+
+    public function testMockedChildWorkflowResolvesWithoutCallingNext(): void
+    {
+        $this->mocker->expectCompletion('SimpleWorkflow', 'mocked-result');
+
+        $request = $this->executeChildRequest('SimpleWorkflow');
+        $nextCalled = false;
+
+        $result = $this->interceptor->handleOutboundRequest(
+            $request,
+            static function () use (&$nextCalled) {
+                $nextCalled = true;
+                return resolve('real-result');
+            },
+        );
+
+        self::assertFalse($nextCalled);
+
+        $decoded = null;
+        EncodedValues::decodePromise($result, 'string')->then(static function ($value) use (&$decoded): void {
+            $decoded = $value;
+        });
+
+        self::assertSame('mocked-result', $decoded);
+    }
+
+    public function testAppliedMockIsRecordedForAssertInvoked(): void
+    {
+        $this->mocker->expectCompletion('SimpleWorkflow', 'mocked-result');
+        self::assertFalse($this->mocker->wasInvoked('SimpleWorkflow'));
+
+        $this->interceptor->handleOutboundRequest(
+            $this->executeChildRequest('SimpleWorkflow'),
+            static fn() => resolve('real-result'),
+        );
+
+        $this->mocker->assertInvoked('SimpleWorkflow');
+        $this->mocker->assertNotInvoked('OtherWorkflow');
+    }
+
+    public function testGetChildWorkflowExecutionResolvesFakeExecutionForMockedChild(): void
+    {
+        $this->mocker->expectCompletion('SimpleWorkflow', 'mocked-result');
+
+        $executeRequest = $this->executeChildRequest('SimpleWorkflow');
+        $this->interceptor->handleOutboundRequest(
+            $executeRequest,
+            static fn() => self::fail('next should not be called for mocked child'),
+        );
+
+        $getRequest = new GetChildWorkflowExecution($executeRequest);
+        $nextCalled = false;
+
+        $started = $this->interceptor->handleOutboundRequest(
+            $getRequest,
+            static function () use (&$nextCalled) {
+                $nextCalled = true;
+                return resolve(EncodedValues::fromValues([new WorkflowExecution()]));
+            },
+        );
+
+        self::assertFalse($nextCalled);
+
+        $execution = null;
+        $started->then(static function (EncodedValues $values) use (&$execution): void {
+            $execution = $values->getValue(0, WorkflowExecution::class);
+        });
+
+        self::assertInstanceOf(WorkflowExecution::class, $execution);
+    }
+
+    public function testUnmockedChildWorkflowPassesThrough(): void
+    {
+        $this->mocker->expectCompletion('MockedWorkflow', 'mocked');
+
+        $executeNextCalled = false;
+        $this->interceptor->handleOutboundRequest(
+            $this->executeChildRequest('UnmockedWorkflow'),
+            static function () use (&$executeNextCalled) {
+                $executeNextCalled = true;
+                return resolve(EncodedValues::empty());
+            },
+        );
+        self::assertTrue($executeNextCalled);
+
+        $getRequest = new GetChildWorkflowExecution($this->executeChildRequest('UnmockedWorkflow'));
+        $getNextCalled = false;
+        $this->interceptor->handleOutboundRequest(
+            $getRequest,
+            static function () use (&$getNextCalled) {
+                $getNextCalled = true;
+                return resolve(EncodedValues::fromValues([new WorkflowExecution()]));
+            },
+        );
+        self::assertTrue($getNextCalled);
+    }
+
+    public function testMockedFailureRejectsResult(): void
+    {
+        $this->mocker->expectFailure('SimpleWorkflow', new \RuntimeException('child boom'));
+
+        $result = $this->interceptor->handleOutboundRequest(
+            $this->executeChildRequest('SimpleWorkflow'),
+            static fn() => self::fail('next should not be called for mocked child'),
+        );
+
+        $caught = null;
+        $result->then(
+            static fn() => self::fail('mocked failure must reject'),
+            static function (\Throwable $error) use (&$caught): void {
+                $caught = $error;
+            },
+        );
+
+        self::assertInstanceOf(ChildWorkflowFailure::class, $caught);
+
+        $execution = $caught->getExecution();
+        self::assertStringStartsWith('mocked-child-', $execution->getID());
+        self::assertStringStartsWith('mocked-run-', (string) $execution->getRunID());
+
+        $cause = $caught->getPrevious();
+        self::assertInstanceOf(ApplicationFailure::class, $cause);
+        self::assertSame('RuntimeException', $cause->getType());
+        self::assertSame('child boom', $cause->getOriginalMessage());
+    }
+
+    public function testInvocationResultSurvivesSerializationRoundTrip(): void
+    {
+        $dataConverter = DataConverter::createDefault();
+        $result = InvocationResult::fromValue('payload-value', $dataConverter);
+
+        $restored = \unserialize(\serialize($result));
+
+        self::assertInstanceOf(InvocationResult::class, $restored);
+        self::assertSame('payload-value', $restored->toValue('string', $dataConverter));
+    }
+
+    public function testArgMatchedChildResolvesMatchingCase(): void
+    {
+        $this->mocker->expectCompletionWhen('SimpleWorkflow', ['A'], 'result-A');
+        $this->mocker->expectCompletionWhen('SimpleWorkflow', ['B'], 'result-B');
+
+        self::assertSame('result-A', $this->resolveChild('SimpleWorkflow', ['A']));
+        self::assertSame('result-B', $this->resolveChild('SimpleWorkflow', ['B']));
+    }
+
+    public function testArgMatchedChildFallsThroughOnNoMatch(): void
+    {
+        $this->mocker->expectCompletionWhen('SimpleWorkflow', ['A'], 'result-A');
+
+        $nextCalled = false;
+        $this->interceptor->handleOutboundRequest(
+            $this->executeChildRequest('SimpleWorkflow', ['Z']),
+            static function () use (&$nextCalled) {
+                $nextCalled = true;
+                return resolve(EncodedValues::empty());
+            },
+        );
+
+        self::assertTrue($nextCalled);
+    }
+
+    private function resolveChild(string $workflowType, array $input): mixed
+    {
+        $result = $this->interceptor->handleOutboundRequest(
+            $this->executeChildRequest($workflowType, $input),
+            static fn() => self::fail('next should not be called for matched child'),
+        );
+
+        $decoded = null;
+        EncodedValues::decodePromise($result, 'string')->then(static function ($value) use (&$decoded): void {
+            $decoded = $value;
+        });
+
+        return $decoded;
+    }
+
+    private function executeChildRequest(string $workflowType, array $input = ['input']): ExecuteChildWorkflow
+    {
+        return new ExecuteChildWorkflow(
+            $workflowType,
+            EncodedValues::fromValues($input),
+            [],
+            Header::empty(),
+        );
+    }
+}

--- a/tests/Unit/Testing/MockSideEffectInterceptorTestCase.php
+++ b/tests/Unit/Testing/MockSideEffectInterceptorTestCase.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\Testing;
+
+use PHPUnit\Framework\TestCase;
+use Temporal\Interceptor\WorkflowOutboundCalls\SideEffectInput;
+use Temporal\Testing\MockSideEffectInterceptor;
+use Temporal\Worker\ChildWorkflowInvocationCache\InMemoryChildWorkflowInvocationCache;
+
+final class MockSideEffectInterceptorTestCase extends TestCase
+{
+    public function testRunsRealClosureWhenNoExpectation(): void
+    {
+        $cache = new InMemoryChildWorkflowInvocationCache();
+        $interceptor = new MockSideEffectInterceptor($cache);
+
+        $result = $interceptor->sideEffect(
+            new SideEffectInput(static fn(): int => 7),
+            $this->realClosure(),
+        );
+
+        self::assertSame(7, $result);
+    }
+
+    public function testConsumesExpectationsInOrderThenFallsBackToRealClosure(): void
+    {
+        $cache = new InMemoryChildWorkflowInvocationCache();
+        $cache->saveSideEffect(100);
+        $cache->saveSideEffect(200);
+
+        $interceptor = new MockSideEffectInterceptor($cache);
+        $input = new SideEffectInput(static fn(): int => 7);
+
+        self::assertSame(100, $interceptor->sideEffect($input, $this->realClosure()));
+        self::assertSame(200, $interceptor->sideEffect($input, $this->realClosure()));
+        self::assertSame(7, $interceptor->sideEffect($input, $this->realClosure()));
+    }
+
+    private function realClosure(): callable
+    {
+        return static fn(SideEffectInput $input): mixed => ($input->callable)();
+    }
+}

--- a/tests/Unit/Testing/WorkflowInteractionsTestCase.php
+++ b/tests/Unit/Testing/WorkflowInteractionsTestCase.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\Testing;
+
+use Google\Protobuf\Duration;
+use PHPUnit\Framework\AssertionFailedError;
+use Temporal\Api\Common\V1\ActivityType;
+use Temporal\Api\Common\V1\Payloads;
+use Temporal\Api\Common\V1\WorkflowType;
+use Temporal\Api\Enums\V1\EventType;
+use Temporal\Api\History\V1\ActivityTaskScheduledEventAttributes;
+use Temporal\Api\History\V1\HistoryEvent;
+use Temporal\Api\History\V1\SignalExternalWorkflowExecutionInitiatedEventAttributes;
+use Temporal\Api\History\V1\StartChildWorkflowExecutionInitiatedEventAttributes;
+use Temporal\Api\History\V1\TimerStartedEventAttributes;
+use Temporal\DataConverter\DataConverter;
+use Temporal\DataConverter\DataConverterInterface;
+use Temporal\DataConverter\EncodedValues;
+use Temporal\Testing\Interactions\WorkflowInteractions;
+use Temporal\Tests\TestCase;
+
+final class WorkflowInteractionsTestCase extends TestCase
+{
+    private DataConverterInterface $converter;
+
+    protected function setUp(): void
+    {
+        $this->converter = DataConverter::createDefault();
+        parent::setUp();
+    }
+
+    public function testActivityCallCount(): void
+    {
+        $interactions = WorkflowInteractions::fromEvents([
+            $this->activityEvent('Pay', [100]),
+            $this->activityEvent('Pay', [200]),
+            $this->activityEvent('Refund', [50]),
+        ], $this->converter);
+
+        $interactions->activity('Pay')->assertCalledTimes(2);
+        $interactions->activity('Refund')->assertCalledOnce();
+        $interactions->activity('Unknown')->assertNeverCalled();
+    }
+
+    public function testActivityCalledOnceFailsWhenCalledTwice(): void
+    {
+        $interactions = WorkflowInteractions::fromEvents([
+            $this->activityEvent('Pay', [1]),
+            $this->activityEvent('Pay', [2]),
+        ], $this->converter);
+
+        $this->expectException(AssertionFailedError::class);
+        $interactions->activity('Pay')->assertCalledOnce();
+    }
+
+    public function testWithInputMatchesRealInput(): void
+    {
+        $interactions = WorkflowInteractions::fromEvents([
+            $this->activityEvent('Pay', [100]),
+        ], $this->converter);
+
+        $interactions->activity('Pay')->withInput(100)->assertCalledOnce();
+        $interactions->activity('Pay')->withInput(999)->assertNeverCalled();
+    }
+
+    public function testWithInputWrongValueFailsAssertCalledOnce(): void
+    {
+        $interactions = WorkflowInteractions::fromEvents([
+            $this->activityEvent('Pay', [100]),
+        ], $this->converter);
+
+        $this->expectException(AssertionFailedError::class);
+        $interactions->activity('Pay')->withInput(101)->assertCalledOnce();
+    }
+
+    public function testChildWorkflowStart(): void
+    {
+        $interactions = WorkflowInteractions::fromEvents([
+            $this->childEvent('SubWorkflow', ['x']),
+        ], $this->converter);
+
+        $interactions->childWorkflow('SubWorkflow')->assertStartedOnce();
+        $interactions->childWorkflow('Other')->assertNeverStarted();
+    }
+
+    public function testTimerDurationDecodedToMs(): void
+    {
+        $interactions = WorkflowInteractions::fromEvents([
+            $this->timerEvent(1800),
+        ], $this->converter);
+
+        $interactions->timer()->assertStarted('30 minutes');
+        $interactions->timer()->assertStarted(1_800_000);
+        $interactions->timer()->assertStartedTimes(1);
+    }
+
+    public function testExternalSignalSent(): void
+    {
+        $interactions = WorkflowInteractions::fromEvents([
+            $this->signalEvent('cancelOrder'),
+        ], $this->converter);
+
+        $interactions->signal('cancelOrder')->assertSentOnce();
+        $interactions->signal('other')->assertNeverSent();
+    }
+
+    public function testAssertNoOtherActivitiesFailsForUnqueriedActivity(): void
+    {
+        $interactions = WorkflowInteractions::fromEvents([
+            $this->activityEvent('Pay', [1]),
+            $this->activityEvent('Refund', [1]),
+        ], $this->converter);
+
+        $interactions->activity('Pay')->assertCalledOnce();
+
+        $this->expectException(AssertionFailedError::class);
+        $interactions->assertNoOtherActivities();
+    }
+
+    /**
+     * @param list<mixed> $args
+     */
+    private function activityEvent(string $type, array $args): HistoryEvent
+    {
+        $attributes = (new ActivityTaskScheduledEventAttributes())
+            ->setActivityType((new ActivityType())->setName($type))
+            ->setInput($this->payloads($args));
+
+        return (new HistoryEvent())
+            ->setEventType(EventType::EVENT_TYPE_ACTIVITY_TASK_SCHEDULED)
+            ->setActivityTaskScheduledEventAttributes($attributes);
+    }
+
+    /**
+     * @param list<mixed> $args
+     */
+    private function childEvent(string $type, array $args): HistoryEvent
+    {
+        $attributes = (new StartChildWorkflowExecutionInitiatedEventAttributes())
+            ->setWorkflowType((new WorkflowType())->setName($type))
+            ->setInput($this->payloads($args));
+
+        return (new HistoryEvent())
+            ->setEventType(EventType::EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED)
+            ->setStartChildWorkflowExecutionInitiatedEventAttributes($attributes);
+    }
+
+    private function timerEvent(int $seconds): HistoryEvent
+    {
+        $attributes = (new TimerStartedEventAttributes())
+            ->setStartToFireTimeout((new Duration())->setSeconds($seconds));
+
+        return (new HistoryEvent())
+            ->setEventType(EventType::EVENT_TYPE_TIMER_STARTED)
+            ->setTimerStartedEventAttributes($attributes);
+    }
+
+    private function signalEvent(string $name): HistoryEvent
+    {
+        $attributes = (new SignalExternalWorkflowExecutionInitiatedEventAttributes())
+            ->setSignalName($name)
+            ->setInput($this->payloads([]));
+
+        return (new HistoryEvent())
+            ->setEventType(EventType::EVENT_TYPE_SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED)
+            ->setSignalExternalWorkflowExecutionInitiatedEventAttributes($attributes);
+    }
+
+    /**
+     * @param list<mixed> $args
+     */
+    private function payloads(array $args): Payloads
+    {
+        return EncodedValues::fromValues($args, $this->converter)->toPayloads();
+    }
+}

--- a/tests/Unit/Worker/InvocationShimTestCase.php
+++ b/tests/Unit/Worker/InvocationShimTestCase.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\Worker;
+
+use PHPUnit\Framework\TestCase;
+use Temporal\DataConverter\DataConverter;
+use Temporal\Worker\ActivityInvocationCache\ActivityInvocationFailure;
+use Temporal\Worker\ActivityInvocationCache\ActivityInvocationResult;
+use Temporal\Worker\InvocationFailure;
+use Temporal\Worker\InvocationResult;
+
+final class InvocationShimTestCase extends TestCase
+{
+    public function testActivityInvocationResultFactoryReturnsTheShimType(): void
+    {
+        $result = ActivityInvocationResult::fromValue('x', DataConverter::createDefault());
+
+        self::assertInstanceOf(ActivityInvocationResult::class, $result);
+        self::assertInstanceOf(InvocationResult::class, $result);
+    }
+
+    public function testActivityInvocationFailureFactoryReturnsTheShimType(): void
+    {
+        $failure = ActivityInvocationFailure::fromThrowable(new \RuntimeException('boom'));
+
+        self::assertInstanceOf(ActivityInvocationFailure::class, $failure);
+        self::assertInstanceOf(InvocationFailure::class, $failure);
+        self::assertInstanceOf(\RuntimeException::class, $failure->toThrowable());
+    }
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

- `WorkflowMocker` — stub child workflows (`expectCompletion` / `expectFailure` / `expectCompletionWhen`) without starting a real child execution, plus `expectVersion` and `expectSideEffect`.
- `ActivityMocker` — per-call results via `expectConsecutiveCompletions` and arg-matched `expectCompletionWhen`.
- `WorkflowInteractions` — history-based assertions over a finished run: activity, local activity, child workflow, timer and external signal calls (call counts + input matching).
- `WorkflowTestCase` base test case wiring the mocks and interactions together.

## Why?
<!-- Tell your future self why have you made these changes -->

Bring the PHP testing framework closer to Go/Java/TS: child workflows were the only outbound call with no way to stub it, and activity mocks couldn't return a different value per call inside a loop.

## Checklist
<!--- add/delete as needed --->

1. Closes #524,
   closes #302

3. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

New Unit + Functional suites: child/activity mocking (incl. failure cause preservation and arg matching), `WorkflowInteractions`, `getVersion`/`sideEffect` mocks, and a time-skipping case proving a stubbed 30-min-timer child fast-forwards in < 60s wall-clock.

4. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

Yes — document child-workflow mocking and `WorkflowInteractions` on docs.temporal.io (PHP testing-suite page).
