### PR TITLE
feat: time-skipping test support and delayed-callback scheduler

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -29,6 +29,16 @@ jobs:
       test-command: composer test:func
       download-binaries: true
 
+  functional-timeskip:
+    permissions:
+      contents: read
+    name: Functional Testing (Time Skipping)
+    uses: ./.github/workflows/run-test-suite.yml
+    with:
+      fail-fast: false
+      test-command: composer test:func-timeskip
+      download-binaries: true
+
   acceptance-slow:
     permissions:
       contents: read

--- a/composer.json
+++ b/composer.json
@@ -101,6 +101,7 @@
         "psalm:baseline": "psalm --set-baseline=psalm-baseline.xml",
         "test:unit": "tests/runner.php vendor/bin/phpunit --testsuite=Unit --color=always --testdox",
         "test:func": "tests/runner.php vendor/bin/phpunit --testsuite=Functional --color=always --testdox",
+        "test:func-timeskip": "tests/runner.php vendor/bin/phpunit --testsuite=Functional-TimeSkipping --color=always --testdox",
         "test:arch": "phpunit --testsuite=Arch --color=always --testdox",
         "test:accept": "tests/runner.php vendor/bin/phpunit --testsuite=Acceptance --color=always --testdox",
         "test:accept-slow": "tests/runner.php vendor/bin/phpunit --testsuite=\"Acceptance-Slow\" --color=always --testdox",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -78,6 +78,28 @@
         </testsuite>
         <testsuite name="Functional">
             <directory suffix="TestCase.php">tests/Functional</directory>
+            <exclude>tests/Functional/TimerOnlyTimeSkipTestCase.php</exclude>
+            <exclude>tests/Functional/ChildWorkflowTimeSkipTestCase.php</exclude>
+            <exclude>tests/Functional/MockedActivityTimeSkipTestCase.php</exclude>
+            <exclude>tests/Functional/DelayedSignalInjectionTestCase.php</exclude>
+            <exclude>tests/Functional/TimeSkippingSpikeTestCase.php</exclude>
+            <exclude>tests/Functional/WorkflowSideDelayedCallbackTestCase.php</exclude>
+            <exclude>tests/Functional/ClientSideDelayedCallbackTestCase.php</exclude>
+            <exclude>tests/Functional/NestedTimeSkipGuardTestCase.php</exclude>
+            <exclude>tests/Functional/ClientSideDelayedCallbackMatrixTestCase.php</exclude>
+            <exclude>tests/Functional/SchedulerWithMockedActivityTestCase.php</exclude>
+        </testsuite>
+        <testsuite name="Functional-TimeSkipping">
+            <file>tests/Functional/TimerOnlyTimeSkipTestCase.php</file>
+            <file>tests/Functional/ChildWorkflowTimeSkipTestCase.php</file>
+            <file>tests/Functional/MockedActivityTimeSkipTestCase.php</file>
+            <file>tests/Functional/DelayedSignalInjectionTestCase.php</file>
+            <file>tests/Functional/TimeSkippingSpikeTestCase.php</file>
+            <file>tests/Functional/WorkflowSideDelayedCallbackTestCase.php</file>
+            <file>tests/Functional/ClientSideDelayedCallbackTestCase.php</file>
+            <file>tests/Functional/NestedTimeSkipGuardTestCase.php</file>
+            <file>tests/Functional/ClientSideDelayedCallbackMatrixTestCase.php</file>
+            <file>tests/Functional/SchedulerWithMockedActivityTestCase.php</file>
         </testsuite>
     </testsuites>
     <extensions>

--- a/testing/src/Command.php
+++ b/testing/src/Command.php
@@ -27,8 +27,7 @@ final class Command
 
     public static function fromEnv(): self
     {
-        $address = \getenv('TEMPORAL_ADDRESS');
-        $self = new self((\is_string($address) && $address !== '') ? $address : '127.0.0.1:7233');
+        $self = new self(TemporalServer::address());
 
         $namespace = \getenv('TEMPORAL_NAMESPACE');
         $self->namespace = (\is_string($namespace) && $namespace !== '') ? $namespace : 'default';

--- a/testing/src/DelayedCallbackScheduler.php
+++ b/testing/src/DelayedCallbackScheduler.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Testing;
+
+use Temporal\Client\WorkflowClientInterface;
+use Temporal\Client\WorkflowStubInterface;
+use Temporal\Workflow\WorkflowExecution;
+
+/**
+ * Fires client-side callbacks at simulated-time offsets by fast-forwarding the time-skipping
+ * test server to each deadline in order. Use it to signal/query/cancel a workflow under test
+ * along its virtual timeline without waiting in real time.
+ */
+final class DelayedCallbackScheduler
+{
+    /** @var list<array{delay: int, callback: \Closure(WorkflowStubInterface): void}> */
+    private array $callbacks = [];
+
+    private TimeSkipDriver $driver;
+
+    /** @var \Closure(): bool|null */
+    private ?\Closure $readyPredicate = null;
+
+    public function __construct(
+        private readonly WorkflowClientInterface $workflowClient,
+        private readonly TestService $testService,
+        int $timerPollAttempts = 50,
+        int $timerPollIntervalMicroseconds = 100_000,
+    ) {
+        $this->driver = new TimeSkipDriver(
+            $workflowClient,
+            $testService,
+            $timerPollAttempts,
+            $timerPollIntervalMicroseconds,
+        );
+    }
+
+    /**
+     * @param int $delaySeconds simulated-time offset from workflow start; must be >= 0
+     * @param \Closure(WorkflowStubInterface): void $callback receives the started stub
+     */
+    public function registerDelayedCallback(int $delaySeconds, \Closure $callback): self
+    {
+        if ($delaySeconds < 0) {
+            throw new \InvalidArgumentException(\sprintf('Delayed callback offset must be >= 0, got %d.', $delaySeconds));
+        }
+
+        $this->callbacks[] = ['delay' => $delaySeconds, 'callback' => $callback];
+
+        return $this;
+    }
+
+    /**
+     * Convenience: signal the workflow under test at a simulated-time offset.
+     */
+    public function signalAfter(int $delaySeconds, string $signalName, mixed ...$signalArgs): self
+    {
+        return $this->registerDelayedCallback(
+            $delaySeconds,
+            static fn(WorkflowStubInterface $stub) => $stub->signal($signalName, ...$signalArgs),
+        );
+    }
+
+    /**
+     * Override the "workflow is ready" condition for workflows that block without scheduling a timer.
+     *
+     * @param \Closure(): bool|null $predicate
+     */
+    public function readyWhen(?\Closure $predicate): self
+    {
+        $this->readyPredicate = $predicate;
+
+        return $this;
+    }
+
+    /**
+     * @param array<array-key, mixed> $startArgs
+     */
+    public function start(WorkflowStubInterface $stub, mixed ...$startArgs): void
+    {
+        $this->driver->assertOwnsTimeSkipping(self::class);
+        $this->testService->lockTimeSkipping();
+
+        try {
+            $this->workflowClient->start($stub, ...$startArgs);
+            $execution = $stub->getExecution();
+            $this->driver->awaitWorkflowReady($execution, $this->readyPredicate);
+
+            $sorted = $this->callbacks;
+            \usort(
+                $sorted,
+                /**
+                 * @param array{delay: int, callback: \Closure} $a
+                 * @param array{delay: int, callback: \Closure} $b
+                 */
+                static fn(array $a, array $b): int => $a['delay'] <=> $b['delay'],
+            );
+
+            $elapsed = 0;
+            foreach ($sorted as $entry) {
+                $delta = $entry['delay'] - $elapsed;
+                if ($delta > 0) {
+                    $this->testService->unlockTimeSkippingWithSleep($delta);
+                    $elapsed = $entry['delay'];
+                }
+
+                $this->fire($entry['delay'], $entry['callback'], $stub, $execution);
+            }
+        } finally {
+            $this->testService->unlockTimeSkipping();
+        }
+    }
+
+    private function fire(int $delay, \Closure $callback, WorkflowStubInterface $stub, WorkflowExecution $execution): void
+    {
+        if ($this->driver->isWorkflowClosed($execution)) {
+            throw new \RuntimeException(\sprintf(
+                'Delayed callback scheduled at +%ds could not fire: the workflow is no longer running.',
+                $delay,
+            ));
+        }
+
+        try {
+            $callback($stub);
+        } catch (\Throwable $e) {
+            throw new \RuntimeException(\sprintf('Delayed callback scheduled at +%ds threw: %s', $delay, $e->getMessage()), 0, $e);
+        }
+    }
+}

--- a/testing/src/TemporalServer.php
+++ b/testing/src/TemporalServer.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Testing;
+
+final class TemporalServer
+{
+    private const DEFAULT_ADDRESS = '127.0.0.1:7233';
+
+    /** @var non-empty-string|null */
+    private static ?string $address = null;
+
+    /**
+     * @param non-empty-string $address
+     */
+    public static function setAddress(string $address): void
+    {
+        self::$address = $address;
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public static function address(): string
+    {
+        if (self::$address === null) {
+            $fromEnv = \getenv('TEMPORAL_ADDRESS');
+            self::$address = \is_string($fromEnv) && $fromEnv !== '' ? $fromEnv : self::DEFAULT_ADDRESS;
+        }
+
+        return self::$address;
+    }
+}

--- a/testing/src/TestService.php
+++ b/testing/src/TestService.php
@@ -21,9 +21,22 @@ final class TestService
 {
     private TestServiceClient $testServiceClient;
 
+    private int $lockDelta = 0;
+
     public function __construct(TestServiceClient $testServiceClient)
     {
         $this->testServiceClient = $testServiceClient;
+    }
+
+    /**
+     * Net lock/unlock delta applied through this instance since it was created.
+     *
+     * `unlockTimeSkippingWithSleep` is balanced (it decrements and increments the server counter),
+     * so it does not change this value. A non-zero delta means a caller leaked a lock/unlock pair.
+     */
+    public function lockDelta(): int
+    {
+        return $this->lockDelta;
     }
 
     public static function create(string $host): self
@@ -45,6 +58,7 @@ final class TestService
     public function lockTimeSkipping(): void
     {
         $this->invoke('LockTimeSkipping', new LockTimeSkippingRequest());
+        ++$this->lockDelta;
     }
 
     /**
@@ -59,6 +73,7 @@ final class TestService
     public function unlockTimeSkipping(): void
     {
         $this->invoke('UnlockTimeSkipping', new UnlockTimeSkippingRequest());
+        --$this->lockDelta;
     }
 
     /**

--- a/testing/src/TimeLockingInterceptor.php
+++ b/testing/src/TimeLockingInterceptor.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Testing;
+
+use Temporal\DataConverter\ValuesInterface;
+use Temporal\Interceptor\Trait\WorkflowClientCallsInterceptorTrait;
+use Temporal\Interceptor\WorkflowClient\GetResultInput;
+use Temporal\Interceptor\WorkflowClientCallsInterceptor;
+
+final class TimeLockingInterceptor implements WorkflowClientCallsInterceptor
+{
+    use WorkflowClientCallsInterceptorTrait;
+
+    public function __construct(
+        private readonly TestService $testService,
+    ) {}
+
+    public function getResult(GetResultInput $input, callable $next): ?ValuesInterface
+    {
+        $this->testService->unlockTimeSkipping();
+
+        try {
+            return $next($input);
+        } finally {
+            $this->testService->lockTimeSkipping();
+        }
+    }
+}

--- a/testing/src/TimeSkipDriver.php
+++ b/testing/src/TimeSkipDriver.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Testing;
+
+use Temporal\Api\Enums\V1\EventType;
+use Temporal\Client\WorkflowClientInterface;
+use Temporal\Workflow\WorkflowExecution;
+
+/**
+ * Shared time-skip driving logic for the client-side delayed-action helpers: exclusive-ownership
+ * assertion, "workflow reached a blocking point" readiness polling, and closed-workflow detection.
+ */
+final class TimeSkipDriver
+{
+    public function __construct(
+        private readonly WorkflowClientInterface $workflowClient,
+        private readonly TestService $testService,
+        private readonly int $pollAttempts = 50,
+        private readonly int $pollIntervalMicroseconds = 100_000,
+    ) {}
+
+    /**
+     * @param class-string $driver
+     */
+    public function assertOwnsTimeSkipping(string $driver): void
+    {
+        $delta = $this->testService->lockDelta();
+        if ($delta === 0) {
+            return;
+        }
+
+        throw new \LogicException(\sprintf(
+            '%s must own time-skipping exclusively, but the lock counter is already held (delta %d). '
+            . 'Do not drive it inside %s or alongside another time-skip driver; extend the plain %s instead.',
+            $driver,
+            $delta,
+            TimeSkippingWorkflowTestCase::class,
+            WorkflowTestCase::class,
+        ));
+    }
+
+    /**
+     * Waits until the workflow is ready for an injected action: the caller predicate if given
+     * (tolerating transient query failures), otherwise the workflow's first scheduled timer.
+     *
+     * @param \Closure(): bool|null $ready
+     */
+    public function awaitWorkflowReady(WorkflowExecution $execution, ?\Closure $ready): void
+    {
+        for ($attempt = 0; $attempt < $this->pollAttempts; ++$attempt) {
+            if ($this->reached($execution, $ready)) {
+                return;
+            }
+
+            \usleep($this->pollIntervalMicroseconds);
+        }
+
+        throw new \RuntimeException(
+            'Timed out waiting for the workflow to reach a blocking point before advancing the clock. '
+            . 'Pass a readiness predicate via readyWhen() for workflows that do not schedule a timer.',
+        );
+    }
+
+    public function isWorkflowClosed(WorkflowExecution $execution): bool
+    {
+        $terminal = [
+            EventType::EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED,
+            EventType::EVENT_TYPE_WORKFLOW_EXECUTION_FAILED,
+            EventType::EVENT_TYPE_WORKFLOW_EXECUTION_CANCELED,
+            EventType::EVENT_TYPE_WORKFLOW_EXECUTION_TIMED_OUT,
+            EventType::EVENT_TYPE_WORKFLOW_EXECUTION_TERMINATED,
+            EventType::EVENT_TYPE_WORKFLOW_EXECUTION_CONTINUED_AS_NEW,
+        ];
+
+        foreach ($this->workflowClient->getWorkflowHistory($execution, pageSize: 250) as $event) {
+            if (\in_array($event->getEventType(), $terminal, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param \Closure(): bool|null $ready
+     */
+    private function reached(WorkflowExecution $execution, ?\Closure $ready): bool
+    {
+        if ($ready !== null) {
+            try {
+                return $ready();
+            } catch (\Throwable) {
+                return false;
+            }
+        }
+
+        foreach ($this->workflowClient->getWorkflowHistory($execution, pageSize: 50) as $event) {
+            if ($event->getEventType() === EventType::EVENT_TYPE_TIMER_STARTED) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/testing/src/TimeSkippingWorkflowTestCase.php
+++ b/testing/src/TimeSkippingWorkflowTestCase.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Testing;
+
+use Temporal\Internal\Interceptor\Interceptor;
+
+/**
+ * @psalm-suppress PropertyNotSetInConstructor
+ */
+class TimeSkippingWorkflowTestCase extends WorkflowTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->testingService->lockTimeSkipping();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->testingService->unlockTimeSkipping();
+
+        parent::tearDown();
+    }
+
+    /**
+     * @return list<Interceptor>
+     */
+    protected function clientInterceptors(): array
+    {
+        return [new TimeLockingInterceptor($this->testingService)];
+    }
+}

--- a/testing/src/WithoutTimeSkipping.php
+++ b/testing/src/WithoutTimeSkipping.php
@@ -11,9 +11,7 @@ trait WithoutTimeSkipping
     protected function setUp(): void
     {
         parent::setUp();
-        $this->testService = TestService::create(
-            \getenv('TEMPORAL_ADDRESS') ?: '127.0.0.1:7233',
-        );
+        $this->testService = TestService::create(TemporalServer::address());
         $this->testService->lockTimeSkipping();
     }
 

--- a/testing/src/WorkflowTestCase.php
+++ b/testing/src/WorkflowTestCase.php
@@ -7,6 +7,8 @@ namespace Temporal\Testing;
 use PHPUnit\Framework\TestCase;
 use Temporal\Client\GRPC\ServiceClient;
 use Temporal\Client\WorkflowClient;
+use Temporal\Interceptor\SimplePipelineProvider;
+use Temporal\Internal\Interceptor\Interceptor;
 use Temporal\Testing\Interactions\WorkflowInteractions;
 use Temporal\Workflow\WorkflowRunInterface;
 
@@ -19,15 +21,19 @@ class WorkflowTestCase extends TestCase
     protected TestService $testingService;
     protected ActivityMocker $activityMocks;
     protected WorkflowMocker $workflowMocks;
+    protected DelayedCallbackScheduler $delayedCallbacks;
 
     protected function setUp(): void
     {
-        $temporalAddress = \getenv('TEMPORAL_ADDRESS');
-        $temporalAddress = \is_string($temporalAddress) && !empty($temporalAddress) ? $temporalAddress : '127.0.0.1:7233';
-        $this->workflowClient = new WorkflowClient(ServiceClient::create($temporalAddress));
+        $temporalAddress = TemporalServer::address();
         $this->testingService = TestService::create($temporalAddress);
         $this->activityMocks = new ActivityMocker();
         $this->workflowMocks = new WorkflowMocker();
+        $this->workflowClient = new WorkflowClient(
+            ServiceClient::create($temporalAddress),
+            interceptorProvider: new SimplePipelineProvider($this->clientInterceptors()),
+        );
+        $this->delayedCallbacks = new DelayedCallbackScheduler($this->workflowClient, $this->testingService);
 
         parent::setUp();
     }
@@ -36,8 +42,39 @@ class WorkflowTestCase extends TestCase
     {
         $this->activityMocks->clear();
         $this->workflowMocks->clear();
+        $this->assertTimeSkippingBalanced();
 
         parent::tearDown();
+    }
+
+    private function assertTimeSkippingBalanced(): void
+    {
+        $delta = $this->testingService->lockDelta();
+        if ($delta === 0) {
+            return;
+        }
+
+        for ($i = 0; $i < $delta; ++$i) {
+            try {
+                $this->testingService->unlockTimeSkipping();
+            } catch (\Throwable) {
+                break;
+            }
+        }
+
+        self::fail(\sprintf(
+            'Time-skip lock counter left unbalanced by %d: a test leaked lockTimeSkipping/unlockTimeSkipping. '
+            . 'The server counter was healed for the next test.',
+            $delta,
+        ));
+    }
+
+    /**
+     * @return list<Interceptor>
+     */
+    protected function clientInterceptors(): array
+    {
+        return [];
     }
 
     protected function interactions(WorkflowRunInterface $run): WorkflowInteractions

--- a/tests/Fixtures/src/Workflow/DelayedCallbackWorkflow.php
+++ b/tests/Fixtures/src/Workflow/DelayedCallbackWorkflow.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Workflow;
+
+use Temporal\Promise;
+use Temporal\Workflow;
+use Temporal\Workflow\WorkflowInterface;
+use Temporal\Workflow\WorkflowMethod;
+
+#[WorkflowInterface]
+class DelayedCallbackWorkflow
+{
+    /** @var array<string, int> tag => virtual epoch seconds when the callback fired */
+    private array $fired = [];
+
+    /**
+     * @param list<array{0: int, 1: string}> $schedule pairs of [delaySeconds, tag]
+     */
+    #[WorkflowMethod(name: 'DelayedCallbackWorkflow')]
+    public function handler(array $schedule): iterable
+    {
+        $scopes = [];
+        foreach ($schedule as [$delaySeconds, $tag]) {
+            $scopes[] = Workflow::async(function () use ($delaySeconds, $tag): \Generator {
+                yield Workflow::timer($delaySeconds);
+                $this->fired[$tag] = Workflow::now()->getTimestamp();
+            });
+        }
+
+        yield Promise::all($scopes);
+
+        return $this->fired;
+    }
+}

--- a/tests/Fixtures/src/Workflow/DelayedSignalWorkflow.php
+++ b/tests/Fixtures/src/Workflow/DelayedSignalWorkflow.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Workflow;
+
+use Temporal\Workflow;
+use Temporal\Workflow\WorkflowInterface;
+use Temporal\Workflow\SignalMethod;
+use Temporal\Workflow\WorkflowMethod;
+
+#[WorkflowInterface]
+class DelayedSignalWorkflow
+{
+    private ?string $received = null;
+
+    #[WorkflowMethod(name: 'DelayedSignalWorkflow')]
+    public function handler(int $timeoutSeconds): iterable
+    {
+        $arrived = yield Workflow::awaitWithTimeout($timeoutSeconds, fn(): bool => $this->received !== null);
+
+        return $arrived ? 'signal:' . $this->received : 'timeout';
+    }
+
+    #[SignalMethod(name: 'unblock')]
+    public function unblock(string $value): void
+    {
+        $this->received = $value;
+    }
+}

--- a/tests/Fixtures/src/Workflow/LongTimerWorkflow.php
+++ b/tests/Fixtures/src/Workflow/LongTimerWorkflow.php
@@ -11,18 +11,18 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Workflow;
 
-use Carbon\CarbonInterval;
 use Temporal\Workflow;
+use Temporal\Workflow\WorkflowInterface;
 use Temporal\Workflow\WorkflowMethod;
 
-#[Workflow\WorkflowInterface]
-class ChildWithLongTimerWorkflow
+#[WorkflowInterface]
+class LongTimerWorkflow
 {
-    #[WorkflowMethod(name: 'ChildWithLongTimerWorkflow')]
-    public function handler(): iterable
+    #[WorkflowMethod(name: 'LongTimerWorkflow')]
+    public function handler(int $seconds): iterable
     {
-        yield Workflow::timer(CarbonInterval::minutes(30));
+        yield Workflow::timer($seconds);
 
-        return 'child done';
+        return 'done';
     }
 }

--- a/tests/Fixtures/src/Workflow/ParentWaitsChildTimerWorkflow.php
+++ b/tests/Fixtures/src/Workflow/ParentWaitsChildTimerWorkflow.php
@@ -11,25 +11,22 @@ declare(strict_types=1);
 
 namespace Temporal\Tests\Workflow;
 
-use Carbon\CarbonInterval;
 use Temporal\Workflow;
+use Temporal\Workflow\WorkflowInterface;
 use Temporal\Workflow\ChildWorkflowOptions;
 use Temporal\Workflow\WorkflowMethod;
 
-#[Workflow\WorkflowInterface]
-class ParentWithChildAndTimerWorkflow
+#[WorkflowInterface]
+class ParentWaitsChildTimerWorkflow
 {
-    #[WorkflowMethod(name: 'ParentWithChildAndTimerWorkflow')]
-    public function handler(): iterable
+    #[WorkflowMethod(name: 'ParentWaitsChildTimerWorkflow')]
+    public function handler(int $seconds): iterable
     {
-        $child = yield Workflow::executeChildWorkflow(
+        return yield Workflow::executeChildWorkflow(
             'LongTimerWorkflow',
-            [1800],
-            ChildWorkflowOptions::new(),
+            [$seconds],
+            ChildWorkflowOptions::new()->withTaskQueue('default'),
+            'string',
         );
-
-        yield Workflow::timer(CarbonInterval::minutes(30));
-
-        return 'parent: ' . $child;
     }
 }

--- a/tests/Fixtures/src/Workflow/SignalCollectorWorkflow.php
+++ b/tests/Fixtures/src/Workflow/SignalCollectorWorkflow.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Workflow;
+
+use Temporal\Workflow;
+use Temporal\Workflow\QueryMethod;
+use Temporal\Workflow\SignalMethod;
+use Temporal\Workflow\WorkflowInterface;
+use Temporal\Workflow\WorkflowMethod;
+
+#[WorkflowInterface]
+class SignalCollectorWorkflow
+{
+    /** @var list<array{value: string, at: int}> */
+    private array $events = [];
+    private bool $done = false;
+
+    /**
+     * @return iterable<mixed>
+     */
+    #[WorkflowMethod(name: 'SignalCollectorWorkflow')]
+    public function handler(int $maxSeconds): iterable
+    {
+        yield Workflow::awaitWithTimeout($maxSeconds, fn(): bool => $this->done);
+
+        return $this->events;
+    }
+
+    #[SignalMethod(name: 'push')]
+    public function push(string $value): void
+    {
+        $this->events[] = ['value' => $value, 'at' => Workflow::now()->getTimestamp()];
+    }
+
+    #[SignalMethod(name: 'finish')]
+    public function finish(): void
+    {
+        $this->done = true;
+    }
+
+    #[QueryMethod(name: 'count')]
+    public function count(): int
+    {
+        return \count($this->events);
+    }
+}

--- a/tests/Fixtures/src/Workflow/SignalOnlyWorkflow.php
+++ b/tests/Fixtures/src/Workflow/SignalOnlyWorkflow.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Workflow;
+
+use Temporal\Workflow;
+use Temporal\Workflow\QueryMethod;
+use Temporal\Workflow\SignalMethod;
+use Temporal\Workflow\WorkflowInterface;
+use Temporal\Workflow\WorkflowMethod;
+
+/**
+ * Blocks on a pure condition with no timer, so a client-side driver cannot rely on the
+ * first-timer readiness heuristic and must be pointed at a query predicate instead.
+ */
+#[WorkflowInterface]
+class SignalOnlyWorkflow
+{
+    private int $received = 0;
+    private bool $done = false;
+
+    #[WorkflowMethod(name: 'SignalOnlyWorkflow')]
+    public function handler(): iterable
+    {
+        yield Workflow::await(fn(): bool => $this->done);
+
+        return $this->received;
+    }
+
+    #[SignalMethod(name: 'ping')]
+    public function ping(): void
+    {
+        ++$this->received;
+    }
+
+    #[SignalMethod(name: 'finish')]
+    public function finish(): void
+    {
+        $this->done = true;
+    }
+
+    #[QueryMethod(name: 'started')]
+    public function started(): bool
+    {
+        return true;
+    }
+}

--- a/tests/Fixtures/src/Workflow/SignalThenMockedActivityWorkflow.php
+++ b/tests/Fixtures/src/Workflow/SignalThenMockedActivityWorkflow.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Workflow;
+
+use Temporal\Activity\ActivityOptions;
+use Temporal\Tests\Activity\SimpleActivity;
+use Temporal\Workflow;
+use Temporal\Workflow\QueryMethod;
+use Temporal\Workflow\SignalMethod;
+use Temporal\Workflow\WorkflowInterface;
+use Temporal\Workflow\WorkflowMethod;
+
+/**
+ * Waits (with no timer) for a signal, then calls a mocked activity with a start-to-close
+ * timeout. Exercises the #745 interaction: a client-driven time advance must not fast-forward
+ * through the activity timeout before the mocked response arrives.
+ */
+#[WorkflowInterface]
+class SignalThenMockedActivityWorkflow
+{
+    private bool $go = false;
+
+    #[WorkflowMethod(name: 'SignalThenMockedActivityWorkflow')]
+    public function handler(): iterable
+    {
+        yield Workflow::await(fn(): bool => $this->go);
+
+        $activity = Workflow::newActivityStub(
+            SimpleActivity::class,
+            ActivityOptions::new()->withStartToCloseTimeout(30),
+        );
+
+        return yield $activity->echo('ping');
+    }
+
+    #[SignalMethod(name: 'go')]
+    public function go(): void
+    {
+        $this->go = true;
+    }
+
+    #[QueryMethod(name: 'ready')]
+    public function ready(): bool
+    {
+        return true;
+    }
+}

--- a/tests/Fixtures/src/Workflow/TimerThenMockedActivityWorkflow.php
+++ b/tests/Fixtures/src/Workflow/TimerThenMockedActivityWorkflow.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Workflow;
+
+use Temporal\Activity\ActivityOptions;
+use Temporal\Tests\Activity\SimpleActivity;
+use Temporal\Workflow;
+use Temporal\Workflow\WorkflowInterface;
+use Temporal\Workflow\WorkflowMethod;
+
+#[WorkflowInterface]
+class TimerThenMockedActivityWorkflow
+{
+    #[WorkflowMethod(name: 'TimerThenMockedActivityWorkflow')]
+    public function handler(int $seconds): iterable
+    {
+        yield Workflow::timer($seconds);
+
+        $activity = Workflow::newActivityStub(
+            SimpleActivity::class,
+            ActivityOptions::new()->withStartToCloseTimeout(30),
+        );
+
+        return yield $activity->echo('ping');
+    }
+}

--- a/tests/Functional/ChildWorkflowMockerTimeSkippingTestCase.php
+++ b/tests/Functional/ChildWorkflowMockerTimeSkippingTestCase.php
@@ -6,7 +6,7 @@ namespace Temporal\Tests\Functional;
 
 use Temporal\Testing\WorkflowMocker;
 use Temporal\Testing\WorkflowTestCase;
-use Temporal\Tests\Workflow\ChildWithLongTimerWorkflow;
+use Temporal\Tests\Workflow\LongTimerWorkflow;
 use Temporal\Tests\Workflow\ParentWithChildAndTimerWorkflow;
 
 final class ChildWorkflowMockerTimeSkippingTestCase extends WorkflowTestCase
@@ -18,7 +18,7 @@ final class ChildWorkflowMockerTimeSkippingTestCase extends WorkflowTestCase
 
     public function testParentWithStubbedChildSkipsThirtyMinuteTimerWithoutRealWaiting(): void
     {
-        $this->childWorkflowMocks()->expectCompletion('ChildWithLongTimerWorkflow', 'stubbed child');
+        $this->childWorkflowMocks()->expectCompletion('LongTimerWorkflow', 'stubbed child');
 
         $serverTimeBefore = $this->testingService->getCurrentTime();
         $wallClockBefore = \microtime(true);
@@ -40,14 +40,14 @@ final class ChildWorkflowMockerTimeSkippingTestCase extends WorkflowTestCase
         $serverTimeBefore = $this->testingService->getCurrentTime();
         $wallClockBefore = \microtime(true);
 
-        $child = $this->workflowClient->newWorkflowStub(ChildWithLongTimerWorkflow::class);
-        $run = $this->workflowClient->start($child);
+        $child = $this->workflowClient->newWorkflowStub(LongTimerWorkflow::class);
+        $run = $this->workflowClient->start($child, self::TIMER_SECONDS);
         $result = $run->getResult('string', self::MAX_WALL_CLOCK_SECONDS);
 
         $wallClockElapsed = \microtime(true) - $wallClockBefore;
         $serverTimeElapsed = $this->testingService->getCurrentTime()->getTimestamp() - $serverTimeBefore->getTimestamp();
 
-        self::assertSame('child done', $result);
+        self::assertSame('done', $result);
         self::assertGreaterThanOrEqual(self::TIMER_SECONDS, $serverTimeElapsed);
         self::assertLessThan(self::MAX_WALL_CLOCK_SECONDS, $wallClockElapsed);
     }

--- a/tests/Functional/ChildWorkflowTimeSkipTestCase.php
+++ b/tests/Functional/ChildWorkflowTimeSkipTestCase.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Functional;
+
+use Temporal\Client\WorkflowOptions;
+use Temporal\Testing\TimeSkippingWorkflowTestCase;
+
+final class ChildWorkflowTimeSkipTestCase extends TimeSkippingWorkflowTestCase
+{
+    public function testParentWaitingOnChildLongTimerSkipsTime(): void
+    {
+        $stub = $this->workflowClient->newUntypedWorkflowStub(
+            'ParentWaitsChildTimerWorkflow',
+            WorkflowOptions::new()->withTaskQueue('default'),
+        );
+
+        $timeBefore = \microtime(true);
+        $serverBefore = $this->testingService->getCurrentTime()->getTimestamp();
+
+        $run = $this->workflowClient->start($stub, 1800);
+        $result = $run->getResult('string', 30);
+
+        $timeElapsed = \microtime(true) - $timeBefore;
+        $serverAfter = $this->testingService->getCurrentTime()->getTimestamp();
+
+        self::assertSame('done', $result);
+        self::assertGreaterThanOrEqual(1800, $serverAfter - $serverBefore);
+        self::assertLessThan(20, $timeElapsed);
+    }
+}

--- a/tests/Functional/Client/AbstractClient.php
+++ b/tests/Functional/Client/AbstractClient.php
@@ -16,6 +16,7 @@ use Temporal\Api\History\V1\HistoryEvent;
 use Temporal\Api\Workflowservice\V1\GetWorkflowExecutionHistoryRequest;
 use Temporal\Client\GRPC\ServiceClient;
 use Temporal\Client\WorkflowClient;
+use Temporal\Testing\TemporalServer;
 use Temporal\Tests\Functional\AbstractFunctional;
 use Temporal\Workflow\WorkflowExecution;
 
@@ -28,10 +29,10 @@ abstract class AbstractClient extends AbstractFunctional
      * @param string $connection
      * @return WorkflowClient
      */
-    protected function createClient(string $connection = '127.0.0.1:7233'): WorkflowClient
+    protected function createClient(?string $connection = null): WorkflowClient
     {
         return new WorkflowClient(
-            ServiceClient::create($connection)
+            ServiceClient::create($connection ?? TemporalServer::address())
         );
     }
 

--- a/tests/Functional/ClientSideDelayedCallbackMatrixTestCase.php
+++ b/tests/Functional/ClientSideDelayedCallbackMatrixTestCase.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Functional;
+
+use Temporal\Client\WorkflowOptions;
+use Temporal\Client\WorkflowStubInterface;
+use Temporal\Exception\Client\WorkflowFailedException;
+use Temporal\Testing\WorkflowTestCase;
+
+final class ClientSideDelayedCallbackMatrixTestCase extends WorkflowTestCase
+{
+    public function testRejectsNegativeDelay(): void
+    {
+        $scheduler = $this->delayedCallbacks;
+
+        $this->expectException(\InvalidArgumentException::class);
+        $scheduler->registerDelayedCallback(-1, static fn(WorkflowStubInterface $s) => null);
+    }
+
+    public function testFiresInSortedOrderRegardlessOfRegistrationOrder(): void
+    {
+        $stub = $this->collector();
+        $scheduler = $this->delayedCallbacks;
+        $scheduler->registerDelayedCallback(600, static fn(WorkflowStubInterface $s) => $s->signal('push', 'second'));
+        $scheduler->registerDelayedCallback(300, static fn(WorkflowStubInterface $s) => $s->signal('push', 'first'));
+        $scheduler->registerDelayedCallback(900, static fn(WorkflowStubInterface $s) => $s->signal('finish'));
+
+        $scheduler->start($stub, 3600);
+        $events = $stub->getResult('array', 30);
+
+        self::assertSame(['first', 'second'], \array_column($events, 'value'));
+    }
+
+    public function testZeroDelayFiresImmediately(): void
+    {
+        $stub = $this->collector();
+        $scheduler = $this->delayedCallbacks;
+        $scheduler->registerDelayedCallback(0, static fn(WorkflowStubInterface $s) => $s->signal('push', 'zero'));
+        $scheduler->registerDelayedCallback(1, static fn(WorkflowStubInterface $s) => $s->signal('finish'));
+
+        $scheduler->start($stub, 3600);
+        $events = $stub->getResult('array', 30);
+
+        self::assertSame(['zero'], \array_column($events, 'value'));
+    }
+
+    public function testQueryCallbackReadsStateAtScheduledTime(): void
+    {
+        $stub = $this->collector();
+        $countAt600 = null;
+        $scheduler = $this->delayedCallbacks;
+        $scheduler->registerDelayedCallback(300, static fn(WorkflowStubInterface $s) => $s->signal('push', 'a'));
+        $scheduler->registerDelayedCallback(600, static function (WorkflowStubInterface $s) use (&$countAt600): void {
+            $countAt600 = $s->query('count')?->getValue(0, 'int');
+        });
+        $scheduler->registerDelayedCallback(900, static fn(WorkflowStubInterface $s) => $s->signal('finish'));
+
+        $scheduler->start($stub, 3600);
+        $stub->getResult('array', 30);
+
+        self::assertSame(1, $countAt600);
+    }
+
+    public function testCancelCallbackCancelsWorkflowAtScheduledTime(): void
+    {
+        $stub = $this->collector();
+        $scheduler = $this->delayedCallbacks;
+        $scheduler->registerDelayedCallback(300, static fn(WorkflowStubInterface $s) => $s->cancel());
+
+        $scheduler->start($stub, 3600);
+
+        $this->expectException(WorkflowFailedException::class);
+        $stub->getResult('array', 30);
+    }
+
+    public function testEmptySchedulerLeavesCounterBalanced(): void
+    {
+        $stub = $this->collector();
+        $scheduler = $this->delayedCallbacks;
+
+        $scheduler->start($stub, 5);
+        $events = $stub->getResult('array', 30);
+
+        self::assertSame([], $events);
+        self::assertSame(0, $this->testingService->lockDelta());
+    }
+
+    public function testLateCallbackFailsWithClearError(): void
+    {
+        $stub = $this->collector();
+        $scheduler = $this->delayedCallbacks;
+        $scheduler->registerDelayedCallback(300, static fn(WorkflowStubInterface $s) => $s->signal('finish'));
+        $scheduler->registerDelayedCallback(600, static fn(WorkflowStubInterface $s) => $s->signal('push', 'late'));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/no longer running/');
+        $scheduler->start($stub, 3600);
+    }
+
+    public function testNoTimerWorkflowDrivenViaReadyWhen(): void
+    {
+        $stub = $this->workflowClient->newUntypedWorkflowStub(
+            'SignalOnlyWorkflow',
+            WorkflowOptions::new()->withTaskQueue('default'),
+        );
+
+        $scheduler = $this->delayedCallbacks;
+        $scheduler->readyWhen(static fn(): bool => (bool) $stub->query('started')?->getValue(0, 'bool'));
+        $scheduler->registerDelayedCallback(300, static fn(WorkflowStubInterface $s) => $s->signal('ping'));
+        $scheduler->registerDelayedCallback(600, static fn(WorkflowStubInterface $s) => $s->signal('ping'));
+        $scheduler->registerDelayedCallback(900, static fn(WorkflowStubInterface $s) => $s->signal('finish'));
+
+        $scheduler->start($stub);
+        $received = $stub->getResult('int', 30);
+
+        self::assertSame(2, $received);
+    }
+
+    private function collector(): WorkflowStubInterface
+    {
+        return $this->workflowClient->newUntypedWorkflowStub(
+            'SignalCollectorWorkflow',
+            WorkflowOptions::new()
+                ->withTaskQueue('default')
+                ->withWorkflowExecutionTimeout(new \DateInterval('PT2H')),
+        );
+    }
+}

--- a/tests/Functional/ClientSideDelayedCallbackTestCase.php
+++ b/tests/Functional/ClientSideDelayedCallbackTestCase.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Functional;
+
+use Temporal\Client\WorkflowOptions;
+use Temporal\Client\WorkflowStubInterface;
+use Temporal\Testing\WorkflowTestCase;
+
+final class ClientSideDelayedCallbackTestCase extends WorkflowTestCase
+{
+    public function testCallbacksFireAtScheduledSimulatedTimes(): void
+    {
+        $stub = $this->workflowClient->newUntypedWorkflowStub(
+            'SignalCollectorWorkflow',
+            WorkflowOptions::new()
+                ->withTaskQueue('default')
+                ->withWorkflowExecutionTimeout(new \DateInterval('PT2H')),
+        );
+
+        $scheduler = $this->delayedCallbacks;
+        $scheduler->registerDelayedCallback(300, static fn(WorkflowStubInterface $s) => $s->signal('push', 'first'));
+        $scheduler->registerDelayedCallback(600, static fn(WorkflowStubInterface $s) => $s->signal('push', 'second'));
+        $scheduler->registerDelayedCallback(900, static fn(WorkflowStubInterface $s) => $s->signal('finish'));
+
+        $before = \microtime(true);
+        $base = $this->testingService->getCurrentTime()->getTimestamp();
+
+        $scheduler->start($stub, 3600);
+        $events = $stub->getResult('array', 30);
+
+        $elapsed = \microtime(true) - $before;
+
+        self::assertCount(2, $events);
+        self::assertSame('first', $events[0]['value']);
+        self::assertSame('second', $events[1]['value']);
+        self::assertSame(300, $events[1]['at'] - $events[0]['at']);
+        self::assertGreaterThanOrEqual(300, $events[0]['at'] - $base);
+        self::assertLessThan(20, $elapsed);
+    }
+}

--- a/tests/Functional/DataConverterTestCase.php
+++ b/tests/Functional/DataConverterTestCase.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
 use Temporal\Client\GRPC\ServiceClient;
 use Temporal\Client\WorkflowClient;
 use Temporal\Testing\Replay\WorkflowReplayer;
+use Temporal\Testing\TemporalServer;
 use Temporal\Tests\TestCase;
 use Temporal\Tests\Workflow\ProtoPayloadWorkflow;
 
@@ -16,7 +17,7 @@ final class DataConverterTestCase extends TestCase
     protected function setUp(): void
     {
         $this->workflowClient = new WorkflowClient(
-            ServiceClient::create('127.0.0.1:7233')
+            ServiceClient::create(TemporalServer::address())
         );
 
         parent::setUp();

--- a/tests/Functional/DelayedSignalInjectionTestCase.php
+++ b/tests/Functional/DelayedSignalInjectionTestCase.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Functional;
+
+use Temporal\Client\WorkflowOptions;
+use Temporal\Testing\WorkflowTestCase;
+
+final class DelayedSignalInjectionTestCase extends WorkflowTestCase
+{
+    public function testSignalIsDeliveredAfterSimulatedDelay(): void
+    {
+        $stub = $this->workflowClient->newUntypedWorkflowStub(
+            'DelayedSignalWorkflow',
+            WorkflowOptions::new()->withTaskQueue('default'),
+        );
+
+        $before = $this->testingService->getCurrentTime()->getTimestamp();
+        $this->delayedCallbacks->signalAfter(30, 'unblock', 'hello')->start($stub, 120);
+        $after = $this->testingService->getCurrentTime()->getTimestamp();
+
+        self::assertGreaterThanOrEqual(30, $after - $before);
+        self::assertSame('signal:hello', $stub->getResult('string', 30));
+    }
+}

--- a/tests/Functional/HistoryLengthWorkflowTestCase.php
+++ b/tests/Functional/HistoryLengthWorkflowTestCase.php
@@ -7,6 +7,7 @@ namespace Temporal\Tests\Functional;
 use Temporal\Client\GRPC\ServiceClient;
 use Temporal\Client\WorkflowClient;
 use Temporal\Testing\ActivityMocker;
+use Temporal\Testing\TemporalServer;
 use Temporal\Tests\TestCase;
 use Temporal\Tests\Workflow\HistoryLengthWorkflow;
 
@@ -18,7 +19,7 @@ final class HistoryLengthWorkflowTestCase extends TestCase
     protected function setUp(): void
     {
         $this->workflowClient = new WorkflowClient(
-            ServiceClient::create('127.0.0.1:7233')
+            ServiceClient::create(TemporalServer::address())
         );
         $this->activityMocks = new ActivityMocker();
 

--- a/tests/Functional/Interceptor/AbstractClient.php
+++ b/tests/Functional/Interceptor/AbstractClient.php
@@ -13,6 +13,7 @@ namespace Temporal\Tests\Functional\Interceptor;
 
 use Temporal\Client\GRPC\ServiceClient;
 use Temporal\Client\WorkflowClient;
+use Temporal\Testing\TemporalServer;
 use Temporal\Tests\Fixtures\PipelineProvider;
 use Temporal\Tests\Functional\AbstractFunctional;
 use Temporal\Tests\Interceptor\InterceptorCallsCounter;
@@ -26,10 +27,10 @@ abstract class AbstractClient extends AbstractFunctional
      * @param string $connection
      * @return WorkflowClient
      */
-    protected function createClient(string $connection = '127.0.0.1:7233'): WorkflowClient
+    protected function createClient(?string $connection = null): WorkflowClient
     {
         return new WorkflowClient(
-            ServiceClient::create($connection),
+            ServiceClient::create($connection ?? TemporalServer::address()),
             interceptorProvider: new PipelineProvider([InterceptorCallsCounter::class]),
         );
     }

--- a/tests/Functional/Interceptor/GrpcClientInterceptor.php
+++ b/tests/Functional/Interceptor/GrpcClientInterceptor.php
@@ -9,6 +9,7 @@ use Temporal\Client\GRPC\ContextInterface;
 use Temporal\Client\GRPC\ServiceClient;
 use Temporal\Client\WorkflowClient;
 use Temporal\Internal\Interceptor\Pipeline;
+use Temporal\Testing\TemporalServer;
 use Temporal\Testing\TestService;
 use Temporal\Tests\Workflow\SimpleWorkflow;
 
@@ -25,7 +26,7 @@ class GrpcClientInterceptor extends TestCase
      */
     protected function setUp(): void
     {
-        $temporalAddress = getenv('TEMPORAL_ADDRESS') ?: '127.0.0.1:7233';
+        $temporalAddress = TemporalServer::address();
         $this->workflowClient = new WorkflowClient(
             ServiceClient::create($temporalAddress)
                 ->withInterceptorPipeline(

--- a/tests/Functional/MockedActivityTimeSkipTestCase.php
+++ b/tests/Functional/MockedActivityTimeSkipTestCase.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Functional;
+
+use Temporal\Client\WorkflowOptions;
+use Temporal\Testing\TimeSkippingWorkflowTestCase;
+
+final class MockedActivityTimeSkipTestCase extends TimeSkippingWorkflowTestCase
+{
+    public function testMockedActivityAfterLongTimerDoesNotHitStartToCloseTimeout(): void
+    {
+        $this->activityMocks->expectCompletion('SimpleActivity.echo', 'mocked-echo');
+
+        $stub = $this->workflowClient->newUntypedWorkflowStub(
+            'TimerThenMockedActivityWorkflow',
+            WorkflowOptions::new()
+                ->withTaskQueue('default')
+                ->withWorkflowExecutionTimeout(new \DateInterval('PT2H')),
+        );
+
+        $timeBefore = \microtime(true);
+        $serverBefore = $this->testingService->getCurrentTime()->getTimestamp();
+
+        $run = $this->workflowClient->start($stub, 1800);
+        $result = $run->getResult('string', 30);
+
+        $timeElapsed = \microtime(true) - $timeBefore;
+        $serverAfter = $this->testingService->getCurrentTime()->getTimestamp();
+
+        self::assertSame('mocked-echo', $result);
+        self::assertGreaterThanOrEqual(1800, $serverAfter - $serverBefore);
+        self::assertLessThan(20, $timeElapsed);
+    }
+}

--- a/tests/Functional/NamedArgumentsTestCase.php
+++ b/tests/Functional/NamedArgumentsTestCase.php
@@ -7,6 +7,7 @@ namespace Temporal\Tests\Functional;
 use Temporal\Client\GRPC\ServiceClient;
 use Temporal\Client\WorkflowClient;
 use Temporal\Client\WorkflowOptions;
+use Temporal\Testing\TemporalServer;
 use Temporal\Tests\Workflow\ContinuaWithTaskQueueWorkflow;
 use Temporal\Tests\Workflow\NamedArguments\ContinueAsNewNamedArgumentsWorkflow;
 use Temporal\Tests\Workflow\NamedArguments\ExecuteChildNamedArgumentsWorkflow;
@@ -278,7 +279,7 @@ final class NamedArgumentsTestCase extends TestCase
     protected function setUp(): void
     {
         $this->workflowClient = new WorkflowClient(
-            ServiceClient::create('127.0.0.1:7233'),
+            ServiceClient::create(TemporalServer::address()),
         );
 
         parent::setUp();

--- a/tests/Functional/NestedTimeSkipGuardTestCase.php
+++ b/tests/Functional/NestedTimeSkipGuardTestCase.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Functional;
+
+use Temporal\Client\WorkflowOptions;
+use Temporal\Client\WorkflowStubInterface;
+use Temporal\Testing\DelayedCallbackScheduler;
+use Temporal\Testing\TimeSkippingWorkflowTestCase;
+use Temporal\Testing\WorkflowTestCase;
+
+final class NestedTimeSkipGuardTestCase extends TimeSkippingWorkflowTestCase
+{
+    public function testSchedulerRefusesToNestInsideALockedContext(): void
+    {
+        $this->delayedCallbacks->registerDelayedCallback(1, static fn(WorkflowStubInterface $s) => null);
+
+        $stub = $this->workflowClient->newUntypedWorkflowStub(
+            'SignalCollectorWorkflow',
+            WorkflowOptions::new()->withTaskQueue('default'),
+        );
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage(\sprintf(
+            '%s must own time-skipping exclusively, but the lock counter is already held (delta 1). '
+            . 'Do not drive it inside %s or alongside another time-skip driver; extend the plain %s instead.',
+            DelayedCallbackScheduler::class,
+            TimeSkippingWorkflowTestCase::class,
+            WorkflowTestCase::class,
+        ));
+
+        $this->delayedCallbacks->start($stub, 3600);
+    }
+}

--- a/tests/Functional/ReplayerTestCase.php
+++ b/tests/Functional/ReplayerTestCase.php
@@ -15,6 +15,7 @@ use Temporal\Client\WorkflowStubInterface;
 use Temporal\Testing\Replay\Exception\NonDeterministicWorkflowException;
 use Temporal\Testing\Replay\Exception\ReplayerException;
 use Temporal\Testing\Replay\WorkflowReplayer;
+use Temporal\Testing\TemporalServer;
 use Temporal\Tests\TestCase;
 use Temporal\Tests\Workflow\AwaitsUpdateWorkflow;
 use Temporal\Tests\Workflow\SignalWorkflow;
@@ -27,7 +28,7 @@ final class ReplayerTestCase extends TestCase
     protected function setUp(): void
     {
         $this->workflowClient = new WorkflowClient(
-            ServiceClient::create('127.0.0.1:7233')
+            ServiceClient::create(TemporalServer::address())
         );
 
         parent::setUp();

--- a/tests/Functional/SchedulerWithMockedActivityTestCase.php
+++ b/tests/Functional/SchedulerWithMockedActivityTestCase.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Functional;
+
+use Temporal\Client\WorkflowOptions;
+use Temporal\Client\WorkflowStubInterface;
+use Temporal\Testing\WorkflowTestCase;
+
+final class SchedulerWithMockedActivityTestCase extends WorkflowTestCase
+{
+    public function testScheduledSignalThenMockedActivityDoesNotHitStartToClose(): void
+    {
+        $this->activityMocks->expectCompletion('SimpleActivity.echo', 'mocked-echo');
+
+        $stub = $this->workflowClient->newUntypedWorkflowStub(
+            'SignalThenMockedActivityWorkflow',
+            WorkflowOptions::new()
+                ->withTaskQueue('default')
+                ->withWorkflowExecutionTimeout(new \DateInterval('PT2H')),
+        );
+
+        $scheduler = $this->delayedCallbacks;
+        $scheduler->readyWhen(static fn(): bool => (bool) $stub->query('ready')?->getValue(0, 'bool'));
+        $scheduler->registerDelayedCallback(1800, static fn(WorkflowStubInterface $s) => $s->signal('go'));
+
+        $before = \microtime(true);
+        $serverBefore = $this->testingService->getCurrentTime()->getTimestamp();
+
+        $scheduler->start($stub);
+        $result = $stub->getResult('string', 30);
+
+        $elapsed = \microtime(true) - $before;
+        $serverElapsed = $this->testingService->getCurrentTime()->getTimestamp() - $serverBefore;
+
+        self::assertSame('mocked-echo', $result);
+        self::assertGreaterThanOrEqual(1800, $serverElapsed);
+        self::assertLessThan(20, $elapsed);
+    }
+}

--- a/tests/Functional/SimpleWorkflowTestCase.php
+++ b/tests/Functional/SimpleWorkflowTestCase.php
@@ -9,6 +9,7 @@ use Temporal\Client\GRPC\ServiceClient;
 use Temporal\Client\WorkflowClient;
 use Temporal\Client\WorkflowOptions;
 use Temporal\Testing\ActivityMocker;
+use Temporal\Testing\TemporalServer;
 use Temporal\Tests\DTO\Message;
 use Temporal\Tests\DTO\User;
 use Temporal\Tests\TestCase;
@@ -130,7 +131,7 @@ final class SimpleWorkflowTestCase extends TestCase
     protected function setUp(): void
     {
         $this->workflowClient = new WorkflowClient(
-            ServiceClient::create('127.0.0.1:7233'),
+            ServiceClient::create(TemporalServer::address()),
         );
         $this->activityMocks = new ActivityMocker();
 

--- a/tests/Functional/TimeSkippingSpikeTestCase.php
+++ b/tests/Functional/TimeSkippingSpikeTestCase.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Functional;
+
+use Temporal\Testing\WorkflowTestCase;
+
+final class TimeSkippingSpikeTestCase extends WorkflowTestCase
+{
+    public function testLockThenUnlockWithSleepFastForwardsServerTime(): void
+    {
+        $this->testingService->lockTimeSkipping();
+
+        $before = $this->testingService->getCurrentTime()->getTimestamp();
+        $this->testingService->unlockTimeSkippingWithSleep(5);
+        $after = $this->testingService->getCurrentTime()->getTimestamp();
+
+        $this->testingService->unlockTimeSkipping();
+
+        self::assertGreaterThanOrEqual(5, $after - $before);
+        self::assertLessThan(15, $after - $before);
+    }
+}

--- a/tests/Functional/TimerOnlyTimeSkipTestCase.php
+++ b/tests/Functional/TimerOnlyTimeSkipTestCase.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Functional;
+
+use Temporal\Client\WorkflowOptions;
+use Temporal\Testing\TimeSkippingWorkflowTestCase;
+
+final class TimerOnlyTimeSkipTestCase extends TimeSkippingWorkflowTestCase
+{
+    public function testLongTimerSkipsInTime(): void
+    {
+        $stub = $this->workflowClient->newUntypedWorkflowStub(
+            'LongTimerWorkflow',
+            WorkflowOptions::new()->withTaskQueue('default'),
+        );
+
+        $before = \microtime(true);
+        $serverBefore = $this->testingService->getCurrentTime()->getTimestamp();
+
+        $run = $this->workflowClient->start($stub, 1800);
+        $result = $run->getResult('string', 30);
+
+        $timeElapsed = \microtime(true) - $before;
+        $serverAfter = $this->testingService->getCurrentTime()->getTimestamp();
+
+        self::assertSame('done', $result);
+        self::assertGreaterThanOrEqual(1800, $serverAfter - $serverBefore);
+        self::assertLessThan(20, $timeElapsed);
+    }
+}

--- a/tests/Functional/WorkflowSideDelayedCallbackTestCase.php
+++ b/tests/Functional/WorkflowSideDelayedCallbackTestCase.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Functional;
+
+use Temporal\Client\WorkflowOptions;
+use Temporal\Testing\TimeSkippingWorkflowTestCase;
+
+final class WorkflowSideDelayedCallbackTestCase extends TimeSkippingWorkflowTestCase
+{
+    public function testDeferredActionsFireAtTheirVirtualTimeWithoutRealWaiting(): void
+    {
+        $stub = $this->workflowClient->newUntypedWorkflowStub(
+            'DelayedCallbackWorkflow',
+            WorkflowOptions::new()
+                ->withTaskQueue('default')
+                ->withWorkflowExecutionTimeout(new \DateInterval('PT2H')),
+        );
+
+        $before = \microtime(true);
+        $serverBefore = $this->testingService->getCurrentTime()->getTimestamp();
+
+        $run = $this->workflowClient->start($stub, [[300, 'a'], [600, 'b'], [1800, 'c']]);
+        $fired = $run->getResult('array', 30);
+
+        $elapsed = \microtime(true) - $before;
+        $serverElapsed = $this->testingService->getCurrentTime()->getTimestamp() - $serverBefore;
+
+        self::assertArrayHasKey('a', $fired);
+        self::assertArrayHasKey('b', $fired);
+        self::assertArrayHasKey('c', $fired);
+        self::assertSame(300, $fired['b'] - $fired['a']);
+        self::assertSame(1500, $fired['c'] - $fired['a']);
+        self::assertGreaterThanOrEqual(1800, $serverElapsed);
+        self::assertLessThan(20, $elapsed);
+    }
+}

--- a/tests/SearchAttributeTestInvoker.php
+++ b/tests/SearchAttributeTestInvoker.php
@@ -7,13 +7,14 @@ namespace Temporal\Tests;
 use Temporal\Api\Operatorservice\V1\OperatorServiceClient;
 use Grpc\ChannelCredentials;
 use Temporal\Api\Operatorservice\V1\AddSearchAttributesRequest;
+use Temporal\Testing\TemporalServer;
 
 final class SearchAttributeTestInvoker
 {
     public function __invoke(): void
     {
         $operation = new OperatorServiceClient(
-            getenv('TEMPORAL_ADDRESS') ?: '127.0.0.1:7233',
+            TemporalServer::address(),
             ['credentials' => ChannelCredentials::createInsecure()]
         );
         $result = $operation->AddSearchAttributes(


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Time-skipping test support + a client-side delayed-callback scheduler.

- `TimeLockingInterceptor` + `TimeSkippingWorkflowTestCase`: timer-only workflows and ActivityMocker now work under time-skipping (`composer test:func-timeskip`).
- `DelayedCallbackScheduler` (`$this->delayedCallbacks`): fire signal/query/cancel at simulated-time offsets; `signalAfter()` / `readyWhen()`.
- Lock-counter ownership guard in `WorkflowTestCase::tearDown` (a leaked lock no longer poisons the suite); test-side address via `TemporalServer::address()`.

## Why?
<!-- Tell your future self why have you made these changes -->

Timer-driven workflows were untestable under time-skipping and ActivityMocker + long timers hit spurious activity timeouts.

## Checklist
<!--- add/delete as needed --->

1. Closes #743 
   closes #745
   closes #529
   closes #744 

3. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
New Unit/Functional/Functional-TimeSkipping suites, all green + a negative repro for #745.

4. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
Yes — testing-suite page on docs.temporal.io.
