### PR TITLE
Remove experimental markers from user metadata fields

### DIFF
--- a/src/Activity/ActivityOptions.php
+++ b/src/Activity/ActivityOptions.php
@@ -125,8 +125,6 @@ class ActivityOptions extends Options implements ActivityOptionsInterface
      * Single-line fixed summary for this activity that will appear in UI/CLI.
      * This can be in single-line Temporal Markdown format.
      *
-     * @experimental This API is experimental and may change in the future.
-     *
      * @since RoadRunner 2025.1.2
      */
     #[Marshal(name: 'Summary')]
@@ -339,8 +337,6 @@ class ActivityOptions extends Options implements ActivityOptionsInterface
      *
      * Single-line fixed summary for this activity that will appear in UI/CLI.
      * This can be in single-line Temporal Markdown format.
-     *
-     * @experimental This API is experimental and may change in the future.
      *
      * @return $this
      */

--- a/src/Activity/LocalActivityOptions.php
+++ b/src/Activity/LocalActivityOptions.php
@@ -69,8 +69,6 @@ class LocalActivityOptions extends Options implements ActivityOptionsInterface
 
     /**
      * Optional summary of the activity.
-     *
-     * @experimental This API is experimental and may change in the future.
      */
     #[Marshal(name: 'Summary')]
     public string $summary = '';
@@ -166,8 +164,6 @@ class LocalActivityOptions extends Options implements ActivityOptionsInterface
      *
      * Single-line fixed summary for this activity that will appear in UI/CLI.
      * This can be in single-line Temporal Markdown format.
-     *
-     * @experimental This API is experimental and may change in the future.
      *
      * @return $this
      */

--- a/src/Client/Schedule/Action/StartWorkflowAction.php
+++ b/src/Client/Schedule/Action/StartWorkflowAction.php
@@ -111,7 +111,6 @@ final class StartWorkflowAction extends ScheduleAction
 
     /**
      * @internal
-     * @experimental This feature is not stable and may change in the future.
      */
     #[Marshal(name: 'user_metadata')]
     public readonly UserMetadata $userMetadata;
@@ -281,7 +280,6 @@ final class StartWorkflowAction extends ScheduleAction
      *
      * This can be in single-line Temporal Markdown format.
      *
-     * @experimental This feature is not stable and may change in the future.
      */
     public function withStaticSummary(string $summary): self
     {
@@ -295,7 +293,6 @@ final class StartWorkflowAction extends ScheduleAction
      * This can be in Temporal Markdown format and can span multiple lines. This is a fixed value on the workflow
      * that cannot be updated.
      *
-     * @experimental This feature is not stable and may change in the future.
      */
     public function withStaticDetails(string $details): self
     {

--- a/src/Client/WorkflowOptions.php
+++ b/src/Client/WorkflowOptions.php
@@ -162,16 +162,12 @@ final class WorkflowOptions extends Options
 
     /**
      * General fixed details for this workflow execution that will appear in UI/CLI.
-     *
-     * @experimental This feature is not stable and may change in the future.
      */
     #[Marshal(name: 'StaticDetails')]
     public string $staticDetails = '';
 
     /**
      * Single-line fixed summary for this workflow execution that will appear in UI/CLI.
-     *
-     * @experimental This feature is not stable and may change in the future.
      */
     #[Marshal(name: 'StaticSummary')]
     public string $staticSummary = '';
@@ -504,7 +500,6 @@ final class WorkflowOptions extends Options
      *
      * @return $this
      * @since SDK 2.14.0
-     * @experimental This API might change in the future.
      */
     #[Pure]
     public function withStaticSummary(string $summary): self
@@ -522,7 +517,6 @@ final class WorkflowOptions extends Options
      *
      * @return $this
      * @since SDK 2.14.0
-     * @experimental This API might change in the future.
      */
     #[Pure]
     public function withStaticDetails(string $details): self

--- a/src/Interceptor/WorkflowOutboundCalls/TimerInput.php
+++ b/src/Interceptor/WorkflowOutboundCalls/TimerInput.php
@@ -25,9 +25,6 @@ final class TimerInput
     public function __construct(
         public readonly \DateInterval $interval,
 
-        /**
-         * @experimental This API is experimental and may change in the future.
-         */
         public readonly ?TimerOptions $timerOptions,
     ) {}
 

--- a/src/Workflow/ChildWorkflowOptions.php
+++ b/src/Workflow/ChildWorkflowOptions.php
@@ -160,16 +160,12 @@ final class ChildWorkflowOptions extends Options
 
     /**
      * General fixed details for this workflow execution that will appear in UI/CLI.
-     *
-     * @experimental This feature is not stable and may change in the future.
      */
     #[Marshal(name: 'StaticDetails')]
     public string $staticDetails = '';
 
     /**
      * Single-line fixed summary for this workflow execution that will appear in UI/CLI.
-     *
-     * @experimental This feature is not stable and may change in the future.
      */
     #[Marshal(name: 'StaticSummary')]
     public string $staticSummary = '';
@@ -468,7 +464,6 @@ final class ChildWorkflowOptions extends Options
      *
      * @return $this
      * @since SDK 2.14.0
-     * @experimental This API might change in the future.
      */
     #[Pure]
     public function withStaticSummary(string $summary): self
@@ -486,7 +481,6 @@ final class ChildWorkflowOptions extends Options
      *
      * @return $this
      * @since SDK 2.14.0
-     * @experimental This API might change in the future.
      */
     #[Pure]
     public function withStaticDetails(string $details): self

--- a/src/Workflow/TimerOptions.php
+++ b/src/Workflow/TimerOptions.php
@@ -15,8 +15,6 @@ use Temporal\Internal\Traits\CloneWith;
 
 /**
  * TimerOptions is used to specify options for a timer.
- *
- * @experimental This API is experimental and may change in the future.
  */
 final class TimerOptions
 {


### PR DESCRIPTION
## Summary
- Remove `@experimental` PHPDoc tags from user metadata fields: staticSummary, staticDetails, activity summary, timer summary
- These features are stable and shipping across all SDKs - graduating to GA API surface
- 7 files changed, 16 tags removed

## Test plan
- [ ] Verify no test failures
- [ ] Confirm SideEffectOptions, AwaitOptions, and FeatureFlags experimental markers are untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)