### PR TITLE
fix: merge method-level #[MethodRetry] into activity/workflow retry options

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -160,9 +160,6 @@
       <code><![CDATA[toPayload]]></code>
       <code><![CDATA[toPayload]]></code>
     </ImpureMethodCall>
-    <PossiblyNullReference>
-      <code><![CDATA[mergeWith]]></code>
-    </PossiblyNullReference>
     <UnnecessaryVarAnnotation>
       <code><![CDATA[SearchAttributeKey]]></code>
     </UnnecessaryVarAnnotation>

--- a/src/Activity/ActivityOptions.php
+++ b/src/Activity/ActivityOptions.php
@@ -153,8 +153,8 @@ class ActivityOptions extends Options implements ActivityOptionsInterface
     {
         $self = clone $this;
 
-        if ($retry !== null && $this->diff->isPresent($self, 'retryOptions')) {
-            $self->retryOptions = $this->retryOptions?->mergeWith($retry);
+        if ($retry !== null) {
+            $self->retryOptions = ($self->retryOptions ?? RetryOptions::new())->mergeWith($retry);
         }
 
         return $self;

--- a/src/Activity/LocalActivityOptions.php
+++ b/src/Activity/LocalActivityOptions.php
@@ -93,8 +93,8 @@ class LocalActivityOptions extends Options implements ActivityOptionsInterface
     {
         $self = clone $this;
 
-        if ($retry !== null && $this->diff->isPresent($self, 'retryOptions')) {
-            $self->retryOptions = $this->retryOptions?->mergeWith($retry);
+        if ($retry !== null) {
+            $self->retryOptions = ($self->retryOptions ?? RetryOptions::new())->mergeWith($retry);
         }
 
         return $self;

--- a/src/Client/WorkflowOptions.php
+++ b/src/Client/WorkflowOptions.php
@@ -215,8 +215,8 @@ final class WorkflowOptions extends Options
     {
         $self = clone $this;
 
-        if ($retry !== null && $self->diff->isPresent($self, 'retryOptions')) {
-            $self->retryOptions = $self->retryOptions->mergeWith($retry);
+        if ($retry !== null) {
+            $self->retryOptions = ($self->retryOptions ?? RetryOptions::new())->mergeWith($retry);
         }
 
         if ($cron !== null && $self->diff->isPresent($self, 'cronSchedule')) {

--- a/src/Workflow/ChildWorkflowOptions.php
+++ b/src/Workflow/ChildWorkflowOptions.php
@@ -210,8 +210,8 @@ final class ChildWorkflowOptions extends Options
     {
         $self = clone $this;
 
-        if ($retry !== null && $self->diff->isPresent($self, 'retryOptions')) {
-            $self->retryOptions = $self->retryOptions?->mergeWith($retry);
+        if ($retry !== null) {
+            $self->retryOptions = ($self->retryOptions ?? RetryOptions::new())->mergeWith($retry);
         }
 
         if ($cron !== null && $self->diff->isPresent($self, 'cronSchedule')) {

--- a/tests/Unit/DTO/ActivityOptionsTestCase.php
+++ b/tests/Unit/DTO/ActivityOptionsTestCase.php
@@ -14,6 +14,7 @@ namespace Temporal\Tests\Unit\DTO;
 use Carbon\CarbonInterval;
 use Temporal\Activity\ActivityCancellationType;
 use Temporal\Activity\ActivityOptions;
+use Temporal\Common\MethodRetry;
 use Temporal\Common\RetryOptions;
 use Temporal\Common\Uuid;
 
@@ -123,5 +124,48 @@ class ActivityOptionsTestCase extends AbstractDTOMarshalling
         $this->assertNotSame($dto, $dto->withRetryOptions(
             RetryOptions::new()
         ));
+    }
+
+    public function testMergeWithMethodRetryFillsDefaultRetryOptions(): void
+    {
+        $dto = ActivityOptions::new()
+            ->withRetryOptions(RetryOptions::new())
+            ->mergeWith(new MethodRetry(maximumAttempts: 5));
+
+        $this->assertSame(5, $dto->retryOptions->maximumAttempts);
+    }
+
+    public function testMergeWithMethodRetryCreatesRetryOptionsWhenNull(): void
+    {
+        $dto = ActivityOptions::new()->mergeWith(new MethodRetry(maximumAttempts: 5));
+
+        $this->assertNotNull($dto->retryOptions);
+        $this->assertSame(5, $dto->retryOptions->maximumAttempts);
+    }
+
+    public function testMergeWithMethodRetryKeepsUserDefinedFields(): void
+    {
+        $methodRetry = new MethodRetry(maximumAttempts: 5, maximumInterval: 30);
+        $dto = ActivityOptions::new()
+            ->withRetryOptions(RetryOptions::new()->withMaximumAttempts(1))
+            ->mergeWith($methodRetry);
+
+        $this->assertSame(1, $dto->retryOptions->maximumAttempts);
+        $this->assertSame($methodRetry->maximumInterval, $dto->retryOptions->maximumInterval);
+    }
+
+    public function testMergeWithNullRetryDoesNotChangeRetryOptions(): void
+    {
+        $retry = RetryOptions::new()->withMaximumAttempts(7);
+        $dto = ActivityOptions::new()->withRetryOptions($retry)->mergeWith(null);
+
+        $this->assertSame(7, $dto->retryOptions->maximumAttempts);
+    }
+
+    public function testMergeWithDoesNotMutateState(): void
+    {
+        $dto = new ActivityOptions();
+
+        $this->assertNotSame($dto, $dto->mergeWith(new MethodRetry(maximumAttempts: 5)));
     }
 }

--- a/tests/Unit/DTO/ChildWorkflowOptionsTestCase.php
+++ b/tests/Unit/DTO/ChildWorkflowOptionsTestCase.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 namespace Temporal\Tests\Unit\DTO;
 
 use Temporal\Common\IdReusePolicy;
+use Temporal\Common\MethodRetry;
+use Temporal\Common\RetryOptions;
 use Temporal\Workflow\ChildWorkflowCancellationType;
 use Temporal\Workflow\ChildWorkflowOptions;
 use Temporal\Workflow\ParentClosePolicy;
@@ -106,5 +108,33 @@ class ChildWorkflowOptionsTestCase extends AbstractDTOMarshalling
             ChildWorkflowCancellationType::WaitCancellationCompleted
         ));
         $this->assertSame(ChildWorkflowCancellationType::TryCancel->value, $dto->cancellationType);
+    }
+
+    public function testMergeWithMethodRetryFillsDefaultRetryOptions(): void
+    {
+        $dto = ChildWorkflowOptions::new()
+            ->withRetryOptions(RetryOptions::new())
+            ->mergeWith(new MethodRetry(maximumAttempts: 5));
+
+        $this->assertSame(5, $dto->retryOptions->maximumAttempts);
+    }
+
+    public function testMergeWithMethodRetryCreatesRetryOptionsWhenNull(): void
+    {
+        $dto = ChildWorkflowOptions::new()->mergeWith(new MethodRetry(maximumAttempts: 5));
+
+        $this->assertNotNull($dto->retryOptions);
+        $this->assertSame(5, $dto->retryOptions->maximumAttempts);
+    }
+
+    public function testMergeWithMethodRetryKeepsUserDefinedFields(): void
+    {
+        $methodRetry = new MethodRetry(maximumAttempts: 5, maximumInterval: 30);
+        $dto = ChildWorkflowOptions::new()
+            ->withRetryOptions(RetryOptions::new()->withMaximumAttempts(1))
+            ->mergeWith($methodRetry);
+
+        $this->assertSame(1, $dto->retryOptions->maximumAttempts);
+        $this->assertSame($methodRetry->maximumInterval, $dto->retryOptions->maximumInterval);
     }
 }

--- a/tests/Unit/DTO/LocalActivityOptionsTestCase.php
+++ b/tests/Unit/DTO/LocalActivityOptionsTestCase.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\DTO;
+
+use Temporal\Activity\LocalActivityOptions;
+use Temporal\Common\MethodRetry;
+use Temporal\Common\RetryOptions;
+
+class LocalActivityOptionsTestCase extends AbstractDTOMarshalling
+{
+    public function testMergeWithMethodRetryFillsDefaultRetryOptions(): void
+    {
+        $dto = LocalActivityOptions::new()
+            ->withRetryOptions(RetryOptions::new())
+            ->mergeWith(new MethodRetry(maximumAttempts: 5));
+
+        $this->assertSame(5, $dto->retryOptions->maximumAttempts);
+    }
+
+    public function testMergeWithMethodRetryCreatesRetryOptionsWhenNull(): void
+    {
+        $dto = LocalActivityOptions::new()->mergeWith(new MethodRetry(maximumAttempts: 5));
+
+        $this->assertNotNull($dto->retryOptions);
+        $this->assertSame(5, $dto->retryOptions->maximumAttempts);
+    }
+
+    public function testMergeWithMethodRetryKeepsUserDefinedFields(): void
+    {
+        $methodRetry = new MethodRetry(maximumAttempts: 5, maximumInterval: 30);
+        $dto = LocalActivityOptions::new()
+            ->withRetryOptions(RetryOptions::new()->withMaximumAttempts(1))
+            ->mergeWith($methodRetry);
+
+        $this->assertSame(1, $dto->retryOptions->maximumAttempts);
+        $this->assertSame($methodRetry->maximumInterval, $dto->retryOptions->maximumInterval);
+    }
+
+    public function testMergeWithNullRetryDoesNotChangeRetryOptions(): void
+    {
+        $retry = RetryOptions::new()->withMaximumAttempts(7);
+        $dto = LocalActivityOptions::new()->withRetryOptions($retry)->mergeWith(null);
+
+        $this->assertSame(7, $dto->retryOptions->maximumAttempts);
+    }
+}

--- a/tests/Unit/DTO/WorkflowOptionsTestCase.php
+++ b/tests/Unit/DTO/WorkflowOptionsTestCase.php
@@ -15,6 +15,7 @@ use Carbon\CarbonInterval;
 use Temporal\Api\Common\V1\SearchAttributes;
 use Temporal\Client\WorkflowOptions;
 use Temporal\Common\IdReusePolicy;
+use Temporal\Common\MethodRetry;
 use Temporal\Common\RetryOptions;
 use Temporal\Common\TypedSearchAttributes;
 use Temporal\Common\Uuid;
@@ -241,5 +242,33 @@ class WorkflowOptionsTestCase extends AbstractDTOMarshalling
 
         $this->assertInstanceOf(SearchAttributes::class, $result);
         $this->assertCount(1, $result->getIndexedFields());
+    }
+
+    public function testMergeWithMethodRetryFillsDefaultRetryOptions(): void
+    {
+        $dto = WorkflowOptions::new()
+            ->withRetryOptions(RetryOptions::new())
+            ->mergeWith(new MethodRetry(maximumAttempts: 5));
+
+        $this->assertSame(5, $dto->retryOptions->maximumAttempts);
+    }
+
+    public function testMergeWithMethodRetryCreatesRetryOptionsWhenNull(): void
+    {
+        $dto = WorkflowOptions::new()->mergeWith(new MethodRetry(maximumAttempts: 5));
+
+        $this->assertNotNull($dto->retryOptions);
+        $this->assertSame(5, $dto->retryOptions->maximumAttempts);
+    }
+
+    public function testMergeWithMethodRetryKeepsUserDefinedFields(): void
+    {
+        $methodRetry = new MethodRetry(maximumAttempts: 5, maximumInterval: 30);
+        $dto = WorkflowOptions::new()
+            ->withRetryOptions(RetryOptions::new()->withMaximumAttempts(1))
+            ->mergeWith($methodRetry);
+
+        $this->assertSame(1, $dto->retryOptions->maximumAttempts);
+        $this->assertSame($methodRetry->maximumInterval, $dto->retryOptions->maximumInterval);
     }
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Fixed `mergeWith()` on `ActivityOptions`, `LocalActivityOptions`, `ChildWorkflowOptions` and `WorkflowOptions` so a method-level `#[MethodRetry]` attribute is actually merged into the stub's retry options.

The guard was inverted (`$this->diff->isPresent(...)` is true only when `retryOptions` is still at its default `null`):
- when `RetryOptions` were set — the merge was skipped and `#[MethodRetry]` was ignored;
- when they were not set — `null?->mergeWith()` collapsed to `null` and the attribute was lost (a fatal `Call to a member function mergeWith() on null` on `WorkflowOptions`, which had no null-safe call).

Now the merge always runs when a `MethodRetry` is present, delegating field-level precedence to `RetryOptions::mergeWith()` (user-set fields win, defaults are filled from the attribute) and falling back to a fresh `RetryOptions` when none is set.

## Why?
<!-- Tell your future self why have you made these changes -->

Restores the documented `MethodRetry` behaviour — "if `RetryOptions` are present on `ActivityOptions`/`ChildWorkflowOptions` the fields that are not default take precedence over parameters of this attribute" — and matches sdk-go/sdk-java/sdk-typescript. Fixes #777.

## Checklist
<!--- add/delete as needed --->

1. Closes #777

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Added unit tests for `mergeWith()` covering all four option classes (`tests/Unit/DTO/*OptionsTestCase.php`): default `RetryOptions` filled from the attribute, `RetryOptions` created when unset, user-set fields kept while unset ones are filled, and `mergeWith(null)` is a no-op. Written first as failing tests, then fixed. Full `Unit` suite green (1163 tests).

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

No.