### PR TITLE
feat: make eager activity reservation limit configurable

### DIFF
--- a/src/Worker/WorkerOptions.php
+++ b/src/Worker/WorkerOptions.php
@@ -279,6 +279,21 @@ class WorkerOptions
     public int $maxConcurrentEagerActivityExecutionSize = 0;
 
     /**
+     * Optional: Maximum number of activity slots that may be reserved for eager
+     * execution when completing a single workflow task.
+     *
+     * The default of null uses the underlying SDK default of 3. A configured
+     * value must be positive; to disable eager activity execution use
+     * {@see self::$disableEagerActivities} instead.
+     *
+     * @see self::$disableEagerActivities for a description of eager activity execution.
+     *
+     * @since RoadRunner 2025.1.16
+     */
+    #[Marshal(name: 'MaxEagerActivityReservationsPerWorkflowTask')]
+    public ?int $maxEagerActivityReservationsPerWorkflowTask = null;
+
+    /**
      * Optional: Disable allowing workflow and activity functions that are
      * registered with custom names from being able to be called with their
      * function references.
@@ -784,6 +799,33 @@ class WorkerOptions
 
         $self = clone $this;
         $self->maxConcurrentEagerActivityExecutionSize = $size;
+        return $self;
+    }
+
+    /**
+     * Optional: Maximum number of activity slots that may be reserved for eager
+     * execution when completing a single workflow task.
+     *
+     * The default of null uses the underlying SDK default of 3. A configured
+     * value must be positive; to disable eager activity execution use
+     * {@see self::withDisableEagerActivities()} instead.
+     *
+     * @see self::$disableEagerActivities for a description of eager activity execution.
+     *
+     * @since RoadRunner 2025.1.16
+     */
+    #[Pure]
+    public function withMaxEagerActivityReservationsPerWorkflowTask(int $value): self
+    {
+        if ($value <= 0) {
+            throw new \InvalidArgumentException(
+                'MaxEagerActivityReservationsPerWorkflowTask must be positive; '
+                . 'use withDisableEagerActivities() to disable eager activity execution.',
+            );
+        }
+
+        $self = clone $this;
+        $self->maxEagerActivityReservationsPerWorkflowTask = $value;
         return $self;
     }
 

--- a/tests/Unit/DTO/WorkerOptionsTestCase.php
+++ b/tests/Unit/DTO/WorkerOptionsTestCase.php
@@ -51,6 +51,7 @@ class WorkerOptionsTestCase extends AbstractDTOMarshalling
             'MaxHeartbeatThrottleInterval' => null,
             'DisableEagerActivities' => false,
             'MaxConcurrentEagerActivityExecutionSize' => 0,
+            'MaxEagerActivityReservationsPerWorkflowTask' => null,
             'DisableRegistrationAliasing' => false,
             'BuildID' => "",
             'DeploymentOptions' => null,
@@ -332,6 +333,28 @@ class WorkerOptionsTestCase extends AbstractDTOMarshalling
         self::assertNotSame($dto, $result);
         self::assertSame(0, $dto->maxConcurrentEagerActivityExecutionSize);
         self::assertSame(10, $result->maxConcurrentEagerActivityExecutionSize);
+    }
+
+    public function testMaxEagerActivityReservationsPerWorkflowTask(): void
+    {
+        $dto = new WorkerOptions();
+        $result = $dto->withMaxEagerActivityReservationsPerWorkflowTask(10);
+
+        self::assertNotSame($dto, $result);
+        self::assertNull($dto->maxEagerActivityReservationsPerWorkflowTask);
+        self::assertSame(10, $result->maxEagerActivityReservationsPerWorkflowTask);
+        self::assertSame(10, $this->marshal($result)['MaxEagerActivityReservationsPerWorkflowTask']);
+    }
+
+    public function testMaxEagerActivityReservationsPerWorkflowTaskRejectsNonPositive(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'MaxEagerActivityReservationsPerWorkflowTask must be positive; '
+            . 'use withDisableEagerActivities() to disable eager activity execution.',
+        );
+
+        (new WorkerOptions())->withMaxEagerActivityReservationsPerWorkflowTask(0);
     }
 
     public function testDisableRegistrationAliasing(): void


### PR DESCRIPTION
<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Added `WorkerOptions::$maxEagerActivityReservationsPerWorkflowTask` (marshalled `MaxEagerActivityReservationsPerWorkflowTask`), nullable → SDK default of 3.

## Why?
<!-- Tell your future self why have you made these changes -->

Port of temporalio/sdk-go#2493 — the hardcoded per-workflow-task eager-activity limit of 3 is now configurable.

## Checklist
<!--- add/delete as needed --->

1. Relates to temporalio/sdk-go#2493. Needs roadrunner-temporal on sdk-go >= v1.47.0 (RR 2025.1.16), else no-op.

2. How was this tested:

`WorkerOptionsTestCase` — marshalling, builder, non-positive guard. Unit green.

3. Any docs updates needed?

No.