### PR TITLE
Drop old package versions that predate PHP 8.1 requirement

### DIFF
--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -100,8 +100,22 @@ jobs:
         run: vendor/bin/validate-prefer-lowest
         continue-on-error: true
 
-      - name: Download binaries
+      - name: Cache runtime binaries
+        id: cache-binaries
         if: inputs.download-binaries == true
+        uses: actions/cache@v4
+        with:
+          path: |
+            ./rr
+            ./rr.exe
+            ./temporal
+            ./temporal.exe
+            ./temporal-test-server
+            ./temporal-test-server.exe
+          key: ${{ runner.os }}-binaries-${{ hashFiles('dload.xml') }}
+
+      - name: Download binaries
+        if: inputs.download-binaries == true && steps.cache-binaries.outputs.cache-hit != 'true'
         run: composer get:binaries
 
       - name: Run tests

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "grpc/grpc": "^1.57",
         "internal/destroy": "^1.0",
         "internal/promise": "^3.4",
-        "nesbot/carbon": "^2.72.6 || ^3.8.4",
+        "nesbot/carbon": "^3.8.4",
         "psr/log": "^2.0 || ^3.0.2",
         "ramsey/uuid": "^4.7.6",
         "roadrunner-php/roadrunner-api-dto": "^1.14.0",
@@ -39,10 +39,10 @@
         "spiral/roadrunner-cli": "^2.6",
         "spiral/roadrunner-kv": "^4.3.1",
         "spiral/roadrunner-worker": "^3.6.2",
-        "symfony/filesystem": "^5.4.45 || ^6.4.13 || ^7.0 || ^8.0",
-        "symfony/http-client": "^5.4.53 || ^6.4.17 || ^7.0 || ^8.0",
+        "symfony/filesystem": "^6.4.13 || ^7.0 || ^8.0",
+        "symfony/http-client": "^6.4.17 || ^7.0 || ^8.0",
         "symfony/polyfill-php83": "^1.31.0",
-        "symfony/process": "^5.4.51 || ^6.4.15 || ^7.0 || ^8.0"
+        "symfony/process": "^6.4.15 || ^7.0 || ^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -39,10 +39,10 @@
         "spiral/roadrunner-cli": "^2.6",
         "spiral/roadrunner-kv": "^4.3.1",
         "spiral/roadrunner-worker": "^3.6.2",
-        "symfony/filesystem": "^6.4.13 || ^7.0 || ^8.0",
+        "symfony/filesystem": "^6.4.24 || ^7.0 || ^8.0",
         "symfony/http-client": "^6.4.17 || ^7.0 || ^8.0",
         "symfony/polyfill-php83": "^1.31.0",
-        "symfony/process": "^6.4.15 || ^7.0 || ^8.0"
+        "symfony/process": "^6.4.33 || ^7.0 || ^8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## What was changed

Removed version ranges for packages that only exist to support PHP 7.x/8.0, which the SDK no longer requires (`"php": ">=8.1"`):

- `nesbot/carbon`: drop `^2.72.6` (PHP 7.4+), keep `^3.8.4` (PHP 8.1+)
- `symfony/filesystem`: drop `^5.4.45` (PHP 7.2.5+), keep `^6.4.13+`
- `symfony/http-client`: drop `^5.4.53` (PHP 7.2.5+), keep `^6.4.17+`
- `symfony/process`: drop `^5.4.51` (PHP 7.2.5+), keep `^6.4.15+`

`internal/promise: ^2.12` was already dropped in a previous change.

## Why?

Carrying version ranges for packages that support end-of-life PHP versions adds unnecessary complexity to dependency resolution and may pull in older, less maintained versions. Since the SDK requires PHP 8.1+, these ranges serve no purpose.

Closes #698