### PR TITLE
Drop PHP 8.1 support

### DIFF
--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -99,8 +99,22 @@ jobs:
         run: vendor/bin/validate-prefer-lowest
         continue-on-error: true
 
-      - name: Download binaries
+      - name: Cache runtime binaries
+        id: cache-binaries
         if: inputs.download-binaries == true
+        uses: actions/cache@v4
+        with:
+          path: |
+            ./rr
+            ./rr.exe
+            ./temporal
+            ./temporal.exe
+            ./temporal-test-server
+            ./temporal-test-server.exe
+          key: ${{ runner.os }}-binaries-${{ hashFiles('dload.xml') }}
+
+      - name: Download binaries
+        if: inputs.download-binaries == true && steps.cache-binaries.outputs.cache-hit != 'true'
         run: composer get:binaries
 
       - name: Run tests

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -55,7 +55,6 @@ jobs:
       fail-fast: ${{ inputs.fail-fast }}
       matrix:
         php:
-          - 8.1
           - 8.2
           - 8.3
           - 8.4
@@ -67,7 +66,7 @@ jobs:
           # Add Windows
           - os: windows-latest
             extensions-suffix: ', protobuf'
-            php: 8.1
+            php: 8.2
             dependencies: highest
     steps:
       - name: Set Git To Use LF
@@ -94,7 +93,7 @@ jobs:
 
       - name: Validate lowest dependencies
         id: validate
-        if: matrix.dependencies == 'lowest' && matrix.php == '8.1'
+        if: matrix.dependencies == 'lowest' && matrix.php == '8.2'
         env:
           COMPOSER_POOL_OPTIMIZER: 0
         run: vendor/bin/validate-prefer-lowest

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "source": "https://github.com/temporalio/sdk-php"
     },
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.2",
         "ext-curl": "*",
         "ext-json": "*",
         "google/common-protos": "^4.9",


### PR DESCRIPTION
## Summary
- Bumps minimum PHP version from 8.1 to 8.2 in `composer.json` (closes #790)
- Removes PHP 8.1 from CI test matrix
- Updates Windows CI entry from PHP 8.1 to 8.2
- Updates lowest-deps validation to run on PHP 8.2 instead of 8.1
- Keeps `symfony/polyfill-php83` since `#[\Override]` attribute (PHP 8.3) is used in 28 places

PHP 8.1 [reached end of life on 2024-12-31](https://www.php.net/supported-versions.php).

## Test plan
- [ ] CI passes on PHP 8.2, 8.3, 8.4, 8.5
- [ ] Windows CI passes on PHP 8.2
- [ ] Lowest-deps validation runs on PHP 8.2