### PR TITLE
Bump Temporal API to 1.62.8

### DIFF
--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -99,8 +99,22 @@ jobs:
         run: vendor/bin/validate-prefer-lowest
         continue-on-error: true
 
-      - name: Download binaries
+      - name: Cache runtime binaries
+        id: cache-binaries
         if: inputs.download-binaries == true
+        uses: actions/cache@v4
+        with:
+          path: |
+            ./rr
+            ./rr.exe
+            ./temporal
+            ./temporal.exe
+            ./temporal-test-server
+            ./temporal-test-server.exe
+          key: ${{ runner.os }}-binaries-${{ hashFiles('dload.xml') }}
+
+      - name: Download binaries
+        if: inputs.download-binaries == true && steps.cache-binaries.outputs.cache-hit != 'true'
         run: composer get:binaries
 
       - name: Run tests

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -55,7 +55,6 @@ jobs:
       fail-fast: ${{ inputs.fail-fast }}
       matrix:
         php:
-          - 8.1
           - 8.2
           - 8.3
           - 8.4
@@ -67,7 +66,7 @@ jobs:
           # Add Windows
           - os: windows-latest
             extensions-suffix: ', protobuf'
-            php: 8.1
+            php: 8.2
             dependencies: highest
     steps:
       - name: Set Git To Use LF
@@ -94,7 +93,7 @@ jobs:
 
       - name: Validate lowest dependencies
         id: validate
-        if: matrix.dependencies == 'lowest' && matrix.php == '8.1'
+        if: matrix.dependencies == 'lowest' && matrix.php == '8.2'
         env:
           COMPOSER_POOL_OPTIMIZER: 0
         run: vendor/bin/validate-prefer-lowest

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "source": "https://github.com/temporalio/sdk-php"
     },
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.2",
         "ext-curl": "*",
         "ext-json": "*",
         "google/common-protos": "^4.9",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "nesbot/carbon": "^2.72.6 || ^3.8.4",
         "psr/log": "^2.0 || ^3.0.2",
         "ramsey/uuid": "^4.7.6",
-        "roadrunner-php/roadrunner-api-dto": "^1.14.0",
+        "roadrunner-php/roadrunner-api-dto": "^1.15.0",
         "roadrunner-php/version-checker": "^1.0.2",
         "spiral/attributes": "^3.1.8",
         "spiral/roadrunner": "^2025.1.5",


### PR DESCRIPTION
## Summary
- Bumps \`roadrunner-php/roadrunner-api-dto\` from \`^1.14.0\` to \`^1.15.0\` (closes #741)
- This requires [roadrunner-php/roadrunner-api-dto#22](https://github.com/roadrunner-php/roadrunner-api-dto/pull/22) to be merged and released first, which updates the API submodule from v4.23.0 to v4.24.0 (Temporal API 1.62.8)

## New API methods available after DTO update
- `CountSchedules` — count schedules with filters
- `PauseWorkflowExecution` / `UnpauseWorkflowExecution` — workflow pause support
- Standalone Activity Execution APIs: `StartActivityExecution`, `DescribeActivityExecution`, `PollActivityExecution`, `ListActivityExecutions`, `CountActivityExecutions`, `RequestCancelActivityExecution`, `TerminateActivityExecution`, `DeleteActivityExecution`
- Worker Deployment APIs: `CreateWorkerDeployment`, `CreateWorkerDeploymentVersion`, `UpdateWorkerDeploymentVersionComputeConfig`, `ValidateWorkerDeploymentVersionComputeConfig`

## Next steps after DTO release
Run \`make generate-client\` to regenerate \`ServiceClient.php\` and \`ServiceClientInterface.php\` with the new gRPC methods.

## Test plan
- [ ] Depends on [roadrunner-php/roadrunner-api-dto#22](https://github.com/roadrunner-php/roadrunner-api-dto/pull/22) being merged and released as v1.15.0
- [ ] After DTO release: \`composer update\` resolves, \`make generate-client\` succeeds, CI passes