### PR TITLE
feat: add Cloud Operations API client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "nesbot/carbon": "^2.72.6 || ^3.8.4",
         "psr/log": "^2.0 || ^3.0.2",
         "ramsey/uuid": "^4.7.6",
-        "roadrunner-php/roadrunner-api-dto": "^1.14.0",
+        "roadrunner-php/roadrunner-api-dto": "^1.15.0",
         "roadrunner-php/version-checker": "^1.0.2",
         "spiral/attributes": "^3.1.8",
         "spiral/roadrunner": "^2025.1.5",

--- a/resources/scripts/generate-client.php
+++ b/resources/scripts/generate-client.php
@@ -184,38 +184,64 @@ PHP);
 
 $versionParam = Generator\ParameterGenerator::fromArray(['type' => 'string', 'name' => 'version']);
 
-$buildWithApiVersionInterfaceMethod = static function () use ($versionParam): MethodGenerator {
+$apiVersionDocBlock = <<<'TEXT'
+    Pin the Cloud Operations API version.
+
+    Sets the `temporal-cloud-api-version` header on every call made by the returned client.
+    A version already present on the call context is not overridden.
+
+    @link https://docs.temporal.io/ops
+    TEXT;
+
+$buildApiVersionProperty = static function (): Generator\PropertyGenerator {
+    $property = new Generator\PropertyGenerator('apiVersion', '', Generator\PropertyGenerator::FLAG_PRIVATE);
+    $property->setType(Generator\TypeGenerator::fromTypeString('string'));
+
+    return $property;
+};
+
+$buildWithApiVersionInterfaceMethod = static function () use ($versionParam, $apiVersionDocBlock): MethodGenerator {
     $method = new MethodGenerator('withApiVersion', [$versionParam]);
     $method->setReturnType('static');
-    $method->setDocBlock(<<<'TEXT'
-        Pin the Cloud Operations API version.
-
-        Sets the `temporal-cloud-api-version` header for every call made by the returned client.
-
-        @link https://docs.temporal.io/ops
-        TEXT);
+    $method->setDocBlock($apiVersionDocBlock);
 
     return $method;
 };
 
-$buildWithApiVersionImplementationMethod = static function () use ($versionParam): MethodGenerator {
+$buildWithApiVersionImplementationMethod = static function () use ($versionParam, $apiVersionDocBlock): MethodGenerator {
     $method = new MethodGenerator('withApiVersion', [$versionParam]);
     $method->setReturnType('static');
-    $method->setDocBlock(<<<'TEXT'
-        Pin the Cloud Operations API version.
-
-        Sets the `temporal-cloud-api-version` header for every call made by the returned client.
-
-        @link https://docs.temporal.io/ops
-        TEXT);
+    $method->setDocBlock($apiVersionDocBlock);
     $method->setBody(<<<'PHP'
-        $context = $this->getContext();
+        $clone = clone $this;
+        $clone->apiVersion = $version;
 
-        return $this->withContext(
-            $context->withMetadata(
-                $context->getMetadata() + ['temporal-cloud-api-version' => [$version]],
-            ),
-        );
+        return $clone;
+        PHP);
+
+    return $method;
+};
+
+$buildCloudInvokeMethod = static function () use ($ctxParam): MethodGenerator {
+    $method = new MethodGenerator(
+        'invoke',
+        [
+            Generator\ParameterGenerator::fromArray(['type' => 'string', 'name' => 'method']),
+            Generator\ParameterGenerator::fromArray(['type' => 'object', 'name' => 'arg']),
+            $ctxParam,
+        ],
+        MethodGenerator::FLAG_PROTECTED,
+    );
+    $method->setReturnType('mixed');
+    $method->setBody(<<<'PHP'
+        if ($this->apiVersion !== '') {
+            $ctx ??= $this->getContext();
+            $ctx = $ctx->withMetadata(
+                $ctx->getMetadata() + ['temporal-cloud-api-version' => [$this->apiVersion]],
+            );
+        }
+
+        return parent::invoke($method, $arg, $ctx);
         PHP);
 
     return $method;
@@ -274,9 +300,11 @@ $clients = [
             'interface' => [],
             'implementation' => [],
         ],
+        'extraProperties' => static fn(): array => [$buildApiVersionProperty()],
         'extraInterfaceMethods' => static fn(): array => [$buildWithApiVersionInterfaceMethod()],
         'extraImplementationMethods' => static fn(): array => [
             $buildWithApiVersionImplementationMethod(),
+            $buildCloudInvokeMethod(),
             $buildCreateServiceClientMethod(CloudServiceClient::class),
         ],
     ],
@@ -338,6 +366,10 @@ foreach ($clients as $client) {
     $implementation = new Generator\ClassGenerator($client['implementationName']);
     $implementation->setExtendedClass('BaseClient');
     $implementation->setImplementedInterfaces([$client['interfaceName']]);
+
+    foreach (($client['extraProperties'] ?? static fn(): array => [])() as $property) {
+        $implementation->addPropertyFromGenerator($property);
+    }
 
     foreach ($methods as $name => $options) {
         $method = new MethodGenerator($name);

--- a/resources/scripts/generate-client.php
+++ b/resources/scripts/generate-client.php
@@ -10,6 +10,7 @@
 use Grpc\BaseStub;
 use Laminas\Code\Generator;
 use Laminas\Code\Generator\MethodGenerator;
+use Temporal\Api\Cloud\Cloudservice\V1\CloudServiceClient;
 use Temporal\Api\Operatorservice\V1\OperatorServiceClient;
 use Temporal\Api\Workflowservice\V1\WorkflowServiceClient;
 use Temporal\Client\GRPC\GrpcClientInterface;
@@ -181,6 +182,45 @@ PHP);
     return $method;
 };
 
+$versionParam = Generator\ParameterGenerator::fromArray(['type' => 'string', 'name' => 'version']);
+
+$buildWithApiVersionInterfaceMethod = static function () use ($versionParam): MethodGenerator {
+    $method = new MethodGenerator('withApiVersion', [$versionParam]);
+    $method->setReturnType('static');
+    $method->setDocBlock(<<<'TEXT'
+        Pin the Cloud Operations API version.
+
+        Sets the `temporal-cloud-api-version` header for every call made by the returned client.
+
+        @link https://docs.temporal.io/ops
+        TEXT);
+
+    return $method;
+};
+
+$buildWithApiVersionImplementationMethod = static function () use ($versionParam): MethodGenerator {
+    $method = new MethodGenerator('withApiVersion', [$versionParam]);
+    $method->setReturnType('static');
+    $method->setDocBlock(<<<'TEXT'
+        Pin the Cloud Operations API version.
+
+        Sets the `temporal-cloud-api-version` header for every call made by the returned client.
+
+        @link https://docs.temporal.io/ops
+        TEXT);
+    $method->setBody(<<<'PHP'
+        $context = $this->getContext();
+
+        return $this->withContext(
+            $context->withMetadata(
+                $context->getMetadata() + ['temporal-cloud-api-version' => [$version]],
+            ),
+        );
+        PHP);
+
+    return $method;
+};
+
 $clients = [
     [
         'label' => 'workflow',
@@ -220,6 +260,24 @@ $clients = [
         'extraInterfaceMethods' => static fn(): array => [],
         'extraImplementationMethods' => static fn(): array => [
             $buildCreateServiceClientMethod(OperatorServiceClient::class),
+        ],
+    ],
+    [
+        'label' => 'cloud',
+        'serviceClass' => CloudServiceClient::class,
+        'apiNamespace' => 'Temporal\\Api\\Cloud\\Cloudservice\\V1',
+        'interfaceName' => 'CloudClientInterface',
+        'implementationName' => 'CloudClient',
+        'interfaceFile' => __DIR__ . '/../../src/Client/GRPC/CloudClientInterface.php',
+        'implementationFile' => __DIR__ . '/../../src/Client/GRPC/CloudClient.php',
+        'extraUses' => [
+            'interface' => [],
+            'implementation' => [],
+        ],
+        'extraInterfaceMethods' => static fn(): array => [$buildWithApiVersionInterfaceMethod()],
+        'extraImplementationMethods' => static fn(): array => [
+            $buildWithApiVersionImplementationMethod(),
+            $buildCreateServiceClientMethod(CloudServiceClient::class),
         ],
     ],
 ];

--- a/src/Client/GRPC/CloudClient.php
+++ b/src/Client/GRPC/CloudClient.php
@@ -9,6 +9,8 @@ use Temporal\Exception\Client\ServiceClientException;
 
 class CloudClient extends BaseClient implements CloudClientInterface
 {
+    private string $apiVersion = '';
+
     /**
      * Get information about the current authenticated user or service account
      * principal
@@ -894,24 +896,34 @@ class CloudClient extends BaseClient implements CloudClientInterface
     /**
      * Pin the Cloud Operations API version.
      *
-     * Sets the `temporal-cloud-api-version` header for every call made by the returned
+     * Sets the `temporal-cloud-api-version` header on every call made by the returned
      * client.
+     * A version already present on the call context is not overridden.
      *
      * @link https://docs.temporal.io/ops
      */
     public function withApiVersion(string $version): static
     {
-        $context = $this->getContext();
+        $clone = clone $this;
+        $clone->apiVersion = $version;
 
-        return $this->withContext(
-            $context->withMetadata(
-                $context->getMetadata() + ['temporal-cloud-api-version' => [$version]],
-            ),
-        );
+        return $clone;
     }
 
     protected static function createGrpcStub(string $address, array $options): \Grpc\BaseStub
     {
         return new V1\CloudServiceClient($address, $options);
+    }
+
+    protected function invoke(string $method, object $arg, ?ContextInterface $ctx = null): mixed
+    {
+        if ($this->apiVersion !== '') {
+            $ctx ??= $this->getContext();
+            $ctx = $ctx->withMetadata(
+                $ctx->getMetadata() + ['temporal-cloud-api-version' => [$this->apiVersion]],
+            );
+        }
+
+        return parent::invoke($method, $arg, $ctx);
     }
 }

--- a/src/Client/GRPC/CloudClient.php
+++ b/src/Client/GRPC/CloudClient.php
@@ -1,0 +1,917 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Client\GRPC;
+
+use Temporal\Api\Cloud\Cloudservice\V1;
+use Temporal\Exception\Client\ServiceClientException;
+
+class CloudClient extends BaseClient implements CloudClientInterface
+{
+    /**
+     * Get information about the current authenticated user or service account
+     * principal
+     *
+     * @throws ServiceClientException
+     */
+    public function GetCurrentIdentity(V1\GetCurrentIdentityRequest $arg, ?ContextInterface $ctx = null): V1\GetCurrentIdentityResponse
+    {
+        return $this->invoke("GetCurrentIdentity", $arg, $ctx);
+    }
+
+    /**
+     * Gets all known users
+     *
+     * @throws ServiceClientException
+     */
+    public function GetUsers(V1\GetUsersRequest $arg, ?ContextInterface $ctx = null): V1\GetUsersResponse
+    {
+        return $this->invoke("GetUsers", $arg, $ctx);
+    }
+
+    /**
+     * Get a user
+     *
+     * @throws ServiceClientException
+     */
+    public function GetUser(V1\GetUserRequest $arg, ?ContextInterface $ctx = null): V1\GetUserResponse
+    {
+        return $this->invoke("GetUser", $arg, $ctx);
+    }
+
+    /**
+     * Create a user
+     *
+     * @throws ServiceClientException
+     */
+    public function CreateUser(V1\CreateUserRequest $arg, ?ContextInterface $ctx = null): V1\CreateUserResponse
+    {
+        return $this->invoke("CreateUser", $arg, $ctx);
+    }
+
+    /**
+     * Update a user
+     *
+     * @throws ServiceClientException
+     */
+    public function UpdateUser(V1\UpdateUserRequest $arg, ?ContextInterface $ctx = null): V1\UpdateUserResponse
+    {
+        return $this->invoke("UpdateUser", $arg, $ctx);
+    }
+
+    /**
+     * Delete a user
+     *
+     * @throws ServiceClientException
+     */
+    public function DeleteUser(V1\DeleteUserRequest $arg, ?ContextInterface $ctx = null): V1\DeleteUserResponse
+    {
+        return $this->invoke("DeleteUser", $arg, $ctx);
+    }
+
+    /**
+     * Set a user's access to a namespace
+     *
+     * @throws ServiceClientException
+     */
+    public function SetUserNamespaceAccess(V1\SetUserNamespaceAccessRequest $arg, ?ContextInterface $ctx = null): V1\SetUserNamespaceAccessResponse
+    {
+        return $this->invoke("SetUserNamespaceAccess", $arg, $ctx);
+    }
+
+    /**
+     * Get the latest information on an async operation
+     *
+     * @throws ServiceClientException
+     */
+    public function GetAsyncOperation(V1\GetAsyncOperationRequest $arg, ?ContextInterface $ctx = null): V1\GetAsyncOperationResponse
+    {
+        return $this->invoke("GetAsyncOperation", $arg, $ctx);
+    }
+
+    /**
+     * Create a new namespace
+     *
+     * @throws ServiceClientException
+     */
+    public function CreateNamespace(V1\CreateNamespaceRequest $arg, ?ContextInterface $ctx = null): V1\CreateNamespaceResponse
+    {
+        return $this->invoke("CreateNamespace", $arg, $ctx);
+    }
+
+    /**
+     * Get all namespaces
+     *
+     * @throws ServiceClientException
+     */
+    public function GetNamespaces(V1\GetNamespacesRequest $arg, ?ContextInterface $ctx = null): V1\GetNamespacesResponse
+    {
+        return $this->invoke("GetNamespaces", $arg, $ctx);
+    }
+
+    /**
+     * Get a namespace
+     *
+     * @throws ServiceClientException
+     */
+    public function GetNamespace(V1\GetNamespaceRequest $arg, ?ContextInterface $ctx = null): V1\GetNamespaceResponse
+    {
+        return $this->invoke("GetNamespace", $arg, $ctx);
+    }
+
+    /**
+     * Update a namespace
+     *
+     * @throws ServiceClientException
+     */
+    public function UpdateNamespace(V1\UpdateNamespaceRequest $arg, ?ContextInterface $ctx = null): V1\UpdateNamespaceResponse
+    {
+        return $this->invoke("UpdateNamespace", $arg, $ctx);
+    }
+
+    /**
+     * Rename an existing customer search attribute
+     *
+     * @throws ServiceClientException
+     */
+    public function RenameCustomSearchAttribute(V1\RenameCustomSearchAttributeRequest $arg, ?ContextInterface $ctx = null): V1\RenameCustomSearchAttributeResponse
+    {
+        return $this->invoke("RenameCustomSearchAttribute", $arg, $ctx);
+    }
+
+    /**
+     * Delete a namespace
+     *
+     * @throws ServiceClientException
+     */
+    public function DeleteNamespace(V1\DeleteNamespaceRequest $arg, ?ContextInterface $ctx = null): V1\DeleteNamespaceResponse
+    {
+        return $this->invoke("DeleteNamespace", $arg, $ctx);
+    }
+
+    /**
+     * Failover a multi-region namespace
+     *
+     * @throws ServiceClientException
+     */
+    public function FailoverNamespaceRegion(V1\FailoverNamespaceRegionRequest $arg, ?ContextInterface $ctx = null): V1\FailoverNamespaceRegionResponse
+    {
+        return $this->invoke("FailoverNamespaceRegion", $arg, $ctx);
+    }
+
+    /**
+     * @throws ServiceClientException
+     */
+    public function AddNamespaceRegion(V1\AddNamespaceRegionRequest $arg, ?ContextInterface $ctx = null): V1\AddNamespaceRegionResponse
+    {
+        return $this->invoke("AddNamespaceRegion", $arg, $ctx);
+    }
+
+    /**
+     * @throws ServiceClientException
+     */
+    public function DeleteNamespaceRegion(V1\DeleteNamespaceRegionRequest $arg, ?ContextInterface $ctx = null): V1\DeleteNamespaceRegionResponse
+    {
+        return $this->invoke("DeleteNamespaceRegion", $arg, $ctx);
+    }
+
+    /**
+     * Get all regions
+     *
+     * @throws ServiceClientException
+     */
+    public function GetRegions(V1\GetRegionsRequest $arg, ?ContextInterface $ctx = null): V1\GetRegionsResponse
+    {
+        return $this->invoke("GetRegions", $arg, $ctx);
+    }
+
+    /**
+     * Get a region
+     *
+     * @throws ServiceClientException
+     */
+    public function GetRegion(V1\GetRegionRequest $arg, ?ContextInterface $ctx = null): V1\GetRegionResponse
+    {
+        return $this->invoke("GetRegion", $arg, $ctx);
+    }
+
+    /**
+     * Get all known API keys
+     *
+     * @throws ServiceClientException
+     */
+    public function GetApiKeys(V1\GetApiKeysRequest $arg, ?ContextInterface $ctx = null): V1\GetApiKeysResponse
+    {
+        return $this->invoke("GetApiKeys", $arg, $ctx);
+    }
+
+    /**
+     * Get an API key
+     *
+     * @throws ServiceClientException
+     */
+    public function GetApiKey(V1\GetApiKeyRequest $arg, ?ContextInterface $ctx = null): V1\GetApiKeyResponse
+    {
+        return $this->invoke("GetApiKey", $arg, $ctx);
+    }
+
+    /**
+     * Create an API key
+     *
+     * @throws ServiceClientException
+     */
+    public function CreateApiKey(V1\CreateApiKeyRequest $arg, ?ContextInterface $ctx = null): V1\CreateApiKeyResponse
+    {
+        return $this->invoke("CreateApiKey", $arg, $ctx);
+    }
+
+    /**
+     * Update an API key
+     *
+     * @throws ServiceClientException
+     */
+    public function UpdateApiKey(V1\UpdateApiKeyRequest $arg, ?ContextInterface $ctx = null): V1\UpdateApiKeyResponse
+    {
+        return $this->invoke("UpdateApiKey", $arg, $ctx);
+    }
+
+    /**
+     * Delete an API key
+     *
+     * @throws ServiceClientException
+     */
+    public function DeleteApiKey(V1\DeleteApiKeyRequest $arg, ?ContextInterface $ctx = null): V1\DeleteApiKeyResponse
+    {
+        return $this->invoke("DeleteApiKey", $arg, $ctx);
+    }
+
+    /**
+     * Gets nexus endpoints
+     *
+     * @throws ServiceClientException
+     */
+    public function GetNexusEndpoints(V1\GetNexusEndpointsRequest $arg, ?ContextInterface $ctx = null): V1\GetNexusEndpointsResponse
+    {
+        return $this->invoke("GetNexusEndpoints", $arg, $ctx);
+    }
+
+    /**
+     * Get a nexus endpoint
+     *
+     * @throws ServiceClientException
+     */
+    public function GetNexusEndpoint(V1\GetNexusEndpointRequest $arg, ?ContextInterface $ctx = null): V1\GetNexusEndpointResponse
+    {
+        return $this->invoke("GetNexusEndpoint", $arg, $ctx);
+    }
+
+    /**
+     * Create a nexus endpoint
+     *
+     * @throws ServiceClientException
+     */
+    public function CreateNexusEndpoint(V1\CreateNexusEndpointRequest $arg, ?ContextInterface $ctx = null): V1\CreateNexusEndpointResponse
+    {
+        return $this->invoke("CreateNexusEndpoint", $arg, $ctx);
+    }
+
+    /**
+     * Update a nexus endpoint
+     *
+     * @throws ServiceClientException
+     */
+    public function UpdateNexusEndpoint(V1\UpdateNexusEndpointRequest $arg, ?ContextInterface $ctx = null): V1\UpdateNexusEndpointResponse
+    {
+        return $this->invoke("UpdateNexusEndpoint", $arg, $ctx);
+    }
+
+    /**
+     * Delete a nexus endpoint
+     *
+     * @throws ServiceClientException
+     */
+    public function DeleteNexusEndpoint(V1\DeleteNexusEndpointRequest $arg, ?ContextInterface $ctx = null): V1\DeleteNexusEndpointResponse
+    {
+        return $this->invoke("DeleteNexusEndpoint", $arg, $ctx);
+    }
+
+    /**
+     * Get all user groups
+     *
+     * @throws ServiceClientException
+     */
+    public function GetUserGroups(V1\GetUserGroupsRequest $arg, ?ContextInterface $ctx = null): V1\GetUserGroupsResponse
+    {
+        return $this->invoke("GetUserGroups", $arg, $ctx);
+    }
+
+    /**
+     * Get a user group
+     *
+     * @throws ServiceClientException
+     */
+    public function GetUserGroup(V1\GetUserGroupRequest $arg, ?ContextInterface $ctx = null): V1\GetUserGroupResponse
+    {
+        return $this->invoke("GetUserGroup", $arg, $ctx);
+    }
+
+    /**
+     * Create new a user group
+     *
+     * @throws ServiceClientException
+     */
+    public function CreateUserGroup(V1\CreateUserGroupRequest $arg, ?ContextInterface $ctx = null): V1\CreateUserGroupResponse
+    {
+        return $this->invoke("CreateUserGroup", $arg, $ctx);
+    }
+
+    /**
+     * Update a user group
+     *
+     * @throws ServiceClientException
+     */
+    public function UpdateUserGroup(V1\UpdateUserGroupRequest $arg, ?ContextInterface $ctx = null): V1\UpdateUserGroupResponse
+    {
+        return $this->invoke("UpdateUserGroup", $arg, $ctx);
+    }
+
+    /**
+     * Delete a user group
+     *
+     * @throws ServiceClientException
+     */
+    public function DeleteUserGroup(V1\DeleteUserGroupRequest $arg, ?ContextInterface $ctx = null): V1\DeleteUserGroupResponse
+    {
+        return $this->invoke("DeleteUserGroup", $arg, $ctx);
+    }
+
+    /**
+     * Set a user group's access to a namespace
+     *
+     * @throws ServiceClientException
+     */
+    public function SetUserGroupNamespaceAccess(V1\SetUserGroupNamespaceAccessRequest $arg, ?ContextInterface $ctx = null): V1\SetUserGroupNamespaceAccessResponse
+    {
+        return $this->invoke("SetUserGroupNamespaceAccess", $arg, $ctx);
+    }
+
+    /**
+     * Add a member to the group, can only be used with Cloud group types.
+     *
+     * @throws ServiceClientException
+     */
+    public function AddUserGroupMember(V1\AddUserGroupMemberRequest $arg, ?ContextInterface $ctx = null): V1\AddUserGroupMemberResponse
+    {
+        return $this->invoke("AddUserGroupMember", $arg, $ctx);
+    }
+
+    /**
+     * Remove a member from the group, can only be used with Cloud group types.
+     *
+     * @throws ServiceClientException
+     */
+    public function RemoveUserGroupMember(V1\RemoveUserGroupMemberRequest $arg, ?ContextInterface $ctx = null): V1\RemoveUserGroupMemberResponse
+    {
+        return $this->invoke("RemoveUserGroupMember", $arg, $ctx);
+    }
+
+    /**
+     * @throws ServiceClientException
+     */
+    public function GetUserGroupMembers(V1\GetUserGroupMembersRequest $arg, ?ContextInterface $ctx = null): V1\GetUserGroupMembersResponse
+    {
+        return $this->invoke("GetUserGroupMembers", $arg, $ctx);
+    }
+
+    /**
+     * Create a service account.
+     *
+     * @throws ServiceClientException
+     */
+    public function CreateServiceAccount(V1\CreateServiceAccountRequest $arg, ?ContextInterface $ctx = null): V1\CreateServiceAccountResponse
+    {
+        return $this->invoke("CreateServiceAccount", $arg, $ctx);
+    }
+
+    /**
+     * Get a service account.
+     *
+     * @throws ServiceClientException
+     */
+    public function GetServiceAccount(V1\GetServiceAccountRequest $arg, ?ContextInterface $ctx = null): V1\GetServiceAccountResponse
+    {
+        return $this->invoke("GetServiceAccount", $arg, $ctx);
+    }
+
+    /**
+     * Get service accounts.
+     *
+     * @throws ServiceClientException
+     */
+    public function GetServiceAccounts(V1\GetServiceAccountsRequest $arg, ?ContextInterface $ctx = null): V1\GetServiceAccountsResponse
+    {
+        return $this->invoke("GetServiceAccounts", $arg, $ctx);
+    }
+
+    /**
+     * Update a service account.
+     *
+     * @throws ServiceClientException
+     */
+    public function UpdateServiceAccount(V1\UpdateServiceAccountRequest $arg, ?ContextInterface $ctx = null): V1\UpdateServiceAccountResponse
+    {
+        return $this->invoke("UpdateServiceAccount", $arg, $ctx);
+    }
+
+    /**
+     * Set a service account's access to a namespace.
+     *
+     * @throws ServiceClientException
+     */
+    public function SetServiceAccountNamespaceAccess(V1\SetServiceAccountNamespaceAccessRequest $arg, ?ContextInterface $ctx = null): V1\SetServiceAccountNamespaceAccessResponse
+    {
+        return $this->invoke("SetServiceAccountNamespaceAccess", $arg, $ctx);
+    }
+
+    /**
+     * Delete a service account.
+     *
+     * @throws ServiceClientException
+     */
+    public function DeleteServiceAccount(V1\DeleteServiceAccountRequest $arg, ?ContextInterface $ctx = null): V1\DeleteServiceAccountResponse
+    {
+        return $this->invoke("DeleteServiceAccount", $arg, $ctx);
+    }
+
+    /**
+     * WARNING: Pre-Release Feature
+     * Get usage data across namespaces
+     *
+     * @throws ServiceClientException
+     */
+    public function GetUsage(V1\GetUsageRequest $arg, ?ContextInterface $ctx = null): V1\GetUsageResponse
+    {
+        return $this->invoke("GetUsage", $arg, $ctx);
+    }
+
+    /**
+     * Get account information.
+     *
+     * @throws ServiceClientException
+     */
+    public function GetAccount(V1\GetAccountRequest $arg, ?ContextInterface $ctx = null): V1\GetAccountResponse
+    {
+        return $this->invoke("GetAccount", $arg, $ctx);
+    }
+
+    /**
+     * Update account information.
+     *
+     * @throws ServiceClientException
+     */
+    public function UpdateAccount(V1\UpdateAccountRequest $arg, ?ContextInterface $ctx = null): V1\UpdateAccountResponse
+    {
+        return $this->invoke("UpdateAccount", $arg, $ctx);
+    }
+
+    /**
+     * Create an export sink
+     *
+     * @throws ServiceClientException
+     */
+    public function CreateNamespaceExportSink(V1\CreateNamespaceExportSinkRequest $arg, ?ContextInterface $ctx = null): V1\CreateNamespaceExportSinkResponse
+    {
+        return $this->invoke("CreateNamespaceExportSink", $arg, $ctx);
+    }
+
+    /**
+     * Get an export sink
+     *
+     * @throws ServiceClientException
+     */
+    public function GetNamespaceExportSink(V1\GetNamespaceExportSinkRequest $arg, ?ContextInterface $ctx = null): V1\GetNamespaceExportSinkResponse
+    {
+        return $this->invoke("GetNamespaceExportSink", $arg, $ctx);
+    }
+
+    /**
+     * Get export sinks
+     *
+     * @throws ServiceClientException
+     */
+    public function GetNamespaceExportSinks(V1\GetNamespaceExportSinksRequest $arg, ?ContextInterface $ctx = null): V1\GetNamespaceExportSinksResponse
+    {
+        return $this->invoke("GetNamespaceExportSinks", $arg, $ctx);
+    }
+
+    /**
+     * Update an export sink
+     *
+     * @throws ServiceClientException
+     */
+    public function UpdateNamespaceExportSink(V1\UpdateNamespaceExportSinkRequest $arg, ?ContextInterface $ctx = null): V1\UpdateNamespaceExportSinkResponse
+    {
+        return $this->invoke("UpdateNamespaceExportSink", $arg, $ctx);
+    }
+
+    /**
+     * Delete an export sink
+     *
+     * @throws ServiceClientException
+     */
+    public function DeleteNamespaceExportSink(V1\DeleteNamespaceExportSinkRequest $arg, ?ContextInterface $ctx = null): V1\DeleteNamespaceExportSinkResponse
+    {
+        return $this->invoke("DeleteNamespaceExportSink", $arg, $ctx);
+    }
+
+    /**
+     * Validates an export sink configuration by delivering an empty test file to the
+     * specified sink.
+     * This operation verifies that the sink is correctly configured, accessible, and
+     * ready for data export.
+     *
+     * @throws ServiceClientException
+     */
+    public function ValidateNamespaceExportSink(V1\ValidateNamespaceExportSinkRequest $arg, ?ContextInterface $ctx = null): V1\ValidateNamespaceExportSinkResponse
+    {
+        return $this->invoke("ValidateNamespaceExportSink", $arg, $ctx);
+    }
+
+    /**
+     * Update the tags for a namespace
+     *
+     * @throws ServiceClientException
+     */
+    public function UpdateNamespaceTags(V1\UpdateNamespaceTagsRequest $arg, ?ContextInterface $ctx = null): V1\UpdateNamespaceTagsResponse
+    {
+        return $this->invoke("UpdateNamespaceTags", $arg, $ctx);
+    }
+
+    /**
+     * Creates a connectivity rule
+     *
+     * @throws ServiceClientException
+     */
+    public function CreateConnectivityRule(V1\CreateConnectivityRuleRequest $arg, ?ContextInterface $ctx = null): V1\CreateConnectivityRuleResponse
+    {
+        return $this->invoke("CreateConnectivityRule", $arg, $ctx);
+    }
+
+    /**
+     * Gets a connectivity rule by id
+     *
+     * @throws ServiceClientException
+     */
+    public function GetConnectivityRule(V1\GetConnectivityRuleRequest $arg, ?ContextInterface $ctx = null): V1\GetConnectivityRuleResponse
+    {
+        return $this->invoke("GetConnectivityRule", $arg, $ctx);
+    }
+
+    /**
+     * Lists connectivity rules by account
+     *
+     * @throws ServiceClientException
+     */
+    public function GetConnectivityRules(V1\GetConnectivityRulesRequest $arg, ?ContextInterface $ctx = null): V1\GetConnectivityRulesResponse
+    {
+        return $this->invoke("GetConnectivityRules", $arg, $ctx);
+    }
+
+    /**
+     * Deletes a connectivity rule by id
+     *
+     * @throws ServiceClientException
+     */
+    public function DeleteConnectivityRule(V1\DeleteConnectivityRuleRequest $arg, ?ContextInterface $ctx = null): V1\DeleteConnectivityRuleResponse
+    {
+        return $this->invoke("DeleteConnectivityRule", $arg, $ctx);
+    }
+
+    /**
+     * Get audit logs
+     *
+     * @throws ServiceClientException
+     */
+    public function GetAuditLogs(V1\GetAuditLogsRequest $arg, ?ContextInterface $ctx = null): V1\GetAuditLogsResponse
+    {
+        return $this->invoke("GetAuditLogs", $arg, $ctx);
+    }
+
+    /**
+     * Validate customer audit log sink is accessible from Temporal's workflow by
+     * delivering an empty file to the specified sink.
+     * The operation verifies that the sink is correctly configured, accessible and
+     * ready to receive audit logs.
+     *
+     * @throws ServiceClientException
+     */
+    public function ValidateAccountAuditLogSink(V1\ValidateAccountAuditLogSinkRequest $arg, ?ContextInterface $ctx = null): V1\ValidateAccountAuditLogSinkResponse
+    {
+        return $this->invoke("ValidateAccountAuditLogSink", $arg, $ctx);
+    }
+
+    /**
+     * Create an audit log sink
+     *
+     * @throws ServiceClientException
+     */
+    public function CreateAccountAuditLogSink(V1\CreateAccountAuditLogSinkRequest $arg, ?ContextInterface $ctx = null): V1\CreateAccountAuditLogSinkResponse
+    {
+        return $this->invoke("CreateAccountAuditLogSink", $arg, $ctx);
+    }
+
+    /**
+     * Get an audit log sink
+     *
+     * @throws ServiceClientException
+     */
+    public function GetAccountAuditLogSink(V1\GetAccountAuditLogSinkRequest $arg, ?ContextInterface $ctx = null): V1\GetAccountAuditLogSinkResponse
+    {
+        return $this->invoke("GetAccountAuditLogSink", $arg, $ctx);
+    }
+
+    /**
+     * Get audit log sinks
+     *
+     * @throws ServiceClientException
+     */
+    public function GetAccountAuditLogSinks(V1\GetAccountAuditLogSinksRequest $arg, ?ContextInterface $ctx = null): V1\GetAccountAuditLogSinksResponse
+    {
+        return $this->invoke("GetAccountAuditLogSinks", $arg, $ctx);
+    }
+
+    /**
+     * Update an audit log sink
+     *
+     * @throws ServiceClientException
+     */
+    public function UpdateAccountAuditLogSink(V1\UpdateAccountAuditLogSinkRequest $arg, ?ContextInterface $ctx = null): V1\UpdateAccountAuditLogSinkResponse
+    {
+        return $this->invoke("UpdateAccountAuditLogSink", $arg, $ctx);
+    }
+
+    /**
+     * Delete an audit log sink
+     *
+     * @throws ServiceClientException
+     */
+    public function DeleteAccountAuditLogSink(V1\DeleteAccountAuditLogSinkRequest $arg, ?ContextInterface $ctx = null): V1\DeleteAccountAuditLogSinkResponse
+    {
+        return $this->invoke("DeleteAccountAuditLogSink", $arg, $ctx);
+    }
+
+    /**
+     * Get namespace capacity information
+     *
+     * @throws ServiceClientException
+     */
+    public function GetNamespaceCapacityInfo(V1\GetNamespaceCapacityInfoRequest $arg, ?ContextInterface $ctx = null): V1\GetNamespaceCapacityInfoResponse
+    {
+        return $this->invoke("GetNamespaceCapacityInfo", $arg, $ctx);
+    }
+
+    /**
+     * Create a billing report
+     *
+     * @throws ServiceClientException
+     */
+    public function CreateBillingReport(V1\CreateBillingReportRequest $arg, ?ContextInterface $ctx = null): V1\CreateBillingReportResponse
+    {
+        return $this->invoke("CreateBillingReport", $arg, $ctx);
+    }
+
+    /**
+     * Get a billing report
+     *
+     * @throws ServiceClientException
+     */
+    public function GetBillingReport(V1\GetBillingReportRequest $arg, ?ContextInterface $ctx = null): V1\GetBillingReportResponse
+    {
+        return $this->invoke("GetBillingReport", $arg, $ctx);
+    }
+
+    /**
+     * Get custom roles
+     *
+     * @throws ServiceClientException
+     */
+    public function GetCustomRoles(V1\GetCustomRolesRequest $arg, ?ContextInterface $ctx = null): V1\GetCustomRolesResponse
+    {
+        return $this->invoke("GetCustomRoles", $arg, $ctx);
+    }
+
+    /**
+     * Get a custom role
+     *
+     * @throws ServiceClientException
+     */
+    public function GetCustomRole(V1\GetCustomRoleRequest $arg, ?ContextInterface $ctx = null): V1\GetCustomRoleResponse
+    {
+        return $this->invoke("GetCustomRole", $arg, $ctx);
+    }
+
+    /**
+     * Create a custom role
+     *
+     * @throws ServiceClientException
+     */
+    public function CreateCustomRole(V1\CreateCustomRoleRequest $arg, ?ContextInterface $ctx = null): V1\CreateCustomRoleResponse
+    {
+        return $this->invoke("CreateCustomRole", $arg, $ctx);
+    }
+
+    /**
+     * Update a custom role
+     *
+     * @throws ServiceClientException
+     */
+    public function UpdateCustomRole(V1\UpdateCustomRoleRequest $arg, ?ContextInterface $ctx = null): V1\UpdateCustomRoleResponse
+    {
+        return $this->invoke("UpdateCustomRole", $arg, $ctx);
+    }
+
+    /**
+     * Delete a custom role
+     *
+     * @throws ServiceClientException
+     */
+    public function DeleteCustomRole(V1\DeleteCustomRoleRequest $arg, ?ContextInterface $ctx = null): V1\DeleteCustomRoleResponse
+    {
+        return $this->invoke("DeleteCustomRole", $arg, $ctx);
+    }
+
+    /**
+     * Get users with access to a namespace
+     *
+     * @throws ServiceClientException
+     */
+    public function GetUserNamespaceAssignments(V1\GetUserNamespaceAssignmentsRequest $arg, ?ContextInterface $ctx = null): V1\GetUserNamespaceAssignmentsResponse
+    {
+        return $this->invoke("GetUserNamespaceAssignments", $arg, $ctx);
+    }
+
+    /**
+     * Get service accounts with access to a namespace
+     *
+     * @throws ServiceClientException
+     */
+    public function GetServiceAccountNamespaceAssignments(V1\GetServiceAccountNamespaceAssignmentsRequest $arg, ?ContextInterface $ctx = null): V1\GetServiceAccountNamespaceAssignmentsResponse
+    {
+        return $this->invoke("GetServiceAccountNamespaceAssignments", $arg, $ctx);
+    }
+
+    /**
+     * Get user groups with access to a namespace
+     *
+     * @throws ServiceClientException
+     */
+    public function GetUserGroupNamespaceAssignments(V1\GetUserGroupNamespaceAssignmentsRequest $arg, ?ContextInterface $ctx = null): V1\GetUserGroupNamespaceAssignmentsResponse
+    {
+        return $this->invoke("GetUserGroupNamespaceAssignments", $arg, $ctx);
+    }
+
+    /**
+     * Get all projects
+     *
+     * @throws ServiceClientException
+     */
+    public function GetProjects(V1\GetProjectsRequest $arg, ?ContextInterface $ctx = null): V1\GetProjectsResponse
+    {
+        return $this->invoke("GetProjects", $arg, $ctx);
+    }
+
+    /**
+     * Get a project
+     *
+     * @throws ServiceClientException
+     */
+    public function GetProject(V1\GetProjectRequest $arg, ?ContextInterface $ctx = null): V1\GetProjectResponse
+    {
+        return $this->invoke("GetProject", $arg, $ctx);
+    }
+
+    /**
+     * Create a new project
+     *
+     * @throws ServiceClientException
+     */
+    public function CreateProject(V1\CreateProjectRequest $arg, ?ContextInterface $ctx = null): V1\CreateProjectResponse
+    {
+        return $this->invoke("CreateProject", $arg, $ctx);
+    }
+
+    /**
+     * Update a project
+     *
+     * @throws ServiceClientException
+     */
+    public function UpdateProject(V1\UpdateProjectRequest $arg, ?ContextInterface $ctx = null): V1\UpdateProjectResponse
+    {
+        return $this->invoke("UpdateProject", $arg, $ctx);
+    }
+
+    /**
+     * Delete a project
+     *
+     * @throws ServiceClientException
+     */
+    public function DeleteProject(V1\DeleteProjectRequest $arg, ?ContextInterface $ctx = null): V1\DeleteProjectResponse
+    {
+        return $this->invoke("DeleteProject", $arg, $ctx);
+    }
+
+    /**
+     * Set a user's access to a project
+     *
+     * @throws ServiceClientException
+     */
+    public function SetUserProjectAccess(V1\SetUserProjectAccessRequest $arg, ?ContextInterface $ctx = null): V1\SetUserProjectAccessResponse
+    {
+        return $this->invoke("SetUserProjectAccess", $arg, $ctx);
+    }
+
+    /**
+     * Set a user group's access to a project
+     *
+     * @throws ServiceClientException
+     */
+    public function SetUserGroupProjectAccess(V1\SetUserGroupProjectAccessRequest $arg, ?ContextInterface $ctx = null): V1\SetUserGroupProjectAccessResponse
+    {
+        return $this->invoke("SetUserGroupProjectAccess", $arg, $ctx);
+    }
+
+    /**
+     * Set a service account's access to a project
+     *
+     * @throws ServiceClientException
+     */
+    public function SetServiceAccountProjectAccess(V1\SetServiceAccountProjectAccessRequest $arg, ?ContextInterface $ctx = null): V1\SetServiceAccountProjectAccessResponse
+    {
+        return $this->invoke("SetServiceAccountProjectAccess", $arg, $ctx);
+    }
+
+    /**
+     * Get users with access to a project
+     *
+     * @throws ServiceClientException
+     */
+    public function GetUserProjectAssignments(V1\GetUserProjectAssignmentsRequest $arg, ?ContextInterface $ctx = null): V1\GetUserProjectAssignmentsResponse
+    {
+        return $this->invoke("GetUserProjectAssignments", $arg, $ctx);
+    }
+
+    /**
+     * Get service accounts with access to a project
+     *
+     * @throws ServiceClientException
+     */
+    public function GetServiceAccountProjectAssignments(V1\GetServiceAccountProjectAssignmentsRequest $arg, ?ContextInterface $ctx = null): V1\GetServiceAccountProjectAssignmentsResponse
+    {
+        return $this->invoke("GetServiceAccountProjectAssignments", $arg, $ctx);
+    }
+
+    /**
+     * Get user groups with access to a project
+     *
+     * @throws ServiceClientException
+     */
+    public function GetUserGroupProjectAssignments(V1\GetUserGroupProjectAssignmentsRequest $arg, ?ContextInterface $ctx = null): V1\GetUserGroupProjectAssignmentsResponse
+    {
+        return $this->invoke("GetUserGroupProjectAssignments", $arg, $ctx);
+    }
+
+    /**
+     * Get service accounts scoped to a project
+     *
+     * @throws ServiceClientException
+     */
+    public function GetProjectScopedServiceAccounts(V1\GetProjectScopedServiceAccountsRequest $arg, ?ContextInterface $ctx = null): V1\GetProjectScopedServiceAccountsResponse
+    {
+        return $this->invoke("GetProjectScopedServiceAccounts", $arg, $ctx);
+    }
+
+    /**
+     * Pin the Cloud Operations API version.
+     *
+     * Sets the `temporal-cloud-api-version` header for every call made by the returned
+     * client.
+     *
+     * @link https://docs.temporal.io/ops
+     */
+    public function withApiVersion(string $version): static
+    {
+        $context = $this->getContext();
+
+        return $this->withContext(
+            $context->withMetadata(
+                $context->getMetadata() + ['temporal-cloud-api-version' => [$version]],
+            ),
+        );
+    }
+
+    protected static function createGrpcStub(string $address, array $options): \Grpc\BaseStub
+    {
+        return new V1\CloudServiceClient($address, $options);
+    }
+}

--- a/src/Client/GRPC/CloudClientInterface.php
+++ b/src/Client/GRPC/CloudClientInterface.php
@@ -12,8 +12,9 @@ interface CloudClientInterface extends GrpcClientInterface
     /**
      * Pin the Cloud Operations API version.
      *
-     * Sets the `temporal-cloud-api-version` header for every call made by the returned
+     * Sets the `temporal-cloud-api-version` header on every call made by the returned
      * client.
+     * A version already present on the call context is not overridden.
      *
      * @link https://docs.temporal.io/ops
      */

--- a/src/Client/GRPC/CloudClientInterface.php
+++ b/src/Client/GRPC/CloudClientInterface.php
@@ -1,0 +1,639 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Client\GRPC;
+
+use Temporal\Api\Cloud\Cloudservice\V1;
+use Temporal\Exception\Client\ServiceClientException;
+
+interface CloudClientInterface extends GrpcClientInterface
+{
+    /**
+     * Pin the Cloud Operations API version.
+     *
+     * Sets the `temporal-cloud-api-version` header for every call made by the returned
+     * client.
+     *
+     * @link https://docs.temporal.io/ops
+     */
+    public function withApiVersion(string $version): static;
+
+    /**
+     * Get information about the current authenticated user or service account
+     * principal
+     *
+     * @throws ServiceClientException
+     */
+    public function GetCurrentIdentity(V1\GetCurrentIdentityRequest $arg, ?ContextInterface $ctx = null): V1\GetCurrentIdentityResponse;
+
+    /**
+     * Gets all known users
+     *
+     * @throws ServiceClientException
+     */
+    public function GetUsers(V1\GetUsersRequest $arg, ?ContextInterface $ctx = null): V1\GetUsersResponse;
+
+    /**
+     * Get a user
+     *
+     * @throws ServiceClientException
+     */
+    public function GetUser(V1\GetUserRequest $arg, ?ContextInterface $ctx = null): V1\GetUserResponse;
+
+    /**
+     * Create a user
+     *
+     * @throws ServiceClientException
+     */
+    public function CreateUser(V1\CreateUserRequest $arg, ?ContextInterface $ctx = null): V1\CreateUserResponse;
+
+    /**
+     * Update a user
+     *
+     * @throws ServiceClientException
+     */
+    public function UpdateUser(V1\UpdateUserRequest $arg, ?ContextInterface $ctx = null): V1\UpdateUserResponse;
+
+    /**
+     * Delete a user
+     *
+     * @throws ServiceClientException
+     */
+    public function DeleteUser(V1\DeleteUserRequest $arg, ?ContextInterface $ctx = null): V1\DeleteUserResponse;
+
+    /**
+     * Set a user's access to a namespace
+     *
+     * @throws ServiceClientException
+     */
+    public function SetUserNamespaceAccess(V1\SetUserNamespaceAccessRequest $arg, ?ContextInterface $ctx = null): V1\SetUserNamespaceAccessResponse;
+
+    /**
+     * Get the latest information on an async operation
+     *
+     * @throws ServiceClientException
+     */
+    public function GetAsyncOperation(V1\GetAsyncOperationRequest $arg, ?ContextInterface $ctx = null): V1\GetAsyncOperationResponse;
+
+    /**
+     * Create a new namespace
+     *
+     * @throws ServiceClientException
+     */
+    public function CreateNamespace(V1\CreateNamespaceRequest $arg, ?ContextInterface $ctx = null): V1\CreateNamespaceResponse;
+
+    /**
+     * Get all namespaces
+     *
+     * @throws ServiceClientException
+     */
+    public function GetNamespaces(V1\GetNamespacesRequest $arg, ?ContextInterface $ctx = null): V1\GetNamespacesResponse;
+
+    /**
+     * Get a namespace
+     *
+     * @throws ServiceClientException
+     */
+    public function GetNamespace(V1\GetNamespaceRequest $arg, ?ContextInterface $ctx = null): V1\GetNamespaceResponse;
+
+    /**
+     * Update a namespace
+     *
+     * @throws ServiceClientException
+     */
+    public function UpdateNamespace(V1\UpdateNamespaceRequest $arg, ?ContextInterface $ctx = null): V1\UpdateNamespaceResponse;
+
+    /**
+     * Rename an existing customer search attribute
+     *
+     * @throws ServiceClientException
+     */
+    public function RenameCustomSearchAttribute(V1\RenameCustomSearchAttributeRequest $arg, ?ContextInterface $ctx = null): V1\RenameCustomSearchAttributeResponse;
+
+    /**
+     * Delete a namespace
+     *
+     * @throws ServiceClientException
+     */
+    public function DeleteNamespace(V1\DeleteNamespaceRequest $arg, ?ContextInterface $ctx = null): V1\DeleteNamespaceResponse;
+
+    /**
+     * Failover a multi-region namespace
+     *
+     * @throws ServiceClientException
+     */
+    public function FailoverNamespaceRegion(V1\FailoverNamespaceRegionRequest $arg, ?ContextInterface $ctx = null): V1\FailoverNamespaceRegionResponse;
+
+    /**
+     * @throws ServiceClientException
+     */
+    public function AddNamespaceRegion(V1\AddNamespaceRegionRequest $arg, ?ContextInterface $ctx = null): V1\AddNamespaceRegionResponse;
+
+    /**
+     * @throws ServiceClientException
+     */
+    public function DeleteNamespaceRegion(V1\DeleteNamespaceRegionRequest $arg, ?ContextInterface $ctx = null): V1\DeleteNamespaceRegionResponse;
+
+    /**
+     * Get all regions
+     *
+     * @throws ServiceClientException
+     */
+    public function GetRegions(V1\GetRegionsRequest $arg, ?ContextInterface $ctx = null): V1\GetRegionsResponse;
+
+    /**
+     * Get a region
+     *
+     * @throws ServiceClientException
+     */
+    public function GetRegion(V1\GetRegionRequest $arg, ?ContextInterface $ctx = null): V1\GetRegionResponse;
+
+    /**
+     * Get all known API keys
+     *
+     * @throws ServiceClientException
+     */
+    public function GetApiKeys(V1\GetApiKeysRequest $arg, ?ContextInterface $ctx = null): V1\GetApiKeysResponse;
+
+    /**
+     * Get an API key
+     *
+     * @throws ServiceClientException
+     */
+    public function GetApiKey(V1\GetApiKeyRequest $arg, ?ContextInterface $ctx = null): V1\GetApiKeyResponse;
+
+    /**
+     * Create an API key
+     *
+     * @throws ServiceClientException
+     */
+    public function CreateApiKey(V1\CreateApiKeyRequest $arg, ?ContextInterface $ctx = null): V1\CreateApiKeyResponse;
+
+    /**
+     * Update an API key
+     *
+     * @throws ServiceClientException
+     */
+    public function UpdateApiKey(V1\UpdateApiKeyRequest $arg, ?ContextInterface $ctx = null): V1\UpdateApiKeyResponse;
+
+    /**
+     * Delete an API key
+     *
+     * @throws ServiceClientException
+     */
+    public function DeleteApiKey(V1\DeleteApiKeyRequest $arg, ?ContextInterface $ctx = null): V1\DeleteApiKeyResponse;
+
+    /**
+     * Gets nexus endpoints
+     *
+     * @throws ServiceClientException
+     */
+    public function GetNexusEndpoints(V1\GetNexusEndpointsRequest $arg, ?ContextInterface $ctx = null): V1\GetNexusEndpointsResponse;
+
+    /**
+     * Get a nexus endpoint
+     *
+     * @throws ServiceClientException
+     */
+    public function GetNexusEndpoint(V1\GetNexusEndpointRequest $arg, ?ContextInterface $ctx = null): V1\GetNexusEndpointResponse;
+
+    /**
+     * Create a nexus endpoint
+     *
+     * @throws ServiceClientException
+     */
+    public function CreateNexusEndpoint(V1\CreateNexusEndpointRequest $arg, ?ContextInterface $ctx = null): V1\CreateNexusEndpointResponse;
+
+    /**
+     * Update a nexus endpoint
+     *
+     * @throws ServiceClientException
+     */
+    public function UpdateNexusEndpoint(V1\UpdateNexusEndpointRequest $arg, ?ContextInterface $ctx = null): V1\UpdateNexusEndpointResponse;
+
+    /**
+     * Delete a nexus endpoint
+     *
+     * @throws ServiceClientException
+     */
+    public function DeleteNexusEndpoint(V1\DeleteNexusEndpointRequest $arg, ?ContextInterface $ctx = null): V1\DeleteNexusEndpointResponse;
+
+    /**
+     * Get all user groups
+     *
+     * @throws ServiceClientException
+     */
+    public function GetUserGroups(V1\GetUserGroupsRequest $arg, ?ContextInterface $ctx = null): V1\GetUserGroupsResponse;
+
+    /**
+     * Get a user group
+     *
+     * @throws ServiceClientException
+     */
+    public function GetUserGroup(V1\GetUserGroupRequest $arg, ?ContextInterface $ctx = null): V1\GetUserGroupResponse;
+
+    /**
+     * Create new a user group
+     *
+     * @throws ServiceClientException
+     */
+    public function CreateUserGroup(V1\CreateUserGroupRequest $arg, ?ContextInterface $ctx = null): V1\CreateUserGroupResponse;
+
+    /**
+     * Update a user group
+     *
+     * @throws ServiceClientException
+     */
+    public function UpdateUserGroup(V1\UpdateUserGroupRequest $arg, ?ContextInterface $ctx = null): V1\UpdateUserGroupResponse;
+
+    /**
+     * Delete a user group
+     *
+     * @throws ServiceClientException
+     */
+    public function DeleteUserGroup(V1\DeleteUserGroupRequest $arg, ?ContextInterface $ctx = null): V1\DeleteUserGroupResponse;
+
+    /**
+     * Set a user group's access to a namespace
+     *
+     * @throws ServiceClientException
+     */
+    public function SetUserGroupNamespaceAccess(V1\SetUserGroupNamespaceAccessRequest $arg, ?ContextInterface $ctx = null): V1\SetUserGroupNamespaceAccessResponse;
+
+    /**
+     * Add a member to the group, can only be used with Cloud group types.
+     *
+     * @throws ServiceClientException
+     */
+    public function AddUserGroupMember(V1\AddUserGroupMemberRequest $arg, ?ContextInterface $ctx = null): V1\AddUserGroupMemberResponse;
+
+    /**
+     * Remove a member from the group, can only be used with Cloud group types.
+     *
+     * @throws ServiceClientException
+     */
+    public function RemoveUserGroupMember(V1\RemoveUserGroupMemberRequest $arg, ?ContextInterface $ctx = null): V1\RemoveUserGroupMemberResponse;
+
+    /**
+     * @throws ServiceClientException
+     */
+    public function GetUserGroupMembers(V1\GetUserGroupMembersRequest $arg, ?ContextInterface $ctx = null): V1\GetUserGroupMembersResponse;
+
+    /**
+     * Create a service account.
+     *
+     * @throws ServiceClientException
+     */
+    public function CreateServiceAccount(V1\CreateServiceAccountRequest $arg, ?ContextInterface $ctx = null): V1\CreateServiceAccountResponse;
+
+    /**
+     * Get a service account.
+     *
+     * @throws ServiceClientException
+     */
+    public function GetServiceAccount(V1\GetServiceAccountRequest $arg, ?ContextInterface $ctx = null): V1\GetServiceAccountResponse;
+
+    /**
+     * Get service accounts.
+     *
+     * @throws ServiceClientException
+     */
+    public function GetServiceAccounts(V1\GetServiceAccountsRequest $arg, ?ContextInterface $ctx = null): V1\GetServiceAccountsResponse;
+
+    /**
+     * Update a service account.
+     *
+     * @throws ServiceClientException
+     */
+    public function UpdateServiceAccount(V1\UpdateServiceAccountRequest $arg, ?ContextInterface $ctx = null): V1\UpdateServiceAccountResponse;
+
+    /**
+     * Set a service account's access to a namespace.
+     *
+     * @throws ServiceClientException
+     */
+    public function SetServiceAccountNamespaceAccess(V1\SetServiceAccountNamespaceAccessRequest $arg, ?ContextInterface $ctx = null): V1\SetServiceAccountNamespaceAccessResponse;
+
+    /**
+     * Delete a service account.
+     *
+     * @throws ServiceClientException
+     */
+    public function DeleteServiceAccount(V1\DeleteServiceAccountRequest $arg, ?ContextInterface $ctx = null): V1\DeleteServiceAccountResponse;
+
+    /**
+     * WARNING: Pre-Release Feature
+     * Get usage data across namespaces
+     *
+     * @throws ServiceClientException
+     */
+    public function GetUsage(V1\GetUsageRequest $arg, ?ContextInterface $ctx = null): V1\GetUsageResponse;
+
+    /**
+     * Get account information.
+     *
+     * @throws ServiceClientException
+     */
+    public function GetAccount(V1\GetAccountRequest $arg, ?ContextInterface $ctx = null): V1\GetAccountResponse;
+
+    /**
+     * Update account information.
+     *
+     * @throws ServiceClientException
+     */
+    public function UpdateAccount(V1\UpdateAccountRequest $arg, ?ContextInterface $ctx = null): V1\UpdateAccountResponse;
+
+    /**
+     * Create an export sink
+     *
+     * @throws ServiceClientException
+     */
+    public function CreateNamespaceExportSink(V1\CreateNamespaceExportSinkRequest $arg, ?ContextInterface $ctx = null): V1\CreateNamespaceExportSinkResponse;
+
+    /**
+     * Get an export sink
+     *
+     * @throws ServiceClientException
+     */
+    public function GetNamespaceExportSink(V1\GetNamespaceExportSinkRequest $arg, ?ContextInterface $ctx = null): V1\GetNamespaceExportSinkResponse;
+
+    /**
+     * Get export sinks
+     *
+     * @throws ServiceClientException
+     */
+    public function GetNamespaceExportSinks(V1\GetNamespaceExportSinksRequest $arg, ?ContextInterface $ctx = null): V1\GetNamespaceExportSinksResponse;
+
+    /**
+     * Update an export sink
+     *
+     * @throws ServiceClientException
+     */
+    public function UpdateNamespaceExportSink(V1\UpdateNamespaceExportSinkRequest $arg, ?ContextInterface $ctx = null): V1\UpdateNamespaceExportSinkResponse;
+
+    /**
+     * Delete an export sink
+     *
+     * @throws ServiceClientException
+     */
+    public function DeleteNamespaceExportSink(V1\DeleteNamespaceExportSinkRequest $arg, ?ContextInterface $ctx = null): V1\DeleteNamespaceExportSinkResponse;
+
+    /**
+     * Validates an export sink configuration by delivering an empty test file to the
+     * specified sink.
+     * This operation verifies that the sink is correctly configured, accessible, and
+     * ready for data export.
+     *
+     * @throws ServiceClientException
+     */
+    public function ValidateNamespaceExportSink(V1\ValidateNamespaceExportSinkRequest $arg, ?ContextInterface $ctx = null): V1\ValidateNamespaceExportSinkResponse;
+
+    /**
+     * Update the tags for a namespace
+     *
+     * @throws ServiceClientException
+     */
+    public function UpdateNamespaceTags(V1\UpdateNamespaceTagsRequest $arg, ?ContextInterface $ctx = null): V1\UpdateNamespaceTagsResponse;
+
+    /**
+     * Creates a connectivity rule
+     *
+     * @throws ServiceClientException
+     */
+    public function CreateConnectivityRule(V1\CreateConnectivityRuleRequest $arg, ?ContextInterface $ctx = null): V1\CreateConnectivityRuleResponse;
+
+    /**
+     * Gets a connectivity rule by id
+     *
+     * @throws ServiceClientException
+     */
+    public function GetConnectivityRule(V1\GetConnectivityRuleRequest $arg, ?ContextInterface $ctx = null): V1\GetConnectivityRuleResponse;
+
+    /**
+     * Lists connectivity rules by account
+     *
+     * @throws ServiceClientException
+     */
+    public function GetConnectivityRules(V1\GetConnectivityRulesRequest $arg, ?ContextInterface $ctx = null): V1\GetConnectivityRulesResponse;
+
+    /**
+     * Deletes a connectivity rule by id
+     *
+     * @throws ServiceClientException
+     */
+    public function DeleteConnectivityRule(V1\DeleteConnectivityRuleRequest $arg, ?ContextInterface $ctx = null): V1\DeleteConnectivityRuleResponse;
+
+    /**
+     * Get audit logs
+     *
+     * @throws ServiceClientException
+     */
+    public function GetAuditLogs(V1\GetAuditLogsRequest $arg, ?ContextInterface $ctx = null): V1\GetAuditLogsResponse;
+
+    /**
+     * Validate customer audit log sink is accessible from Temporal's workflow by
+     * delivering an empty file to the specified sink.
+     * The operation verifies that the sink is correctly configured, accessible and
+     * ready to receive audit logs.
+     *
+     * @throws ServiceClientException
+     */
+    public function ValidateAccountAuditLogSink(V1\ValidateAccountAuditLogSinkRequest $arg, ?ContextInterface $ctx = null): V1\ValidateAccountAuditLogSinkResponse;
+
+    /**
+     * Create an audit log sink
+     *
+     * @throws ServiceClientException
+     */
+    public function CreateAccountAuditLogSink(V1\CreateAccountAuditLogSinkRequest $arg, ?ContextInterface $ctx = null): V1\CreateAccountAuditLogSinkResponse;
+
+    /**
+     * Get an audit log sink
+     *
+     * @throws ServiceClientException
+     */
+    public function GetAccountAuditLogSink(V1\GetAccountAuditLogSinkRequest $arg, ?ContextInterface $ctx = null): V1\GetAccountAuditLogSinkResponse;
+
+    /**
+     * Get audit log sinks
+     *
+     * @throws ServiceClientException
+     */
+    public function GetAccountAuditLogSinks(V1\GetAccountAuditLogSinksRequest $arg, ?ContextInterface $ctx = null): V1\GetAccountAuditLogSinksResponse;
+
+    /**
+     * Update an audit log sink
+     *
+     * @throws ServiceClientException
+     */
+    public function UpdateAccountAuditLogSink(V1\UpdateAccountAuditLogSinkRequest $arg, ?ContextInterface $ctx = null): V1\UpdateAccountAuditLogSinkResponse;
+
+    /**
+     * Delete an audit log sink
+     *
+     * @throws ServiceClientException
+     */
+    public function DeleteAccountAuditLogSink(V1\DeleteAccountAuditLogSinkRequest $arg, ?ContextInterface $ctx = null): V1\DeleteAccountAuditLogSinkResponse;
+
+    /**
+     * Get namespace capacity information
+     *
+     * @throws ServiceClientException
+     */
+    public function GetNamespaceCapacityInfo(V1\GetNamespaceCapacityInfoRequest $arg, ?ContextInterface $ctx = null): V1\GetNamespaceCapacityInfoResponse;
+
+    /**
+     * Create a billing report
+     *
+     * @throws ServiceClientException
+     */
+    public function CreateBillingReport(V1\CreateBillingReportRequest $arg, ?ContextInterface $ctx = null): V1\CreateBillingReportResponse;
+
+    /**
+     * Get a billing report
+     *
+     * @throws ServiceClientException
+     */
+    public function GetBillingReport(V1\GetBillingReportRequest $arg, ?ContextInterface $ctx = null): V1\GetBillingReportResponse;
+
+    /**
+     * Get custom roles
+     *
+     * @throws ServiceClientException
+     */
+    public function GetCustomRoles(V1\GetCustomRolesRequest $arg, ?ContextInterface $ctx = null): V1\GetCustomRolesResponse;
+
+    /**
+     * Get a custom role
+     *
+     * @throws ServiceClientException
+     */
+    public function GetCustomRole(V1\GetCustomRoleRequest $arg, ?ContextInterface $ctx = null): V1\GetCustomRoleResponse;
+
+    /**
+     * Create a custom role
+     *
+     * @throws ServiceClientException
+     */
+    public function CreateCustomRole(V1\CreateCustomRoleRequest $arg, ?ContextInterface $ctx = null): V1\CreateCustomRoleResponse;
+
+    /**
+     * Update a custom role
+     *
+     * @throws ServiceClientException
+     */
+    public function UpdateCustomRole(V1\UpdateCustomRoleRequest $arg, ?ContextInterface $ctx = null): V1\UpdateCustomRoleResponse;
+
+    /**
+     * Delete a custom role
+     *
+     * @throws ServiceClientException
+     */
+    public function DeleteCustomRole(V1\DeleteCustomRoleRequest $arg, ?ContextInterface $ctx = null): V1\DeleteCustomRoleResponse;
+
+    /**
+     * Get users with access to a namespace
+     *
+     * @throws ServiceClientException
+     */
+    public function GetUserNamespaceAssignments(V1\GetUserNamespaceAssignmentsRequest $arg, ?ContextInterface $ctx = null): V1\GetUserNamespaceAssignmentsResponse;
+
+    /**
+     * Get service accounts with access to a namespace
+     *
+     * @throws ServiceClientException
+     */
+    public function GetServiceAccountNamespaceAssignments(V1\GetServiceAccountNamespaceAssignmentsRequest $arg, ?ContextInterface $ctx = null): V1\GetServiceAccountNamespaceAssignmentsResponse;
+
+    /**
+     * Get user groups with access to a namespace
+     *
+     * @throws ServiceClientException
+     */
+    public function GetUserGroupNamespaceAssignments(V1\GetUserGroupNamespaceAssignmentsRequest $arg, ?ContextInterface $ctx = null): V1\GetUserGroupNamespaceAssignmentsResponse;
+
+    /**
+     * Get all projects
+     *
+     * @throws ServiceClientException
+     */
+    public function GetProjects(V1\GetProjectsRequest $arg, ?ContextInterface $ctx = null): V1\GetProjectsResponse;
+
+    /**
+     * Get a project
+     *
+     * @throws ServiceClientException
+     */
+    public function GetProject(V1\GetProjectRequest $arg, ?ContextInterface $ctx = null): V1\GetProjectResponse;
+
+    /**
+     * Create a new project
+     *
+     * @throws ServiceClientException
+     */
+    public function CreateProject(V1\CreateProjectRequest $arg, ?ContextInterface $ctx = null): V1\CreateProjectResponse;
+
+    /**
+     * Update a project
+     *
+     * @throws ServiceClientException
+     */
+    public function UpdateProject(V1\UpdateProjectRequest $arg, ?ContextInterface $ctx = null): V1\UpdateProjectResponse;
+
+    /**
+     * Delete a project
+     *
+     * @throws ServiceClientException
+     */
+    public function DeleteProject(V1\DeleteProjectRequest $arg, ?ContextInterface $ctx = null): V1\DeleteProjectResponse;
+
+    /**
+     * Set a user's access to a project
+     *
+     * @throws ServiceClientException
+     */
+    public function SetUserProjectAccess(V1\SetUserProjectAccessRequest $arg, ?ContextInterface $ctx = null): V1\SetUserProjectAccessResponse;
+
+    /**
+     * Set a user group's access to a project
+     *
+     * @throws ServiceClientException
+     */
+    public function SetUserGroupProjectAccess(V1\SetUserGroupProjectAccessRequest $arg, ?ContextInterface $ctx = null): V1\SetUserGroupProjectAccessResponse;
+
+    /**
+     * Set a service account's access to a project
+     *
+     * @throws ServiceClientException
+     */
+    public function SetServiceAccountProjectAccess(V1\SetServiceAccountProjectAccessRequest $arg, ?ContextInterface $ctx = null): V1\SetServiceAccountProjectAccessResponse;
+
+    /**
+     * Get users with access to a project
+     *
+     * @throws ServiceClientException
+     */
+    public function GetUserProjectAssignments(V1\GetUserProjectAssignmentsRequest $arg, ?ContextInterface $ctx = null): V1\GetUserProjectAssignmentsResponse;
+
+    /**
+     * Get service accounts with access to a project
+     *
+     * @throws ServiceClientException
+     */
+    public function GetServiceAccountProjectAssignments(V1\GetServiceAccountProjectAssignmentsRequest $arg, ?ContextInterface $ctx = null): V1\GetServiceAccountProjectAssignmentsResponse;
+
+    /**
+     * Get user groups with access to a project
+     *
+     * @throws ServiceClientException
+     */
+    public function GetUserGroupProjectAssignments(V1\GetUserGroupProjectAssignmentsRequest $arg, ?ContextInterface $ctx = null): V1\GetUserGroupProjectAssignmentsResponse;
+
+    /**
+     * Get service accounts scoped to a project
+     *
+     * @throws ServiceClientException
+     */
+    public function GetProjectScopedServiceAccounts(V1\GetProjectScopedServiceAccountsRequest $arg, ?ContextInterface $ctx = null): V1\GetProjectScopedServiceAccountsResponse;
+}

--- a/tests/Unit/Client/GRPC/CloudClientTestCase.php
+++ b/tests/Unit/Client/GRPC/CloudClientTestCase.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Unit\Client\GRPC;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Temporal\Api\Cloud\Cloudservice\V1\CloudServiceClient as ApiCloudServiceClient;
+use Temporal\Api\Cloud\Cloudservice\V1\GetUsersRequest;
+use Temporal\Api\Cloud\Cloudservice\V1\GetUsersResponse;
+use Temporal\Client\GRPC\CloudClient;
+use Temporal\Client\GRPC\CloudClientInterface;
+use Temporal\Client\GRPC\Connection\ConnectionState;
+use Temporal\Client\GRPC\ContextInterface;
+use Temporal\Client\GRPC\GrpcClientInterface;
+use Temporal\Interceptor\GrpcClientInterceptor;
+use Temporal\Internal\Interceptor\Pipeline;
+use Temporal\Tests\TestCase;
+
+#[CoversClass(CloudClient::class)]
+final class CloudClientTestCase extends TestCase
+{
+    #[Test]
+    public function rpcIsDispatchedByMethodName(): void
+    {
+        [$captured, $client] = $this->createInterceptedClient();
+
+        $response = $client->GetUsers((new GetUsersRequest())->setPageSize(10));
+
+        self::assertSame('GetUsers', $captured->method);
+        self::assertInstanceOf(GetUsersRequest::class, $captured->arg);
+        self::assertSame(10, $captured->arg->getPageSize());
+        self::assertSame('next-page', $response->getNextPageToken());
+    }
+
+    #[Test]
+    public function apiVersionIsInjectedIntoContext(): void
+    {
+        [$captured, $client] = $this->createInterceptedClient();
+
+        $client->withApiVersion('2024-05-13-00')->GetUsers(new GetUsersRequest());
+
+        self::assertSame(['2024-05-13-00'], $captured->ctx->getMetadata()['temporal-cloud-api-version'] ?? null);
+    }
+
+    #[Test]
+    public function withoutApiVersionNoVersionHeader(): void
+    {
+        [$captured, $client] = $this->createInterceptedClient();
+
+        $client->GetUsers(new GetUsersRequest());
+
+        self::assertArrayNotHasKey('temporal-cloud-api-version', $captured->ctx->getMetadata());
+    }
+
+    #[Test]
+    public function apiVersionDoesNotOverrideExplicitContextHeader(): void
+    {
+        [$captured, $client] = $this->createInterceptedClient();
+
+        $client
+            ->withContext($client->getContext()->withMetadata(['temporal-cloud-api-version' => ['explicit']]))
+            ->withApiVersion('2024-05-13-00')
+            ->GetUsers(new GetUsersRequest());
+
+        self::assertSame(['explicit'], $captured->ctx->getMetadata()['temporal-cloud-api-version'] ?? null);
+    }
+
+    #[Test]
+    public function apiVersionIsCombinedWithAuthKey(): void
+    {
+        [$captured, $client] = $this->createInterceptedClient();
+
+        $client->withApiVersion('2024-05-13-00')->withAuthKey('cloud-key')->GetUsers(new GetUsersRequest());
+
+        self::assertSame(['2024-05-13-00'], $captured->ctx->getMetadata()['temporal-cloud-api-version'] ?? null);
+        self::assertSame(['Bearer cloud-key'], $captured->ctx->getMetadata()['Authorization'] ?? null);
+    }
+
+    #[Test]
+    public function withApiVersionReturnsNewImmutableInstance(): void
+    {
+        [, $client] = $this->createInterceptedClient();
+
+        $client2 = $client->withApiVersion('2024-05-13-00');
+
+        self::assertNotSame($client, $client2);
+        self::assertArrayNotHasKey('temporal-cloud-api-version', $client->getContext()->getMetadata());
+    }
+
+    #[Test]
+    public function implementsCloudClientInterface(): void
+    {
+        [, $client] = $this->createInterceptedClient();
+
+        self::assertInstanceOf(CloudClientInterface::class, $client);
+        self::assertInstanceOf(GrpcClientInterface::class, $client);
+    }
+
+    /**
+     * @return array{object, CloudClient}
+     */
+    private function createInterceptedClient(): array
+    {
+        $captured = new class {
+            public ?string $method = null;
+            public ?object $arg = null;
+            public ?ContextInterface $ctx = null;
+        };
+
+        $client = (new CloudClient(static fn() => new class extends ApiCloudServiceClient {
+            public function __construct() {}
+
+            public function getConnectivityState($try_to_connect = false): int
+            {
+                return ConnectionState::Ready->value;
+            }
+
+            public function close(): void {}
+        }))->withInterceptorPipeline(
+            Pipeline::prepare([new class($captured) implements GrpcClientInterceptor {
+                public function __construct(
+                    private readonly object $captured,
+                ) {}
+
+                public function interceptCall(
+                    string $method,
+                    object $arg,
+                    ContextInterface $ctx,
+                    callable $next,
+                ): object {
+                    $this->captured->method = $method;
+                    $this->captured->arg = $arg;
+                    $this->captured->ctx = $ctx;
+
+                    return (new GetUsersResponse())->setNextPageToken('next-page');
+                }
+            }]),
+        );
+
+        return [$captured, $client];
+    }
+}

--- a/tests/Unit/Client/GRPC/CloudClientTestCase.php
+++ b/tests/Unit/Client/GRPC/CloudClientTestCase.php
@@ -12,6 +12,7 @@ use Temporal\Api\Cloud\Cloudservice\V1\GetUsersResponse;
 use Temporal\Client\GRPC\CloudClient;
 use Temporal\Client\GRPC\CloudClientInterface;
 use Temporal\Client\GRPC\Connection\ConnectionState;
+use Temporal\Client\GRPC\Context;
 use Temporal\Client\GRPC\ContextInterface;
 use Temporal\Client\GRPC\GrpcClientInterface;
 use Temporal\Interceptor\GrpcClientInterceptor;
@@ -55,6 +56,16 @@ final class CloudClientTestCase extends TestCase
     }
 
     #[Test]
+    public function apiVersionIsInjectedIntoPerCallContext(): void
+    {
+        [$captured, $client] = $this->createInterceptedClient();
+
+        $client->withApiVersion('2024-05-13-00')->GetUsers(new GetUsersRequest(), Context::default()->withTimeout(5));
+
+        self::assertSame(['2024-05-13-00'], $captured->ctx->getMetadata()['temporal-cloud-api-version'] ?? null);
+    }
+
+    #[Test]
     public function apiVersionDoesNotOverrideExplicitContextHeader(): void
     {
         [$captured, $client] = $this->createInterceptedClient();
@@ -63,6 +74,17 @@ final class CloudClientTestCase extends TestCase
             ->withContext($client->getContext()->withMetadata(['temporal-cloud-api-version' => ['explicit']]))
             ->withApiVersion('2024-05-13-00')
             ->GetUsers(new GetUsersRequest());
+
+        self::assertSame(['explicit'], $captured->ctx->getMetadata()['temporal-cloud-api-version'] ?? null);
+    }
+
+    #[Test]
+    public function apiVersionDoesNotOverrideExplicitPerCallHeader(): void
+    {
+        [$captured, $client] = $this->createInterceptedClient();
+
+        $ctx = Context::default()->withMetadata(['temporal-cloud-api-version' => ['explicit']]);
+        $client->withApiVersion('2024-05-13-00')->GetUsers(new GetUsersRequest(), $ctx);
 
         self::assertSame(['explicit'], $captured->ctx->getMetadata()['temporal-cloud-api-version'] ?? null);
     }
@@ -81,12 +103,13 @@ final class CloudClientTestCase extends TestCase
     #[Test]
     public function withApiVersionReturnsNewImmutableInstance(): void
     {
-        [, $client] = $this->createInterceptedClient();
+        [$captured, $client] = $this->createInterceptedClient();
 
         $client2 = $client->withApiVersion('2024-05-13-00');
+        $client->GetUsers(new GetUsersRequest());
 
         self::assertNotSame($client, $client2);
-        self::assertArrayNotHasKey('temporal-cloud-api-version', $client->getContext()->getMetadata());
+        self::assertArrayNotHasKey('temporal-cloud-api-version', $captured->ctx->getMetadata());
     }
 
     #[Test]


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Adds `CloudClient` for the [Cloud Operations API](https://docs.temporal.io/ops), generated from the CloudService gRPC stub shipped in roadrunner-api-dto 1.15.0 ([roadrunner-php/roadrunner-api-dto#23](https://github.com/roadrunner-php/roadrunner-api-dto/issues/23)).

`withApiVersion()` sets the required temporal-cloud-api-version header; a header already on the context wins.

## Why?
<!-- Tell your future self why have you made these changes -->

Closes [#476](https://github.com/temporalio/sdk-php/issues/476).

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
